### PR TITLE
Add analytics and a cookie consent banner

### DIFF
--- a/tooling/google-analytics-baseline-checker/public/cookie-banner.js
+++ b/tooling/google-analytics-baseline-checker/public/cookie-banner.js
@@ -1,0 +1,71 @@
+const template = document.createElement('template');
+template.innerHTML = `
+<style>
+* { margin: 0}
+aside {
+  border: 0;
+  border-top: 1px solid #eee;
+  box-shadow: 0 0 1em #0001;
+  font-size: 0.9em;
+  gap: 1em;
+  height: auto;
+  padding: 1em;
+  text-wrap-style: pretty;
+  top: unset;
+  translate: 0px 100%;
+  transition: translate .2s ease, display .2s allow-discrete;
+  width: auto;
+}
+aside:popover-open {
+  display: grid;
+  translate: 0px 0px;
+}
+@media (min-width: 540px) {
+  aside {
+    grid-template-columns: 1fr max-content;
+    align-items: center;
+  }
+}
+button {
+  background: #eee;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  padding: .5em 1.5em;
+  border-radius: .4em;
+  width: 100%;
+}
+button:hover {
+  background: #ddd;
+}
+</style>
+<aside popover="manual" id="cdd-cookie-consent">
+  <p>
+    Chrome.dev uses cookies from Google to deliver and
+    enhance the quality of its services and to analyze traffic.
+    <a href="https://policies.google.com/technologies/cookies">Learn more.</a>
+  </p>
+  <button popovertarget="cdd-cookie-consent">Ok, Got it.</button>
+</aside>`;
+
+class CookieBanner extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({mode: 'open'});
+    this.shadowRoot.appendChild(template.content.cloneNode(true));
+  }
+  connectedCallback() {
+    const popover = this.shadowRoot.querySelector('[popover]');
+    popover.showPopover();
+    popover.addEventListener('toggle', (event) => {
+      if (event.newState === 'closed') {
+        localStorage.setItem('cdd-cookie-consent', '1');
+        popover.ontransitionend = () => this.remove();
+      }
+    });
+  }
+}
+
+if (!localStorage.getItem('cdd-cookie-consent')) {
+  customElements.define('cookie-banner', CookieBanner);
+}

--- a/tooling/google-analytics-baseline-checker/public/index.html
+++ b/tooling/google-analytics-baseline-checker/public/index.html
@@ -210,6 +210,15 @@
         </aside>
       </div>
     </footer>
+    <cookie-banner></cookie-banner>
     <script type="module" src="script.js"></script>
+    <script type="module" src="./cookie-banner.js"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-754F24EHD8"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-754F24EHD8');
+    </script>
   </body>
 </html>


### PR DESCRIPTION
This PR add analytics and a cookie consent banner. It uses a modified version of the script at https://chrome.dev/components/cookie-banner.js with slightly different styling and local storage to persist consent status.

I plan to submit a separate PR to update cookie-banner.js file for chrome.dev, but for now we can import it locally to not delay adding analytics.