### PR TITLE
Add example report and data to the Baseline Checker tool

### DIFF
--- a/tooling/google-analytics-baseline-checker/public/index.html
+++ b/tooling/google-analytics-baseline-checker/public/index.html
@@ -73,6 +73,10 @@
       <h2 id="import-tool" class="SubHeading">
         Import your Google Analytics data
       </h2>
+      <p class="Note Note-subHead">
+        Or view an <a id="example-report" href="#">example report</a> based on
+        <a download href="web-dev-baseline-export.tsv">data from web.dev</a>.
+      </p>
       <label id="drop-zone" class="Importer">
         Drag & Drop file here, or click to choose a file
         <svg class="Importer-icon" aria-label="Upload icon">

--- a/tooling/google-analytics-baseline-checker/public/script.js
+++ b/tooling/google-analytics-baseline-checker/public/script.js
@@ -33,11 +33,9 @@ function toPercent(num) {
 
 function formatDate(dateString) {
   return new Date(
-    [
-      dateString.slice(0, 4),
-      dateString.slice(4, 6),
-      dateString.slice(6, 8),
-    ].join('-')
+    Number(dateString.slice(0, 4)),
+    Number(dateString.slice(4, 6) - 1),
+    Number(dateString.slice(6, 8))
   ).toLocaleDateString();
 }
 
@@ -281,6 +279,11 @@ document.getElementById('input').addEventListener('change', ({target}) => {
   if (target.files.length > 0) {
     handleImport(target.files[0]);
   }
+});
+
+document.getElementById('example-report').addEventListener('click', (event) => {
+  event.preventDefault();
+  fetchData('web-dev-baseline-export.tsv').then(processData);
 });
 
 const dropZone = document.getElementById('drop-zone');

--- a/tooling/google-analytics-baseline-checker/public/style.css
+++ b/tooling/google-analytics-baseline-checker/public/style.css
@@ -182,6 +182,10 @@
     text-wrap-style: balance;
   }
 
+  .Note-subHead {
+    margin: 0 auto 2rem;
+  }
+
   /*
    * Importer
    * ----------------------------------------------------------------------- */
@@ -215,6 +219,7 @@
    .Steps {
     display: grid;
     grid-template-columns: auto auto;
+    margin-bottom: 4rem;
     place-content: center;
   }
 

--- a/tooling/google-analytics-baseline-checker/public/web-dev-baseline-export.tsv
+++ b/tooling/google-analytics-baseline-checker/public/web-dev-baseline-export.tsv
@@ -1,0 +1,10923 @@
+# ----------------------------------------
+# web.dev
+# Baseline Export-Free form 1
+# 20250624-20250721
+# ----------------------------------------
+
+Browser	Browser version	Device category	Operating system	OS version	Active users
+					560687	Grand total
+Android Webview	137.0.7151.115	mobile	Android	14	36736
+Android Webview	137.0.7151.115	mobile	Android	15	26913
+Chrome	137.0.7151.120	desktop	Windows	11	22377
+Chrome	138.0.7204.101	desktop	Windows	11	18144
+Android Webview	137.0.7151.115	mobile	Android	13	13449
+Chrome	138.0.7204.97	desktop	Windows	11	13157
+Chrome	137.0.7151.120	desktop	Windows	10	12119
+Chrome	138.0.7204.101	desktop	Windows	10	9719
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 15.5	9248
+Android Webview	137.0.7151.115	mobile	Android	12	8360
+Safari	18.5	mobile	iOS	18.5	8282
+Chrome	137.0.7151.122	desktop	Windows	11	8270
+Chrome	138.0.7204.158	desktop	Windows	11	7439
+Chrome	138.0.7204.97	desktop	Windows	10	7182
+Android Webview	137.0.7151.115	mobile	Android	11	6683
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 15.5	6519
+Chrome	137.0.7151.115	mobile	Android	15.0.0	5974
+Android Webview	137.0.7151.116	mobile	Android	14	5350
+Chrome	138.0.7204.63	mobile	Android	15.0.0	5309
+Chrome	138.0.7204.49	mobile	Android	11.0	5285
+Android Webview	138.0.7204.45	mobile	Android	14	5282
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 15.5	5067
+Chrome	137.0.7151.115	mobile	Android	14.0.0	4983
+Chrome	137.0.7151.122	desktop	Windows	10	4698
+Android Webview	138.0.7204.67	mobile	Android	14	4661
+Android Webview	138.0.7204.67	mobile	Android	15	4563
+Android Webview	137.0.7151.89	mobile	Android	14	4371
+Safari	18.5	desktop	Macintosh	Intel 10.15	4344
+Chrome	138.0.7204.158	desktop	Windows	10	4178
+Android Webview	137.0.7151.116	mobile	Android	15	4113
+Firefox	140.0	desktop	Windows	10	3995
+Android Webview	138.0.7204.45	mobile	Android	15	3984
+Chrome	138.0.7204.63	mobile	Android	14.0.0	3662
+(not set)	(not set)	desktop	(not set)	(not set)	3554
+Chrome	138.0.7204.49	desktop	Windows	11	3431
+Edge	138.0.3351.83	desktop	Windows	11	3277
+Edge	138.0.3351.65	desktop	Windows	11	3270
+Chrome	137.0.7151.115	mobile	Android	13.0.0	3241
+Edge	137.0.3296.93	desktop	Windows	11	3136
+Opera	119.0.0.0	desktop	Windows	10	3103
+Android Webview	137.0.7151.90	mobile	Android	14	2941
+Edge	138.0.3351.55	desktop	Windows	11	2838
+Samsung Internet	28.0	mobile	Android	10	2809
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 15.5	2783
+Chrome	138.0.7204.96	desktop	Windows	11	2782
+Chrome	138.0.7204.51	desktop	Windows	11	2678
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 15.5	2669
+Chrome	138.0.7204.63	mobile	Android	13.0.0	2565
+Chrome	137.0.7151.104	desktop	Windows	11	2347
+Android Webview	137.0.7151.89	mobile	Android	15	2204
+Android Webview	138.0.7204.67	mobile	Android	13	2176
+Android Webview	137.0.7151.118	mobile	Android	14	1994
+Chrome	137.0.7151.115	mobile	Android	12.0.0	1981
+Android Webview	137.0.7151.118	mobile	Android	15	1970
+Android Webview	138.0.7204.45	mobile	Android	13	1948
+Edge	138.0.3351.77	desktop	Windows	11	1948
+Android Webview	137.0.7151.116	mobile	Android	13	1942
+Chrome	138.0.7204.49	desktop	Windows	10	1924
+Chrome	138.0.7204.157	desktop	Windows	11	1839
+Chrome	138.0.7204.50	desktop	Windows	11	1818
+Android Webview	137.0.7151.115	mobile	Android	10	1732
+Chrome	137.0.7151.115	mobile	Android	11.0.0	1721
+Chrome	138.0.7204.100	desktop	Windows	11	1706
+Chrome	138.0.7204.102	desktop	Windows	11	1704
+Chrome	138.0.7204.98	desktop	Windows	11	1701
+Chrome	138.0.0.0	desktop	Linux	(not set)	1688
+Chrome	138.0.7204.157	mobile	Android	15.0.0	1683
+Chrome	138.0.7204.63	mobile	Android	12.0.0	1530
+Edge	138.0.3351.95	desktop	Windows	11	1526
+Chrome	137.0.7151.104	desktop	Windows	10	1511
+Android Webview	138.0.7204.68	mobile	Android	14	1478
+Android Webview	138.0.7204.157	mobile	Android	14	1477
+Android Webview	137.0.7151.117	mobile	Android	14	1476
+Android Webview	138.0.7204.63	mobile	Android	14	1474
+Chrome	138.0.7204.96	desktop	Windows	10	1466
+Chrome	109.0.5414.120	desktop	Windows	7	1443
+YaBrowser	25.6.0.0	desktop	Windows	10	1436
+Android Webview	137.0.7151.89	mobile	Android	13	1424
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 15.5	1406
+Chrome	138.0.7204.119	mobile	iOS	18.5.0	1404
+Chrome	138.0.7204.51	desktop	Windows	10	1404
+Android Webview	137.0.7151.90	mobile	Android	15	1389
+Android Webview	138.0.7204.68	mobile	Android	15	1352
+Android Webview	138.0.7204.157	mobile	Android	15	1351
+Chrome	137.0.0.0	desktop	Macintosh	Intel 10.15	1319
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 15.5	1308
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 15.5	1302
+Chrome	137.0.0.0	desktop	Linux	(not set)	1220
+Firefox	140.0	desktop	Macintosh	Intel 10.15	1210
+Chrome	138.0.7204.63	mobile	Android	11.0.0	1203
+Android Webview	138.0.7204.63	mobile	Android	15	1193
+Android Webview	137.0.7151.117	mobile	Android	15	1184
+Android Webview	138.0.7204.67	mobile	Android	12	1176
+Safari (in-app)	(not set)	mobile	iOS	18.5	1163
+Android Webview	137.0.7151.116	mobile	Android	12	1144
+Android Webview	138.0.7204.45	mobile	Android	12	1121
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 15.4	1120
+Android Webview	138.0.7204.67	mobile	Android	11	1116
+Chrome	137.0.7151.115	mobile	Android	10.0.0	1097
+Edge	138.0.3351.65	desktop	Windows	10	1097
+Chrome	124.0.0.0	desktop	Linux	(not set)	1081
+Chrome	138.0.7204.157	mobile	Android	14.0.0	1078
+Chrome	138.0.0.0	desktop	Macintosh	Intel 10.15	1071
+Edge	137.0.3296.93	desktop	Windows	10	1062
+Edge	138.0.3351.83	desktop	Windows	10	1016
+Firefox	140.0	desktop	Linux	(not set)	974
+Android Webview	138.0.7204.45	mobile	Android	11	971
+Android Webview	137.0.7151.116	mobile	Android	11	952
+Chrome	138.0.7204.157	desktop	Windows	10	935
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 15.5	923
+Chrome	138.0.7204.102	desktop	Windows	10	917
+Firefox	139.0	desktop	Linux	(not set)	911
+Android Webview	137.0.7151.89	mobile	Android	12	891
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 15.3	888
+Firefox	139.0	desktop	Windows	10	887
+Chrome	138.0.7204.100	desktop	Windows	10	885
+Safari	604.1	mobile	iOS	18.5.0	885
+Android Webview	137.0.7151.90	mobile	Android	13	882
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 15.5	881
+Chrome	138.0.7204.50	desktop	Windows	10	872
+Chrome	137.0.7151.123	desktop	Chrome OS	x86_64 16267.51.0	868
+Edge	138.0.3351.55	desktop	Windows	10	862
+Chrome	138.0.7204.98	desktop	Windows	10	857
+Chrome	138.0.7204.63	mobile	Android	10.0.0	850
+Android Webview	137.0.7151.118	mobile	Android	13	846
+Chrome	137.0.7151.69	desktop	Windows	11	841
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 15.5	820
+Chrome	138.0.7204.46	mobile	Android	15.0.0	811
+Android Webview	137.0.7151.89	mobile	Android	11	810
+Chrome	137.0.7151.107	mobile	iOS	18.5.0	807
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 15.5	793
+Chrome	138.0.7204.157	mobile	Android	13.0.0	774
+Chrome	138.0.0.0	desktop	Macintosh	Intel 15.5	771
+Chrome	131.0.6778.260	mobile	Android	15.0.0	711
+Android Webview	138.0.7204.68	mobile	Android	13	701
+Chrome	137.0.7151.115	mobile	Android	15	700
+Chrome	131.0.6778.204	desktop	Windows	10	692
+Chrome	117.0.5938.132	desktop	Windows	10	677
+Android Webview	138.0.7204.157	mobile	Android	13	676
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 14.6	635
+Android Webview	138.0.7204.63	mobile	Android	13	618
+Edge	138.0.3351.77	desktop	Windows	10	617
+Chrome	138.0.7204.46	mobile	Android	14.0.0	616
+Firefox	139.0	desktop	Macintosh	Intel 10.15	616
+YaBrowser	25.4.0.0	desktop	Windows	10	612
+Chrome	137.0.7151.117	mobile	Android	15.0.0	605
+Android Webview	137.0.7151.117	mobile	Android	13	569
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 14.7	554
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 15.4	541
+Android Webview	137.0.7151.90	mobile	Android	12	534
+Samsung Internet	27.0	mobile	Android	10	525
+Chrome	137.0.7151.115	mobile	Android	14	517
+Chrome	137.0.7151.69	desktop	Windows	10	516
+Chrome	138.0.7204.45	mobile	Android	15.0.0	516
+Chrome	138.0.7204.92	desktop	Linux	6.8.0	514
+Android Webview	137.0.7151.90	mobile	Android	11	504
+Android Webview	126.0.6478.71	mobile	Android	14	494
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 15.5	491
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 15.4	483
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 15.5	479
+Edge	138.0.3351.95	desktop	Windows	10	477
+Chrome	118.0.0.0	desktop	Windows	10	462
+Chrome	138.0.7204.49	desktop	Linux	6.8.0	461
+Edge	137.0.3296.83	desktop	Windows	11	460
+Chrome	137.0.7151.115	mobile	Android	13	456
+Chrome	126.0.6478.71	mobile	Android	14.0.0	450
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 15.3	450
+Android Webview	137.0.7151.118	mobile	Android	12	449
+Chrome	138.0.7204.45	mobile	Android	14.0.0	449
+Chrome	138.0.7204.46	mobile	Android	13.0.0	445
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 15.5	433
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 14.5	431
+Chrome	138.0.7204.157	mobile	Android	12.0.0	431
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 15.5	428
+Android Webview	137.0.7151.89	mobile	Android	10	424
+Chrome	137.0.7151.117	mobile	Android	14.0.0	424
+Chrome	136.0.7103.114	desktop	Windows	11	409
+Edge	137.0.3296.68	desktop	Windows	11	409
+Android Webview	137.0.7151.112	mobile	Android	15	401
+Android Webview	131.0.6778.260	mobile	Android	15	400
+Chrome	138.0.7204.63	mobile	Android	16.0.0	399
+Chrome	137.0.7151.115	mobile	Android	9.0.0	397
+Chrome	138.0.7204.92	desktop	Linux	6.11.0	395
+Android Webview	137.0.7151.118	mobile	Android	11	389
+Chrome	137.0.7151.119	desktop	Linux	6.8.0	388
+Chrome	109.0.5414.168	desktop	Windows	8.1	386
+Safari	18.4	desktop	Macintosh	Intel 10.15	384
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 12.7	377
+Safari	17.6	desktop	Macintosh	Intel 10.15	375
+Chrome	123.0.6312.118	mobile	Android	10	362
+Chrome	138.0.7204.157	mobile	Android	11.0.0	360
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 15.3	357
+Android Webview	138.0.7204.63	mobile	Android	12	353
+Chrome	133.0.6943.98	mobile	Android	11.0	352
+Chrome	136.0.7103.114	desktop	Windows	10	350
+Chrome	137.0.7151.105	desktop	Windows	11	347
+Chrome	137.0.7151.89	mobile	Android	14.0.0	345
+Opera	90.0.0.0	mobile	Android	10	345
+Android Webview	137.0.7151.115	mobile	Android	9	343
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 15.4	341
+Chrome	137.0.7151.56	desktop	Windows	10	341
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 14.7	340
+Android Webview	138.0.7204.157	mobile	Android	12	339
+Chrome	137.0.7151.119	desktop	Windows	11	336
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 14.4	334
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 14.6	333
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 14.7	333
+Android Webview	138.0.7204.157	mobile	Android	11	330
+Android Webview	138.0.7204.68	mobile	Android	12	330
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 15.1	330
+Chrome	138.0.7204.49	desktop	Linux	6.11.0	327
+Android Webview	138.0.7204.68	mobile	Android	11	326
+Android Webview	137.0.7151.117	mobile	Android	12	321
+Chrome	137.0.7151.119	desktop	Linux	6.11.0	319
+Chrome	138.0.7204.100	desktop	Linux	6.8.0	317
+Safari	26.0	mobile	iOS	19.0	317
+Android Webview	138.0.7204.63	mobile	Android	11	306
+Chrome	138.0.7204.156	mobile	iOS	18.5.0	302
+Chrome	138.0.7204.100	desktop	Linux	6.11.0	297
+Chrome	138.0.7204.45	mobile	Android	13.0.0	297
+Chrome	135.0.7049.41	desktop	Windows	10	288
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 13.7	286
+Chrome	137.0.7151.121	desktop	Windows	11	286
+Chrome	137.0.0.0	desktop	Macintosh	Intel 15.5	283
+Chrome	137.0.7151.115	mobile	Android	16.0.0	280
+Opera	120.0.0.0	desktop	Windows	10	280
+Chrome	137.0.7151.89	mobile	Android	15.0.0	277
+Chrome	137.0.7151.117	mobile	Android	13.0.0	276
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 15.3	275
+Android Webview	137.0.7151.112	mobile	Android	14	273
+Android Webview	137.0.7151.117	mobile	Android	11	273
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 15.2	273
+Chrome	138.0.7204.63	mobile	Android	9.0.0	272
+Safari	18.4	mobile	iOS	18.4.1	258
+Chrome	128.0.6613.138	desktop	Macintosh	Intel 10.15	254
+Chrome	127.0.6533.103	mobile	Android	15.0.0	252
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 14.6	251
+Chrome	137.0.7151.132	desktop	Chrome OS	x86_64 16267.60.0	245
+Chrome	137.0.7151.103	desktop	Linux	6.8.0	244
+Chrome	127.0.6533.64	mobile	Android	14.0.0	243
+Chrome	125.0.6422.141	desktop	Windows	10	242
+Chrome	136.0.7103.113	desktop	Linux	6.8.0	242
+Chrome	103.0.5060.132	desktop	Chrome OS	x86_64 14816.131.0	241
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 15.0	238
+Android Webview	127.0.6533.103	mobile	Android	15	237
+Safari	17.6	mobile	iOS	17.6.1	234
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 15.4	230
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 15.5	230
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 14.5	229
+Samsung Internet	25.0	mobile	Android	10	229
+Safari	26.0	desktop	Macintosh	Intel 10.15	227
+Firefox	141.0	desktop	Windows	10	226
+Android Webview	137.0.7151.90	mobile	Android	10	225
+Chrome	137.0.7151.68	desktop	Linux	6.8.0	225
+Chrome	137.0.7151.89	mobile	Android	13.0.0	225
+Android Webview	118.0.0.0	mobile	Android	14	223
+Chrome	138.0.7204.46	mobile	Android	12.0.0	222
+Chrome	137.0.7151.115	mobile	Android	8.1.0	221
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 15.5	220
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 12.7	218
+Opera	119.0.0.0	desktop	Macintosh	Intel 10.15	218
+YaBrowser	25.4.0.0	desktop	Macintosh	Intel 10.15	218
+Chrome	138.0.7204.157	mobile	Android	10.0.0	212
+Safari	18.3.1	mobile	iOS	18.3.2	211
+Safari	18.6	mobile	iOS	18.6	211
+Firefox	128.0	desktop	Linux	(not set)	208
+Chrome	136.0.7103.125	mobile	Android	14.0.0	207
+Chrome	138.0.7204.64	mobile	Android	15.0.0	207
+Chrome	137.0.7151.115	mobile	Android	12	206
+Chrome	114.0.0.0	mobile	Android	11	205
+Android Webview	138.0.7204.45	mobile	Android	10	203
+Chrome	137.0.7151.119	desktop	Windows	10	203
+Chrome	138.0.7204.46	mobile	Android	11.0.0	203
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 15.4	202
+Chrome	137.0.7151.117	mobile	Android	12.0.0	201
+Edge	137.0.3296.93	desktop	Macintosh	Intel 15.5	201
+Android Webview	137.0.7151.116	mobile	Android	10	200
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 14.6	199
+Android Webview	137.0.7151.112	mobile	Android	13	197
+Chrome	79.0.3945.79	desktop	Windows	10	197
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 15.4	193
+Chrome	120.0.6099.193	mobile	Android	14.0.0	191
+Chrome	136.0.7103.25	desktop	Windows	10	190
+Android Webview	111.0.5563.116	mobile	Android	13	189
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 14.5	189
+Chrome	137.0.7151.103	desktop	Linux	6.11.0	188
+Chrome	138.0.7204.63	mobile	Android	8.1.0	186
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 15.1	184
+Chrome	137.0.7151.105	desktop	Windows	10	182
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 13.7	182
+Chrome	138.0.7204.45	mobile	Android	12.0.0	182
+Safari	16.6.1	mobile	iOS	16.7.11	182
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 15.3	179
+Chrome	137.0.0.0	desktop	Windows	10	178
+YaBrowser	25.6.0.0	desktop	Macintosh	Intel 10.15	178
+Chrome	133.0.6943.98	desktop	Macintosh	 10.15	176
+Firefox	140.0	mobile	Android	15	176
+Safari	18.3	desktop	Macintosh	Intel 10.15	176
+Chrome	137.0.7151.89	mobile	Android	12.0.0	175
+Chrome	138.0.0.0	desktop	Windows	11	175
+Edge	138.0.3351.83	desktop	Macintosh	Intel 15.5	175
+Chrome	111.0.5563.116	mobile	Android	13.0.0	174
+Samsung Internet	28.0	desktop	Linux	(not set)	174
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 15.3	172
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 12.7	171
+Chrome	137.0.7151.121	desktop	Windows	10	170
+Chrome	137.0.7151.137	desktop	Chrome OS	x86_64 16267.66.0	170
+Android Webview	130.0.6723.86	mobile	Android	15	169
+Chrome	136.0.7103.93	desktop	Windows	11	169
+Chrome	137.0.7151.115	mobile	Android	11	169
+Edge	138.0.3351.65	desktop	Macintosh	Intel 15.5	169
+Chrome	136.0.7103.125	mobile	Android	13.0.0	164
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 14.4	162
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 14.4	159
+Chrome	106.0.5249.126	mobile	Android	6.0.1	158
+Chrome	137.0.7151.56	desktop	Windows	11	156
+Samsung Internet	26.0	mobile	Android	10	155
+Firefox	128.0	desktop	Windows	10	154
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 15.5	152
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 15.1	151
+Edge	137.0.3296.83	desktop	Windows	10	151
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 15.5	150
+Safari	18.1.1	mobile	iOS	18.1.1	150
+Chrome	136.0.7103.125	mobile	Android	11.0.0	149
+Android Webview	108.0.5359.128	mobile	Android	13	148
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 14.7	148
+Chrome	138.0.7204.157	mobile	Android	16.0.0	146
+Edge	137.0.3296.68	desktop	Windows	10	145
+Safari	18.3	mobile	iOS	18.3.1	145
+Chrome	138.0.7204.157	desktop	Linux	6.8.0	144
+Edge	138.0.3351.55	desktop	Macintosh	Intel 15.5	142
+Firefox	136.0	desktop	Linux	(not set)	142
+Firefox	141.0	desktop	Macintosh	Intel 10.15	142
+Safari	17.5	desktop	Macintosh	Intel 10.15	141
+Chrome	136.0.7103.125	mobile	Android	15.0.0	140
+Safari	17.5	mobile	iOS	17.5.1	139
+Chrome	70.0.3538.110	mobile	Android	8.1.0	138
+Chrome	137.0.7151.117	mobile	Android	11.0.0	137
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 16.0	137
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 15.3	136
+Chrome	136.0.7103.49	desktop	Windows	10	136
+Chrome	137.0.0.0	desktop	Windows	11	136
+Safari	18.3.1	desktop	Macintosh	Intel 10.15	136
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 14.6	135
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 14.3	135
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 14.5	135
+Chrome	138.0.0.0	desktop	Windows	10	135
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 15.2	135
+Chrome	126.0.6478.71	mobile	Android	13.0.0	134
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 15.4	134
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 13.7	134
+Chrome	134.0.0.0	desktop	Macintosh	Intel 10.15	133
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 14.1	133
+Chrome	138.0.7204.119	tablet	iOS	18.5.0	132
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 14.2	131
+Chrome	138.0.7204.64	mobile	Android	14.0.0	130
+Chrome	87.0.4280.141	mobile	Android	11	130
+Samsung Internet	24.0	mobile	Android	10	130
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 14.7	129
+Chrome	138.0.7204.45	mobile	Android	11.0.0	129
+Chrome	123.0.6312.118	mobile	Android	15	128
+Chrome	137.0.7151.86	desktop	Chrome OS	x86_64 16267.43.0	127
+Safari	15.6.7	mobile	iOS	15.8.4	127
+Chrome	125.0.6422.72	mobile	Android	15	126
+Chrome	138	mobile	iOS	(not set)	126
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 12.7	125
+Chrome	131.0.6778.204	desktop	Linux	5.10.153	124
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 15.3	123
+Chrome	116.0.5845.187	desktop	Macintosh	Intel 10.13	121
+Chrome	124.0.6367.179	mobile	Android	14.0.0	121
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 13.6	121
+Chrome	137.0.7151.89	mobile	Android	11.0.0	121
+Chrome	136.0.7103.93	desktop	Windows	10	120
+Chrome	137.0.7151.68	desktop	Linux	6.11.0	120
+Android Webview	120.0.6099.193	mobile	Android	14	119
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 15.4	119
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 15.3	119
+Chrome	138.0.7204.92	desktop	Linux	5.15.0	119
+Firefox	115.0	desktop	Windows	7	119
+Chrome	119.0.0.0	mobile	Macintosh	 10.15	118
+Chrome	138.0.7204.46	mobile	Android	10.0.0	118
+Chrome	93.0.4577.107	desktop	Chrome OS	x86_64 14092.77.0	117
+Chrome	97.0.4692.98	mobile	Android	11	117
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 13.5	116
+Chrome	137.0.7151.72	mobile	Android	15.0.0	116
+Chrome	137.0.7151.119	desktop	Linux	5.15.0	115
+Android Webview	138.0.7204.67	mobile	Android	10	114
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 15.1	114
+Chrome	137.0.7151.72	mobile	Android	14.0.0	114
+Chrome	138.0.7204.49	desktop	Linux	5.15.0	114
+Chrome	118.0.5993.80	mobile	Android	14.0.0	113
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 13.4	113
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 14.7	112
+Android Webview	136.0.7103.125	mobile	Android	9	111
+Chrome	136.0.7103.113	desktop	Linux	6.11.0	111
+Chrome	136.0.7103.125	mobile	Android	12.0.0	111
+Chrome	138.0.7204.100	desktop	Linux	5.15.0	111
+Chrome	135.0.7049.115	desktop	Windows	11	110
+Chrome	137.0.7151.89	mobile	Android	10.0.0	110
+Chrome	138.0.7204.45	mobile	Android	15	109
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 14.7	108
+Safari	16.6	mobile	iOS	16.6	108
+Chrome	137.0.7151.72	mobile	Android	13.0.0	107
+Chrome	138.0.7204.56	mobile	iOS	18.5.0	107
+Chrome	140.0.7259.2	desktop	Windows	11	107
+Chrome	94.0.4606.85	mobile	Android	11	107
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 11.7	105
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 14.4	105
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 14.5	104
+Firefox	109.0	desktop	Windows	10	104
+Android Webview	127.0.6533.64	mobile	Android	14	103
+Chrome	114.0.5735.196	mobile	Android	10.0.0	103
+Chrome	114.0.5735.60	mobile	Android	13.0.0	103
+Chrome	99.0.4844.88	mobile	Android	12	103
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 15.2	102
+Chrome	105.0.5195.136	mobile	Android	12.0.0	101
+Chrome	137.0.7151.115	mobile	Android	10	101
+Chrome	137.0.7151.116	mobile	Android	15	101
+Android Webview	137.0.7151.112	mobile	Android	12	100
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 15.5	100
+Chrome	137.0.7151.55	desktop	Linux	6.8.0	100
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 15.0	100
+Chrome	138.0.7204.64	mobile	Android	13.0.0	100
+Chrome	138.0.7204.67	mobile	Android	15	100
+Android Webview	136.0.7103.125	mobile	Android	11	99
+Chrome	137.0.7151.70	desktop	Windows	11	99
+Chrome	95.0.4638.74	mobile	Android	5.1.1	99
+Chrome	119.0.0.0	mobile	Android	11.0	98
+Firefox	140.0	mobile	Android	14	98
+Chrome	114.0.5735.196	desktop	Windows	10	97
+Firefox	125.0.1	desktop	Windows	10	96
+Chrome	136.0.7103.92	desktop	Linux	6.8.0	95
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 26.0	95
+Chrome	136.0.7103.125	mobile	Android	10.0.0	94
+Safari	18.2	desktop	Macintosh	Intel 10.15	94
+Android Webview	80.0.3987.99	mobile	Android	9	93
+Edge	137.0.3296.62	desktop	Windows	11	93
+Safari	605.1.15	mobile	iOS	18.5	93
+Chrome	131.0.6778.260	mobile	Android	14.0.0	92
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 15.5	92
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 12.7	92
+Safari	16.6	desktop	Macintosh	Intel 10.15	92
+Android Webview	137.0.7151.89	mobile	Android	9	91
+Chrome	134.0.6998.178	desktop	Windows	11	91
+Chrome	119.0.6045.193	mobile	Android	7.1.1	90
+Chrome	135.0.7049.96	desktop	Windows	10	90
+Chrome	136.0.0.0	desktop	Linux	(not set)	90
+Chrome	137.0.7151.103	desktop	Windows	10	90
+Chrome	137.0.7151.103	desktop	Windows	11	90
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 14.4	90
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 13.7	90
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 14.6	90
+Android Webview	99.0.4844.88	mobile	Android	12	89
+Chrome	135.0.7049.115	desktop	Windows	10	89
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 14.6	89
+Chrome	137.0.7151.123	desktop	Chrome OS	aarch64 16267.51.0	89
+Chrome	138.0.7204.45	mobile	Android	10.0.0	89
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 15.4	88
+Android Webview	138.0.7204.42	mobile	Android	15	87
+Chrome	133.0.6943.127	desktop	Windows	11	87
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 14.6	87
+Edge	138.0.3351.77	desktop	Macintosh	Intel 15.5	87
+Chrome	126.0.6478.110	mobile	Android	14.0.0	86
+Chrome	130.0.6723.86	mobile	Android	15.0.0	86
+Chrome	135.0.7049.96	desktop	Windows	11	86
+Chrome	137.0.7151.79	mobile	iOS	18.5.0	86
+Chrome	137.0.7151.107	tablet	iOS	18.5.0	85
+Chrome	138.0.0.0	desktop	Linux	6.8.0	85
+Chrome	138.0.7204.157	desktop	Linux	6.14.0	85
+Android Webview	136.0.7103.125	mobile	Android	14	84
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 15.4	84
+Chrome	136.0.7103.91	mobile	iOS	18.5.0	83
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 14.0	83
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 15.5	83
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 14.6	83
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 15.4	83
+Chrome	123.0.6312.118	mobile	Android	12	82
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 14.5	82
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 15.1	82
+Chrome	138.0.7204.45	mobile	Android	14	82
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 15.0	82
+Safari	18.0	mobile	iOS	18.5.0	82
+Chrome	131.0.0.0	desktop	Windows	10	81
+Chrome	137.0.7151.103	desktop	Macintosh	Intel 15.5	81
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 14.5	81
+Chrome	138.0.7204.92	desktop	Linux	6.15.4	81
+Chrome	136.0.7103.158	desktop	Chrome OS	x86_64 16238.64.0	80
+Chrome	137.0.7151.103	desktop	Linux	5.15.0	80
+Chrome	137.0.7151.115	tablet	Android	15.0.0	80
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 13.2	80
+Chrome	119.0.6045.193	mobile	Android	7.0.0	79
+Chrome	125.0.6422.72	mobile	Android	14	79
+Chrome	137.0.7151.41	desktop	Macintosh	Intel 15.5	79
+Chrome	87.0.4280.101	mobile	Android	10	79
+Chrome	137.0.7151.117	mobile	Android	10.0.0	78
+Edge	137.0.3296.92	mobile	Android	15.0.0	78
+Safari	19.0	mobile	iOS	19.0	78
+Android Webview	126.0.6478.110	mobile	Android	14	77
+Chrome	133.0.0.0	desktop	Windows	10	77
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 13.0	77
+Chrome	132.0.6834.160	desktop	Windows	11	76
+Chrome	136.0.7103.49	desktop	Windows	11	76
+Chrome	136.0.7103.59	desktop	Linux	6.8.0	76
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 15.3	76
+Chrome	137.0.7151.116	mobile	Android	14	75
+Chrome	136.0.7103.154	desktop	Windows	11	74
+Chrome	137.0.7151.117	mobile	Android	15	74
+Chrome	138.0.7204.63	mobile	Android	15	74
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 14.3	74
+YaBrowser	24.10.0.0	desktop	Windows	10	74
+Android Webview	138.0.7204.42	mobile	Android	14	73
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 14.7	73
+Chrome	122.0.0.0	desktop	Linux	5.15.0	72
+Chrome	135.0.7049.85	desktop	Windows	10	72
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 12.6	72
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 15.0	72
+Chrome	137.0.7151.51	mobile	iOS	18.5.0	72
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 14.1	72
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 14.2	72
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 15.1	72
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 15.3	72
+Chrome	126.0.0.0	desktop	Windows	10	71
+Chrome	131.0.6778.265	desktop	Windows	11	71
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 14.7	71
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 15.2	71
+Chrome	137.0.7151.72	mobile	Android	12.0.0	71
+Chrome	138.0.7204.63	tablet	Android	14.0.0	71
+Chrome	138.0.7204.63	tablet	Android	15.0.0	71
+Safari	18.1.1	desktop	Macintosh	Intel 10.15	71
+Android Webview	126.0.6478.71	mobile	Android	15	70
+Chrome	133.0.6943.142	desktop	Windows	10	70
+Chrome	137.0.7151.68	desktop	Linux	5.15.0	70
+Chrome	138.0.0.0	desktop	Linux	6.11.0	70
+Android Webview	119.0.6045.193	mobile	Android	7.0	69
+Chrome	131.0.0.0	desktop	Linux	(not set)	69
+Chrome	137.0.7151.115	tablet	Android	14.0.0	69
+Chrome	137.0.7151.57	desktop	Macintosh	Intel 15.5	69
+Chrome	138.0.7204.157	mobile	Android	9.0.0	69
+Safari	18.4	mobile	iOS	18.4	69
+Safari	18.6	desktop	Macintosh	Intel 10.15	69
+Chrome	130.0.6723.58	mobile	Android	15.0.0	68
+Chrome	137.0.7151.55	desktop	Linux	6.11.0	68
+Chrome	138.0.7204.92	desktop	Linux	6.11.1	68
+Chrome	139.0.7258.3	mobile	Android	14.0.0	68
+Firefox	140.0	mobile	Android	13	68
+Safari	16.6.1	desktop	Macintosh	Intel 10.15	68
+Safari	17.4.1	desktop	Macintosh	Intel 10.15	68
+Samsung Internet	23.0	mobile	Android	14	68
+Chrome	134.0.6998.89	desktop	Windows	10	67
+Chrome	136.0.7103.56	mobile	iOS	18.5.0	67
+Chrome	138.0.7204.45	mobile	Android	13	67
+Safari	18.2	mobile	iOS	18.2	67
+Android Webview	136.0.7103.125	mobile	Android	13	66
+Chrome	129.0.0.0	desktop	Windows	10	66
+Chrome	137.0.7151.72	mobile	Android	11.0.0	66
+Chrome	138.0.7204.67	mobile	Android	13	66
+YaBrowser	25.4.0.0	desktop	Linux	(not set)	66
+Android Webview	137.0.7151.112	mobile	Android	11	65
+Android Webview	137.0.7151.61	mobile	Android	14	65
+Android Webview	139.0.7258.3	mobile	Android	15	65
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 14.6	65
+Chrome	80.0.3987.99	mobile	Android	10	65
+Safari	18.1	desktop	Macintosh	Intel 10.15	65
+Chrome	123.0.6312.118	mobile	Android	11	64
+Chrome	126.0.6478.71	mobile	Android	15.0.0	64
+Chrome	137.0.0.0	desktop	Linux	6.8.0	64
+Chrome	138.0.7204.33	mobile	iOS	18.5.0	64
+Chrome	138.0.7204.64	mobile	Android	12.0.0	64
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 15.3	64
+Chrome	74.0.3729.136	mobile	Android	9	64
+Edge	139.0.3405.21	desktop	Windows	11	64
+Firefox	135.0	desktop	Linux	(not set)	64
+Firefox	138.0	desktop	Linux	(not set)	64
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 15.1	63
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 13.3	63
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 15.5	63
+Chrome	138.0.7204.67	mobile	Android	14	63
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 13.6	63
+Chrome	103.0.5060.129	mobile	Android	12.0.0	62
+Chrome	125.0.6422.72	mobile	Android	13	62
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 14.4	62
+Chrome	139.0.0.0	desktop	Linux	(not set)	62
+Edge	138.0.3351.95	desktop	Macintosh	Intel 15.5	62
+Safari	18.4.1	mobile	iOS	18.4.1	62
+Android Webview	137.0.7151.72	mobile	Android	9	61
+Chrome	122.0.6261.129	desktop	Windows	11	61
+Chrome	123.0.6312.118	mobile	Android	8.1.0	61
+Chrome	135.0.7049.114	desktop	Linux	6.8.0	61
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 12.5	61
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 15.6	61
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 15.1	61
+Chrome	138.0.0.0	desktop	Macintosh	Intel 15.3	61
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 11.7	61
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 14.1	61
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 14.2	61
+Safari	18.0.1	mobile	iOS	18.0.1	61
+Chrome	123.0.6312.118	mobile	Android	14	60
+Chrome	134.0.6998.36	desktop	Windows	10	60
+Chrome	135.0.7049.85	desktop	Windows	11	60
+Chrome	137.0.7151.70	desktop	Windows	10	60
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 14.3	60
+Chrome	140.0.7259.2	desktop	Windows	10	60
+Android Webview	138.0.7204.63	mobile	Android	10	59
+Chrome	109.0.5414.168	desktop	Windows	8	59
+Chrome	128.0.0.0	desktop	Macintosh	Intel 10.15	59
+Chrome	135.0.7049.42	desktop	Windows	10	59
+Chrome	136.0.7103.113	desktop	Linux	5.15.0	59
+Chrome	137.0.7151.107	mobile	iOS	16.7.11	59
+Chrome	138.0.7204.35	desktop	Windows	11	59
+Edge	137.0.3296.83	desktop	Macintosh	Intel 15.5	59
+Chrome	116.0.5845.187	desktop	Macintosh	Intel 10.14	58
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 15.4	58
+Chrome	138.0.7204.119	mobile	iOS	18.6.0	58
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 14.7	58
+Edge	136.0.3240.64	desktop	Windows	11	58
+Android Webview	136.0.7103.125	mobile	Android	12	57
+Chrome	132.0.0.0	desktop	Windows	10	57
+Chrome	137.0.7151.117	mobile	Android	13	57
+Chrome	137.0.7151.124	desktop	Windows	11	57
+Chrome	138.0.7204.46	mobile	Android	9.0.0	57
+Chrome	99.0.4844.51	desktop	Windows	10	57
+Firefox	138.0	desktop	Macintosh	Intel 10.15	57
+Android Webview	104.0.5112.97	mobile	Android	13	56
+Chrome	133.0.0.0	desktop	Linux	(not set)	56
+Chrome	135.0.0.0	desktop	Windows	10	56
+Chrome	136.0.7103.154	desktop	Windows	10	56
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 15.4	56
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 15.6	56
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 13.7	56
+Chrome	138.0.7204.46	mobile	Android	16.0.0	56
+Edge	136.0.3240.92	desktop	Windows	11	56
+Android Webview	126.0.6478.71	mobile	Android	13	55
+Chrome	106.0.5249.126	mobile	Android	6.0.0	55
+Chrome	114.0.5735.196	mobile	Android	12	55
+Chrome	121.0.0.0	desktop	Macintosh	Intel 10.15	55
+Chrome	132.0.6834.160	desktop	Windows	10	55
+Chrome	136.0.0.0	desktop	Windows	10	55
+Chrome	137.0.7151.116	mobile	Android	13	55
+Chrome	138.0.0.0	desktop	Macintosh	Intel 15.4	55
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 14.4	55
+Chrome	138.0.7204.49	desktop	Linux	6.15.3	55
+Chrome	91.0.4472.114	mobile	Android	12	55
+Chrome	131.0.6778.104	mobile	Android	14.0.0	54
+Chrome	136.0.7103.92	desktop	Linux	6.11.0	54
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 15.0	54
+Chrome	90.0.4430.210	mobile	Android	11	54
+Chrome	109.0.0.0	mobile	Android	11.0	53
+Chrome	126.0.6478.222	desktop	Chrome OS	x86_64 15886.74.0	53
+Chrome	131.0.6778.205	desktop	Windows	10	53
+Chrome	135.0.7049.84	desktop	Linux	6.8.0	53
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 15.5	53
+Chrome	137.0.0.0	desktop	Linux	6.11.0	53
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 12.7	53
+Chrome	138.0.7204.35	desktop	Macintosh	Intel 15.5	53
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 12.7	53
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 14.5	53
+Chrome	139.0.7258.3	mobile	Android	15.0.0	53
+Safari	17.4.1	mobile	iOS	17.4.1	53
+Safari (in-app)	(not set)	mobile	iOS	19.0	53
+Android Webview	137.0.7151.117	mobile	Android	10	52
+Chrome	133.0.6943.127	desktop	Windows	10	52
+Chrome	137.0.7151.124	desktop	Windows	10	52
+Chrome	138.0.7204.157	desktop	Linux	6.11.0	52
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 14.6	52
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 14.7	52
+Chrome	91.0.4472.88	mobile	Android	15	52
+Chrome	137.0.7151.72	mobile	Android	10.0.0	51
+Chrome	81.0.4044.138	mobile	Android	10	51
+Safari	18.0	mobile	iOS	18.0	51
+Safari	18.5	tablet	iOS	18.5	51
+Chrome	125.0.6422.72	desktop	Linux	(not set)	50
+Chrome	135.0.7049.111	mobile	Android	14.0.0	50
+Chrome	137.0.7151.117	mobile	Android	14	50
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 14.1	50
+Chrome	137.0.7151.68	desktop	Windows	10	50
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 14.5	50
+Chrome	138.0.7204.100	desktop	Linux	6.14.0	50
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 13.6	50
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 15.1	50
+Safari	15.6.1	desktop	Macintosh	Intel 10.15	50
+Android Webview	136.0.7103.60	mobile	Android	14	49
+Chrome	108.0.5359.128	mobile	Android	13.0.0	49
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 15.2	49
+Chrome	138.0.7204.45	mobile	Android	16.0.0	49
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 16.0	49
+Chrome	139.0.7258.32	mobile	Android	15.0.0	49
+Edge	136.0.3240.76	desktop	Windows	11	49
+Safari	18.0.1	desktop	Macintosh	Intel 10.15	49
+Safari	18.3	mobile	iOS	18.3	49
+YaBrowser	18.0	mobile	iOS	18.5.0	49
+Android Webview	137.0.7151.61	mobile	Android	13	48
+Android Webview	139.0.7258.3	mobile	Android	14	48
+Android Webview	74.0.3729.136	mobile	Android	9	48
+Chrome	120.0.6099.193	mobile	Android	13.0.0	48
+Chrome	131.0.6778.204	desktop	Linux	6.8.0	48
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 13.5	48
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 15.0	48
+Android Webview	138.0.7204.68	mobile	Android	10	47
+Chrome	137.0.7151.118	mobile	Android	15	47
+Chrome	137.0.7151.55	desktop	Windows	10	47
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 15.4	47
+Chrome	138.0.7204.119	mobile	iOS	18.3.2	47
+Chrome	138.0.7204.63	mobile	Android	13	47
+Chrome	95.0.4638.74	mobile	Android	5.1	47
+Android Webview	137.0.7151.112	mobile	Android	10	46
+Android Webview	138.0.7204.42	mobile	Android	13	46
+Android Webview	97.0.4692.98	mobile	Android	11	46
+Chrome	124.0.0.0	desktop	Macintosh	Intel 10.15	46
+Chrome	129.0.6668.59	desktop	Windows	11	46
+Chrome	135.0.0.0	desktop	Linux	(not set)	46
+Chrome	136.0.7103.87	mobile	Android	13.0.0	46
+Chrome	136.0.7103.87	mobile	Android	14.0.0	46
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 14.4	46
+Chrome	138.0.7204.119	mobile	iOS	19.0.0	46
+Chrome	138.0.7204.92	desktop	Linux	6.1.0	46
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 16.0	46
+Safari	17.6.1	mobile	iOS	17.6.1	46
+Android Webview	123.0.6312.118	mobile	Android	11	45
+Chrome	134.0.6998.165	desktop	Linux	6.8.0	45
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 14.3	45
+Chrome	138.0.7204.119	mobile	iOS	26.0.0	45
+Chrome	138.0.7204.63	tablet	Android	12.0.0	45
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 26.0	45
+Chrome	76.0.3809.136	desktop	Chrome OS	x86_64 12239.92.0	45
+Chrome	79.0.3945.116	mobile	Android	9	45
+Firefox	138.0	desktop	Windows	10	45
+Chrome	106.0.0.0	desktop	Linux	(not set)	44
+Chrome	134.0.6998.118	desktop	Windows	10	44
+Chrome	134.0.6998.35	desktop	Windows	10	44
+Edge	136.0.3240.92	desktop	Windows	10	44
+Safari	604.1	mobile	iOS	16.7.11	44
+Safari	604.1	mobile	iOS	18.5	44
+Android Webview	116.0.0.0	mobile	Android	13	43
+Chrome	125.0.6422.165	mobile	Android	14.0.0	43
+Chrome	130.0.0.0	desktop	Windows	10	43
+Chrome	134.0.6998.205	desktop	Windows	11	43
+Chrome	136.0.7103.87	mobile	Android	15.0.0	43
+Chrome	137.0.7151.107	mobile	iOS	18.3.2	43
+Chrome	138.0.7204.100	desktop	Linux	6.15.5	43
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 15.4	43
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 14.4	43
+Chrome	138.0.7204.64	mobile	Android	11.0.0	43
+Chrome	138.0.7204.92	desktop	Linux	6.14.0	43
+Chrome	139.0.7258.3	mobile	Android	11.0.0	43
+Edge	122.0.0.0	desktop	Windows	10	43
+Firefox	142.0	desktop	Windows	10	43
+Safari	16.2	mobile	iOS	16.2	43
+Safari	18.0	desktop	Macintosh	Intel 10.15	43
+Safari	18.3.2	mobile	iOS	18.3.2	43
+Safari	604.1	tablet	iOS	18.5.0	43
+Android Webview	123.0.6312.118	mobile	Android	8.1.0	42
+Chrome	123.0.6312.118	mobile	Android	13	42
+Chrome	125.0.6422.72	mobile	Android	12	42
+Chrome	135.0.7049.95	desktop	Linux	6.8.0	42
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 15.2	42
+Chrome	137.0.7151.41	desktop	Windows	10	42
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 13.4	42
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 14.7	42
+Chrome	139.0.7258.8	desktop	Chrome OS	x86_64 16328.6.0	42
+Chrome	140.0.7259.2	desktop	Macintosh	Intel 15.5	42
+Safari	18.1	mobile	iOS	18.1	42
+Safari	18.2	mobile	iOS	18.2.1	42
+Android Webview	87.0.4280.141	mobile	Android	11	41
+Chrome	125.0.6422.72	mobile	Android	11	41
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 15.3	41
+Chrome	137.0.7151.115	mobile	Android	16	41
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 14.2	41
+Chrome	138.0.7204.63	mobile	Android	14	41
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 14.5	41
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 13.4	41
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 15.4	41
+Edge	137.0.3296.92	mobile	Android	14.0.0	41
+Safari	5.1	mobile	iOS	5.1.1	41
+Android Webview	137.0.7151.118	mobile	Android	10	40
+Android Webview	138.0.7204.63	mobile	Android	9	40
+Chrome	127.0.6533.17	desktop	Windows	10	40
+Chrome	134.0.6998.178	desktop	Windows	10	40
+Chrome	137.0.7151.89	mobile	Android	15	40
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 15.4	40
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 14.5	40
+Chrome	138.0.7204.63	tablet	Android	13.0.0	40
+Chrome	140.0.7259.0	mobile	Android	14.0.0	40
+Chrome	91.0.4472.88	mobile	Android	12	40
+Edge	117.0.2045.43	desktop	Windows	10	40
+Android Webview	137.0.7151.61	mobile	Android	11	39
+Chrome	114.0.5735.196	mobile	Android	12.0.0	39
+Chrome	131.0.6778.265	desktop	Windows	10	39
+Chrome	132.0.6834.226	desktop	Chrome OS	x86_64 16093.108.0	39
+Chrome	135.0.7049.111	mobile	Android	13.0.0	39
+Chrome	135.0.7049.52	desktop	Linux	6.8.0	39
+Chrome	137.0.7151.55	desktop	Linux	5.15.0	39
+Chrome	137.0.7151.89	mobile	Android	9.0.0	39
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 11.7	39
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 13.2	39
+Firefox	141.0	desktop	Linux	(not set)	39
+Opera	119.0.0.0	desktop	Linux	(not set)	39
+Chrome	122.0.6261.95	desktop	Windows	10	38
+Chrome	135.0.7049.111	mobile	Android	10.0.0	38
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 15.2	38
+Chrome	136.0.7103.87	mobile	Android	11.0.0	38
+Chrome	137.0.7151.132	desktop	Chrome OS	aarch64 16267.60.0	38
+Chrome	137.0.7151.89	mobile	Android	8.1.0	38
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 26.0	38
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 13.5	38
+Chrome	140.0.0.0	desktop	Linux	(not set)	38
+Chrome	96.0.4664.104	mobile	Android	12	38
+Safari (in-app)	(not set)	mobile	iOS	18.3.2	38
+Android Webview	117.0.0.0	mobile	Android	14	37
+Chrome	128.0.0.0	desktop	Linux	6.8.0	37
+Chrome	133.0.6943.141	desktop	Linux	6.8.0	37
+Chrome	133.0.6943.142	desktop	Windows	11	37
+Chrome	136.0.7103.125	mobile	Android	8.1.0	37
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 13.7	37
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 13.0	37
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 14.6	37
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 13.7	37
+Chrome	83.0.4103.106	mobile	Android	11	37
+Firefox	142.0	desktop	Linux	(not set)	37
+Safari	16.6	mobile	iOS	16.6.1	37
+Chrome	122.0.6261.129	desktop	Windows	10	36
+Chrome	132.0.6834.83	desktop	Windows	10	36
+Chrome	134.0.6998.135	mobile	Android	13.0.0	36
+Chrome	134.0.6998.88	desktop	Linux	6.8.0	36
+Chrome	135.0.7049.111	mobile	Android	12.0.0	36
+Chrome	136.0.7103.59	desktop	Linux	6.11.0	36
+Chrome	137.0.7151.115	tablet	Android	13.0.0	36
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 11.7	36
+Chrome	137.0.7151.55	desktop	Windows	11	36
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 13.3	36
+Chrome	138.0.7204.157	desktop	Linux	6.15.6	36
+Chrome	138.0.7204.63	mobile	Android	8.0.0	36
+Edge	136.0.3240.76	desktop	Windows	10	36
+Safari	15.6.6	mobile	iOS	15.8.3	36
+Safari	17.3.1	mobile	iOS	17.3.1	36
+Safari	604.1	mobile	iOS	18.6.0	36
+Android Webview	123.0.6312.118	mobile	Android	12	35
+Android Webview	124.0.6367.179	mobile	Android	14	35
+Android Webview	135.0.7049.111	mobile	Android	9	35
+Android Webview	136.0.7103.125	mobile	Android	10	35
+Chrome	111.0.0.0	desktop	Windows	7	35
+Chrome	126.0.0.0	desktop	Linux	(not set)	35
+Chrome	131.0.6778.205	desktop	Windows	11	35
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 12.7	35
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 14.1	35
+Chrome	136.0.7103.125	mobile	Android	9.0.0	35
+Chrome	136.0.7103.87	mobile	Android	12.0.0	35
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 13.5	35
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 15.6	35
+Firefox	139.0	mobile	Android	15	35
+Opera	95.0.0.0	desktop	Windows	7	35
+Safari	16.6	mobile	iOS	16.7.10	35
+Safari	17.7	mobile	iOS	17.7	35
+Safari	604.1	mobile	iOS	18.3.2	35
+Android Webview	70.0.3538.110	mobile	Android	8.1.0	34
+Android Webview	95.0.4638.74	mobile	Android	12	34
+Chrome	126.0.6478.127	desktop	Windows	10	34
+Chrome	133.0.6943.60	desktop	Windows	10	34
+Chrome	137.0.7151.115	tablet	Android	12.0.0	34
+Chrome	137.0.7151.117	mobile	Android	9.0.0	34
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 14.3	34
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 13.2	34
+Chrome	138.0.7204.55	desktop	Chrome OS	x86_64 16295.32.0	34
+Chrome	138.0.7204.92	desktop	Linux	6.12.10	34
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 12.7	34
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 15.1	34
+Chrome	91.0.4472.88	mobile	Android	14	34
+Firefox	137.0	desktop	Linux	(not set)	34
+Opera	120.0.0.0	desktop	Linux	(not set)	34
+Safari	10.0	mobile	iOS	10.3.1	34
+Safari	16.3	mobile	iOS	16.3.1	34
+Android Webview	123.0.6312.118	mobile	Android	15	33
+Android Webview	131.0.6778.260	mobile	Android	14	33
+Android Webview	138.0.7204.67	tablet	Android	14	33
+Chrome	102.0.5005.125	mobile	Android	12.0.0	33
+Chrome	104.0.5112.97	mobile	Android	13.0.0	33
+Chrome	130.0.6723.58	desktop	Linux	5.15.0	33
+Chrome	131.0.6778.85	desktop	Linux	6.8.0	33
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 15.3	33
+Chrome	136.0.0.0	mobile	Android	11.0	33
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 15.0	33
+Chrome	136.0.7103.116	desktop	Windows	11	33
+Chrome	137.0.0.0	desktop	Macintosh	Intel 15.4	33
+Chrome	137.0.7151.115	mobile	Android	8.0.0	33
+Chrome	137.0.7151.117	mobile	Android	16.0.0	33
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 15.0	33
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 15.4	33
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 15.0	33
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 15.2	33
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 14.6	33
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 12.7	33
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 14.4	33
+Chrome	138.0.7204.67	mobile	Android	12	33
+Chrome	139.0.7258.5	desktop	Macintosh	Intel 15.5	33
+Chrome	139.0.7258.5	desktop	Windows	10	33
+Chrome	76.0.3809.71	desktop	Linux	5.10.0	33
+Chrome	87.0.4280.141	mobile	Android	8.1.0	33
+Chrome	91.0.4472.88	mobile	Android	13	33
+Edge	138.0.3351.66	mobile	Android	15.0.0	33
+Android Webview	105.0.5195.136	mobile	Android	12	32
+Android Webview	136.0.7103.60	mobile	Android	13	32
+Android Webview	138.0.7204.157	mobile	Android	10	32
+Chrome	125.0.6422.145	mobile	iOS	15.8	32
+Chrome	132.0.6834.83	desktop	Linux	6.8.0	32
+Chrome	134.0.6998.89	desktop	Windows	11	32
+Chrome	135.0.7049.111	mobile	Android	15.0.0	32
+Chrome	135.0.7049.114	desktop	Linux	6.11.0	32
+Chrome	136.0.0.0	desktop	Macintosh	Intel 15.5	32
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 13.6	32
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 16.0	32
+Chrome	138.0.7204.156	tablet	iOS	18.5.0	32
+Chrome	138.0.7204.45	mobile	Android	9.0.0	32
+Chrome	138.0.7204.49	desktop	Linux	6.1.0	32
+Chrome	59.0.3071.125	mobile	Android	7.0	32
+Chrome	83.0.4103.106	mobile	Android	10	32
+Edge	137.0.3296.52	desktop	Windows	11	32
+YaBrowser	25.2.0.0	desktop	Windows	10	32
+Android Webview	136.0.7103.60	mobile	Android	11	31
+Android Webview	137.0.7151.88	mobile	Android	13	31
+Android Webview	137.0.7151.88	mobile	Android	14	31
+Chrome	117.0.5938.60	mobile	Android	13.0.0	31
+Chrome	122.0.6261.95	desktop	Windows	11	31
+Chrome	127.0.0.0	desktop	Linux	(not set)	31
+Chrome	132.0.6834.110	desktop	Linux	6.8.0	31
+Chrome	134.0.0.0	desktop	Linux	(not set)	31
+Chrome	135.0.7049.111	mobile	Android	11.0.0	31
+Chrome	135.0.7049.114	desktop	Linux	5.15.0	31
+Chrome	135.0.7049.42	desktop	Windows	11	31
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 14.3	31
+Chrome	136.0.7103.116	desktop	Windows	10	31
+Chrome	136.0.7103.177	desktop	Windows	10	31
+Chrome	136.0.7103.92	desktop	Linux	5.15.0	31
+Chrome	137	mobile	iOS	(not set)	31
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 14.3	31
+Chrome	138.0.7204.100	desktop	Linux	6.1.0	31
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 14.7	31
+Chrome	138.0.7204.157	mobile	Android	8.1.0	31
+Chrome	138.0.7204.45	mobile	Android	12	31
+Chrome	138.0.7204.46	mobile	Android	8.1.0	31
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 14.4	31
+Chrome	138.0.7204.53	mobile	iOS	18.5.0	31
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 14.4	31
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 12.5	31
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 14.0	31
+Chrome	139.0.7258.3	mobile	Android	13.0.0	31
+Chrome	139.0.7258.33	desktop	Chrome OS	x86_64 16328.18.0	31
+Edge	134.0.3124.93	desktop	Windows	10	31
+Safari	17.1	desktop	Macintosh	Intel 10.15	31
+Safari	17.13	desktop	Macintosh	Intel 10.15	31
+Safari	17.2.1	desktop	Macintosh	Intel 10.15	31
+Samsung Internet	7.2	mobile	Android	8.1.0	31
+Android Webview	114.0.5735.196	mobile	Android	12	30
+Android Webview	114.0.5735.60	mobile	Android	13	30
+Android Webview	137.0.7151.61	mobile	Android	12	30
+Chrome	133.0.6943.126	desktop	Linux	6.8.0	30
+Chrome	133.0.6943.137	mobile	Android	14.0.0	30
+Chrome	133.0.6943.53	desktop	Linux	6.8.0	30
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 15.5	30
+Chrome	135.0.7049.83	mobile	iOS	18.5.0	30
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 14.1	30
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 15.3	30
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 13.4	30
+Chrome	137.0.7151.57	desktop	Windows	11	30
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 15.2	30
+Chrome	137.0.7151.89	mobile	Android	14	30
+Chrome	138.0.0.0	desktop	Linux	6.14.0	30
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 12.6	30
+Chrome	138.0.7204.119	mobile	iOS	18.3.1	30
+Chrome	138.0.7204.35	desktop	Windows	10	30
+Edge	138.0.3351.83	mobile	Android	15.0.0	30
+Firefox	134.0	desktop	Linux	(not set)	30
+Firefox	140.0	mobile	Android	12	30
+Mozilla Compatible Agent	5.0	desktop	(not set)	(not set)	30
+Safari	604.1	mobile	iOS	15.8.4	30
+Safari (in-app)	(not set)	mobile	iOS	18.6	30
+Android Webview	106.0.5249.126	mobile	Android	13	29
+Android Webview	94.0.4606.85	mobile	Android	11	29
+Chrome	103.0.5060.132	desktop	Chrome OS	x86_64 14816.131.5	29
+Chrome	103.0.5060.134	desktop	Macintosh	Intel 10.11	29
+Chrome	130.0.0.0	desktop	Macintosh	Intel 10.15	29
+Chrome	131.0.6778.86	desktop	Windows	11	29
+Chrome	132.0.6834.84	desktop	Windows	10	29
+Chrome	133.0.6943.99	desktop	Windows	10	29
+Chrome	134.0.6998.166	desktop	Windows	10	29
+Chrome	134.0.6998.167	desktop	Windows	10	29
+Chrome	135.0.7049.100	mobile	Android	14.0.0	29
+Chrome	137.0.0.0	desktop	Macintosh	Intel 15.3	29
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 14.2	29
+Chrome	138.0.0.0	desktop	Macintosh	Intel 16.0	29
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 15.3	29
+Chrome	138.0.7204.157	desktop	Linux	5.15.0	29
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 14.3	29
+Chrome	138.0.7204.49	desktop	Linux	6.14.0	29
+Chrome	138.0.7204.67	mobile	Android	11	29
+Chrome	140.0.7259.0	mobile	Android	15.0.0	29
+Chrome	91.0.4472.124	desktop	Windows	10	29
+Edge	138.0.3351.42	desktop	Windows	11	29
+Firefox	137.0	desktop	Windows	10	29
+Safari	12.1.2	mobile	iOS	12.5.7	29
+Safari	604.1	mobile	iOS	17.6.1	29
+Safari (in-app)	(not set)	mobile	iOS	18.4.1	29
+Samsung Internet	7.4	mobile	Android	13	29
+Android Webview	137.0.7151.115	tablet	Android	14	28
+Android Webview	81.0.4044.138	mobile	Android	10	28
+Android Webview	87.0.4280.101	mobile	Android	10	28
+Chrome	114.0.5735.196	mobile	Android	10	28
+Chrome	122.0.6261.112	desktop	Windows	10	28
+Chrome	131.0.6778.140	desktop	Windows	10	28
+Chrome	134.0.0.0	desktop	Windows	10	28
+Chrome	134.0.6998.35	desktop	Linux	6.8.0	28
+Chrome	135.0.7049.116	desktop	Windows	11	28
+Chrome	137.0.7151.103	desktop	Linux	6.11.1	28
+Chrome	137.0.7151.115	tablet	Android	11.0.0	28
+Chrome	137.0.7151.116	mobile	Android	12	28
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 12.4	28
+Chrome	137.0.7151.41	desktop	Windows	11	28
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 15.3	28
+Chrome	137.0.7151.90	mobile	Android	14	28
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 14.0	28
+Chrome	138.0.7204.143	desktop	Windows	11	28
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 15.3	28
+Chrome	138.0.7204.45	mobile	Android	8.1.0	28
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 14.5	28
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 13.7	28
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 15.2	28
+Chrome	139.0.7258.5	desktop	Windows	11	28
+Chrome	87.0.4280.141	mobile	Android	12	28
+Firefox	140.0	mobile	Android	16	28
+Safari	16.0	desktop	Macintosh	Intel 10.15	28
+Safari	16.1	desktop	Macintosh	Intel 10.15	28
+Safari	16.1	mobile	iOS	16.1.2	28
+Safari	17.1.1	mobile	iOS	17.1.1	28
+Safari	604.1	mobile	iOS	18.4.1	28
+Android Webview	136.0.7103.125	mobile	Android	15	27
+Chrome	125.0.6422.72	mobile	Android	15.0.0	27
+Chrome	132.0.6834.111	desktop	Windows	11	27
+Chrome	133.0.6943.84	mobile	iOS	18.3.1	27
+Chrome	135.0.7049.100	mobile	Android	15.0.0	27
+Chrome	137.0.7151.107	mobile	iOS	19.0.0	27
+Chrome	137.0.7151.119	desktop	Linux	6.14.11	27
+Chrome	137.0.7151.119	desktop	Linux	6.15.3	27
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 15.4	27
+Chrome	138.0.0.0	desktop	Macintosh	Intel 15.1	27
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 14.2	27
+Chrome	139.0.7246.0	desktop	Windows	11	27
+Chrome	139.0.7258.32	mobile	Android	13.0.0	27
+Chrome	71.0.3578.141	mobile	Android	9	27
+Edge	121.0.0.0	desktop	Windows	10	27
+Firefox	128.0	desktop	Macintosh	Intel 10.15	27
+Safari (in-app)	(not set)	mobile	iOS	17.6.1	27
+Safari (in-app)	(not set)	tablet	iOS	18.5	27
+Android Webview	136.0.7103.87	mobile	Android	9	26
+Chrome	119.0.6045.193	mobile	Android	7.1.2	26
+Chrome	120.0.0.0	desktop	Linux	(not set)	26
+Chrome	130.0.6723.70	desktop	Windows	11	26
+Chrome	131.0.6778.104	mobile	Android	13.0.0	26
+Chrome	131.0.6778.264	desktop	Linux	6.8.0	26
+Chrome	131.0.6778.86	desktop	Windows	10	26
+Chrome	132.0.6834.163	mobile	Android	14.0.0	26
+Chrome	133.0.6943.53	desktop	Windows	10	26
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 13.5	26
+Chrome	137.0.7151.119	desktop	Linux	6.14.0	26
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 13.1	26
+Chrome	137.0.7151.120	mobile	Windows	11	26
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 13.5	26
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 14.2	26
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 14.6	26
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 13.7	26
+Chrome	138.0.7204.157	tablet	Android	15.0.0	26
+Chrome	138.0.7204.49	desktop	Linux	6.12.10	26
+Chrome	138.0.7204.64	mobile	Android	16.0.0	26
+Chrome	138.0.7204.92	desktop	Linux	6.12.27	26
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 14.5	26
+Edge	139.0.3405.36	desktop	Windows	11	26
+Firefox	137.0	desktop	Macintosh	Intel 10.15	26
+Firefox	139.0	mobile	Android	14	26
+Android Webview	79.0.3945.116	mobile	Android	9	25
+Android Webview	92.0.4515.105	mobile	Android	10	25
+Chrome	123.0.6312.118	mobile	Android	15.0.0	25
+Chrome	125.0.6422.142	desktop	Windows	10	25
+Chrome	132.0.6834.224	desktop	Chrome OS	x86_64 16093.106.0	25
+Chrome	134.0.6998.118	desktop	Windows	11	25
+Chrome	134.0.6998.165	desktop	Linux	6.11.0	25
+Chrome	135.0.7049.95	desktop	Windows	10	25
+Chrome	136.0.7103.60	mobile	Android	14.0.0	25
+Chrome	137.0.7151.116	mobile	Android	11	25
+Chrome	137.0.7151.72	mobile	Android	8.1.0	25
+Chrome	138.0.0.0	desktop	Macintosh	Intel 14.6	25
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 15.3	25
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 14.1	25
+Chrome	138.0.7204.92	desktop	Windows	10	25
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 12.6	25
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 13.3	25
+Chrome	139.0.7258.3	mobile	Android	10.0.0	25
+Chrome	139.0.7258.3	mobile	Android	12.0.0	25
+Chrome	139.0.7258.32	mobile	Android	14.0.0	25
+Chrome	140.0.7299.0	desktop	Windows	11	25
+Mozilla Compatible Agent	5.0	desktop	Macintosh	Intel 10.15	25
+Opera	120.0.0.0	desktop	Macintosh	Intel 10.15	25
+Safari	16.7.11	mobile	iOS	16.7.11	25
+Safari	17.4	desktop	Macintosh	Intel 10.15	25
+Android Webview	138.0.7204.139	mobile	Android	15	24
+Android Webview	138.0.7204.42	mobile	Android	11	24
+Android Webview	138.0.7204.42	mobile	Android	12	24
+Android Webview	138.0.7204.45	mobile	Android	9	24
+Chrome	119.0.0.0	desktop	Linux	(not set)	24
+Chrome	121.0.6167.185	desktop	Windows	10	24
+Chrome	128.0.6613.88	mobile	Android	15.0.0	24
+Chrome	130.0.6723.86	mobile	Android	14.0.0	24
+Chrome	132.0.6834.110	desktop	Linux	5.15.0	24
+Chrome	132.0.6834.110	desktop	Windows	11	24
+Chrome	133.0.6943.98	desktop	Windows	10	24
+Chrome	134.0.6998.135	mobile	Android	14.0.0	24
+Chrome	135.0.7049.114	desktop	Windows	10	24
+Chrome	136.0.7103.149	desktop	Windows	10	24
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 13.6	24
+Chrome	137.0.7151.116	mobile	Android	10	24
+Chrome	137.0.7151.117	mobile	Android	11	24
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 13.2	24
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 12.7	24
+Chrome	137.0.7151.72	mobile	Android	9.0.0	24
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 15.1	24
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 12.5	24
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 16.0	24
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 16.0	24
+Chrome	138.0.7204.63	mobile	Android	12	24
+Chrome	75.0.3770.144	desktop	Chrome OS	armv7l 12105.100.0	24
+Edge	136.0.3240.64	desktop	Windows	10	24
+Edge	137.0.3296.68	desktop	Macintosh	Intel 15.5	24
+Edge	139.0.3405.42	desktop	Windows	11	24
+Firefox	135.0	desktop	Windows	10	24
+Opera	121.0.0.0	desktop	Linux	(not set)	24
+Safari	17.0	desktop	Macintosh	Intel 10.15	24
+Safari	18.3.1	mobile	iOS	18.3.1	24
+Android Webview	114.0.5735.196	mobile	Android	10	23
+Android Webview	120.0.6099.193	mobile	Android	13	23
+Chrome	121.0.6167.185	desktop	Windows	11	23
+Chrome	128.0.6613.127	mobile	Android	13.0.0	23
+Chrome	132.0.6834.111	desktop	Windows	10	23
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 14.6	23
+Chrome	135.0.7049.116	desktop	Windows	10	23
+Chrome	136.0.7103.150	desktop	Chrome OS	x86_64 16238.62.0	23
+Chrome	136.0.7103.177	desktop	Windows	11	23
+Chrome	136.0.7103.48	desktop	Windows	10	23
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 14.6	23
+Chrome	137.0.0.0	desktop	Linux	6.15.3	23
+Chrome	137.0.0.0	desktop	Macintosh	Intel 15.1	23
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 13.4	23
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 12.1	23
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 12.3	23
+Chrome	137.0.7151.90	mobile	Android	14.0.0	23
+Chrome	138.0.0.0	desktop	Linux	5.15.0	23
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 16.0	23
+Chrome	138.0.7204.63	mobile	Android	10	23
+Chrome	139.0.7258.41	mobile	Android	15.0.0	23
+Chrome	91.0.4472.88	mobile	Android	10	23
+Edge	136.0.3240.131	desktop	Windows	11	23
+Edge	137.0.3296.92	mobile	Android	13.0.0	23
+Edge	138.0.3351.77	mobile	Android	15.0.0	23
+Firefox	115.0	desktop	Windows	8.1	23
+Firefox	136.0	desktop	Windows	10	23
+Safari	19.0	desktop	Macintosh	Intel 10.15	23
+Android Webview	137.0.7151.115	mobile	Android	8.1.0	22
+Chrome	103.0.5060.134	desktop	Macintosh	Intel 10.12	22
+Chrome	123.0.6312.118	desktop	Linux	15.0.0	22
+Chrome	129.0.6668.90	desktop	Windows	10	22
+Chrome	130.0.6723.70	desktop	Windows	10	22
+Chrome	131.0.6778.109	desktop	Windows	10	22
+Chrome	131.0.6778.139	desktop	Linux	6.8.0	22
+Chrome	132.0.6834.210	desktop	Windows	10	22
+Chrome	134.0.6998.205	desktop	Windows	10	22
+Chrome	134.0.6998.89	desktop	Macintosh	Intel 15.5	22
+Chrome	134.0.6998.99	mobile	iOS	18.5.0	22
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 14.5	22
+Chrome	135.0.7049.95	desktop	Linux	6.11.0	22
+Chrome	136.0.7103.113	desktop	Linux	6.14.0	22
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 13.5	22
+Chrome	136.0.7103.177	desktop	Macintosh	Intel 14.7	22
+Chrome	137.0.7151.107	mobile	iOS	17.6.1	22
+Chrome	137.0.7151.107	mobile	iOS	18.6.0	22
+Chrome	137.0.7151.117	mobile	Android	8.1.0	22
+Chrome	137.0.7151.118	mobile	Android	13	22
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 10.15	22
+Chrome	137.0.7151.120	mobile	Android	11.0	22
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 15.3	22
+Chrome	138.0.7204.148	desktop	Chrome OS	x86_64 16295.44.0	22
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 11.7	22
+Chrome	138.0.7204.45	mobile	Android	10	22
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 13.7	22
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 13.0	22
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 14.7	22
+Chrome	58.0.3029.110	desktop	Windows	10	22
+Chrome	71.0.3578.141	mobile	Android	8.1.0	22
+Chrome	92.0.4515.131	mobile	Android	11	22
+Edge	137.0.3296.62	desktop	Windows	10	22
+Opera	118.0.0.0	desktop	Windows	10	22
+Safari	15.6.7	desktop	Macintosh	Intel 10.15	22
+Safari	16.1	mobile	iOS	16.1.1	22
+Safari	17.3	desktop	Macintosh	Intel 10.15	22
+Safari	17.5.1	mobile	iOS	17.5.1	22
+Android Webview	125.0.6422.165	mobile	Android	14	21
+Android Webview	139.0.7258.32	mobile	Android	15	21
+Android Webview	72.0.3626.121	mobile	Android	9	21
+Chrome	116.0.5845.92	mobile	Android	13.0.0	21
+Chrome	125.0.6422.80	mobile	iOS	15.8	21
+Chrome	126.0.6478.127	desktop	Windows	11	21
+Chrome	132.0.6834.163	mobile	Android	13.0.0	21
+Chrome	133.0.6943.137	mobile	Android	16.0.0	21
+Chrome	134.0.6998.135	mobile	Android	11.0.0	21
+Chrome	135.0.0.0	desktop	Macintosh	Intel 15.5	21
+Chrome	135.0.0.0	mobile	Android	10	21
+Chrome	135.0.7049.100	mobile	Android	10.0.0	21
+Chrome	135.0.7049.79	mobile	Android	14.0.0	21
+Chrome	135.0.7049.79	mobile	Android	15.0.0	21
+Chrome	136.0.0.0	desktop	Linux	6.12.9	21
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 13.4	21
+Chrome	136.0.7103.59	desktop	Linux	5.15.0	21
+Chrome	136.0.7103.87	mobile	Android	10.0.0	21
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 13.2	21
+Chrome	137.0.7151.107	mobile	iOS	18.3.1	21
+Chrome	137.0.7151.107	mobile	iOS	18.4.1	21
+Chrome	137.0.7151.118	mobile	Android	14	21
+Chrome	137.0.7151.119	desktop	Linux	6.1.0	21
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 15.3	21
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 11.6	21
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 12.0	21
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 15.4	21
+Chrome	137.0.7151.68	desktop	Windows	11	21
+Chrome	137.0.7151.90	mobile	Android	15.0.0	21
+Chrome	138.0.0.0	desktop	Linux	6.15.4	21
+Chrome	138.0.0.0	desktop	Macintosh	Intel 14.5	21
+Chrome	138.0.7204.101	mobile	Windows	11	21
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 14.6	21
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 15.6	21
+Chrome	138.0.7204.49	desktop	Linux	6.15.4	21
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 13.7	21
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 15.1	21
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 15.0	21
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 15.0	21
+Chrome	81.0.4044.138	tablet	Android	4.4.4	21
+Edge	122.0.2365.106	desktop	Windows	11	21
+Firefox	133.0	desktop	Windows	10	21
+Opera	92.0.2254.77878	mobile	Android	14	21
+Safari	16.0	mobile	iOS	16.0	21
+Safari	17.2	mobile	iOS	17.2.1	21
+Safari	17.3.1	desktop	Macintosh	Intel 10.15	21
+Safari	604.1	mobile	iOS	19.0.0	21
+Safari (in-app)	(not set)	mobile	iOS	18.3.1	21
+Samsung Internet	22.0	mobile	Android	14	21
+Android Webview	131.0.6778.260	mobile	Android	9	20
+Android Webview	136.0.7103.60	mobile	Android	12	20
+Android Webview	137.0.7151.61	mobile	Android	15	20
+Android Webview	137.0.7151.88	mobile	Android	11	20
+Android Webview	138.0.7204.32	mobile	Android	15	20
+Android Webview	138.0.7204.35	mobile	Android	15	20
+Chrome	109.0.0.0	desktop	Macintosh	Intel 10.15	20
+Chrome	114.0.0.0	desktop	Windows	10	20
+Chrome	123.0.6312.118	mobile	Android	14.0.0	20
+Chrome	130.0.0.0	desktop	Linux	(not set)	20
+Chrome	130.0.6723.117	desktop	Windows	10	20
+Chrome	131.0.6778.200	mobile	Android	11.0.0	20
+Chrome	133.0.6943.54	desktop	Windows	10	20
+Chrome	133.0.6943.98	desktop	Linux	6.8.0	20
+Chrome	134.0.6998.135	mobile	Android	15.0.0	20
+Chrome	134.0.6998.165	desktop	Windows	10	20
+Chrome	135.0.7049.84	desktop	Windows	10	20
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 13.7	20
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 14.2	20
+Chrome	136.0.7103.48	desktop	Windows	11	20
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 14.7	20
+Chrome	137.0.0.0	mobile	Android	15.0.0	20
+Chrome	137.0.7151.115	tablet	Android	10.0.0	20
+Chrome	137.0.7151.119	desktop	Linux	6.12.10	20
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 12.2	20
+Chrome	138.0.7204.157	mobile	Android	15	20
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 13.4	20
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 14.1	20
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 15.3	20
+Chrome	96.0.4664.61	mobile	Android	12	20
+Opera	89.0.0.0	mobile	Android	10	20
+Safari	15.6.1	mobile	iOS	15.6.1	20
+Safari	15.8.4	mobile	iOS	15.8.4	20
+Safari	604.1	mobile	iOS	18.1.1	20
+Android Webview	123.0.6312.118	mobile	Android	13	19
+Android Webview	130.0.6723.86	mobile	Android	14	19
+Android Webview	133.0.6943.137	mobile	Android	9	19
+Android Webview	136.0.7103.127	mobile	Android	13	19
+Android Webview	138.0.7204.146	mobile	Android	15	19
+Android Webview	139.0.7258.3	mobile	Android	12	19
+Android Webview	71.0.3578.99	mobile	Android	8.1.0	19
+Chrome	114.0.0.0	desktop	Linux	(not set)	19
+Chrome	121.0.6167.178	mobile	Android	14.0.0	19
+Chrome	122.0.0.0	desktop	Windows	10	19
+Chrome	122.0.6261.119	mobile	Android	15	19
+Chrome	123.0.6312.118	desktop	Linux	(not set)	19
+Chrome	124.0.0.0	mobile	Android	14	19
+Chrome	126.0.6478.183	desktop	Windows	10	19
+Chrome	128.0.0.0	desktop	Windows	10	19
+Chrome	128.0.6613.138	desktop	Windows	10	19
+Chrome	131.0.6778.140	desktop	Windows	11	19
+Chrome	134.0.6998.135	mobile	Android	10.0.0	19
+Chrome	134.0.6998.135	mobile	Android	12.0.0	19
+Chrome	134.0.6998.205	desktop	Macintosh	Intel 15.5	19
+Chrome	135.0.7049.52	desktop	Linux	6.11.0	19
+Chrome	135.0.7049.84	desktop	Linux	6.11.0	19
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 15.5	19
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 15.4	19
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 13.6	19
+Chrome	136.0.7103.87	mobile	Android	9.0.0	19
+Chrome	136.0.7103.92	desktop	Windows	10	19
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 14.4	19
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 15.4	19
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 12.5	19
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 12.6	19
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 13.0	19
+Chrome	137.0.7151.57	desktop	Windows	10	19
+Chrome	138.0.0.0	desktop	Macintosh	Intel 14.7	19
+Chrome	138.0.7204.100	desktop	Linux	6.12.10	19
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 14.7	19
+Chrome	138.0.7204.156	mobile	iOS	18.6.0	19
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 14.5	19
+Chrome	138.0.7204.23	desktop	Windows	10	19
+Chrome	138.0.7204.63	mobile	Android	11	19
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 13.1	19
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 14.6	19
+Chrome	91.0.4472.88	mobile	Android	11	19
+Edge	139.0.3405.13	desktop	Windows	11	19
+Firefox	125.0	desktop	Linux	(not set)	19
+Firefox	140.0	mobile	Android	10	19
+Firefox	140.0	mobile	Android	11	19
+Safari	16.3	desktop	Macintosh	Intel 10.15	19
+Safari	6.0	tablet	iOS	6.0.1	19
+Safari (in-app)	(not set)	mobile	iOS	16.7.11	19
+Safari (in-app)	(not set)	mobile	iOS	18.1.1	19
+Android Webview	132.0.6834.163	mobile	Android	9	18
+Android Webview	138.0.7204.157	mobile	Android	9	18
+Android Webview	138.0.7204.63	mobile	Android	8.1.0	18
+Android Webview	75.0.3770.156	mobile	Android	10	18
+Android Webview	96.0.4664.104	mobile	Android	12	18
+Chrome	122.0.6261.112	desktop	Windows	11	18
+Chrome	123.0.6312.118	mobile	Android	9	18
+Chrome	126.0.6478.122	mobile	Android	11.0.0	18
+Chrome	126.0.6478.126	desktop	Linux	6.8.0	18
+Chrome	127.0.6533.120	desktop	Windows	10	18
+Chrome	129.0.0.0	desktop	Windows	11	18
+Chrome	131.0.6778.204	desktop	Linux	6.11.0	18
+Chrome	131.0.6778.260	mobile	Android	12.0.0	18
+Chrome	132.0.6834.159	desktop	Linux	6.8.0	18
+Chrome	132.0.6834.83	desktop	Windows	11	18
+Chrome	133.0.6943.137	mobile	Android	13.0.0	18
+Chrome	134.0.6998.35	desktop	Linux	5.15.0	18
+Chrome	134.0.6998.88	desktop	Linux	6.11.0	18
+Chrome	134.0.6998.89	desktop	Macintosh	Intel 15.3	18
+Chrome	135.0.7049.100	mobile	Android	12.0.0	18
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 15.5	18
+Chrome	135.0.7049.128	desktop	Chrome OS	x86_64 16209.67.0	18
+Chrome	135.0.7049.84	desktop	Linux	5.15.0	18
+Chrome	136.0.0.0	mobile	Android	10	18
+Chrome	136.0.7103.179	desktop	Windows	11	18
+Chrome	136.0.7103.60	mobile	Android	15.0.0	18
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 14.4	18
+Chrome	137.0.7151.68	desktop	Linux	6.14.0	18
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 14.1	18
+Chrome	137.0.7151.90	mobile	Android	15	18
+Chrome	138.0.0.0	desktop	Linux	6.1.0	18
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 14.0	18
+Chrome	138.0.7204.45	mobile	Android	11	18
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 13.5	18
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 14.3	18
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 15.2	18
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 15.2	18
+Chrome	140.0.7268.0	mobile	Android	11.0	18
+Edge	136.0.3240.50	desktop	Windows	11	18
+Edge	137.0.3296.92	mobile	Android	12.0.0	18
+Edge	137.0.3296.93	desktop	Macintosh	Intel 15.4	18
+Edge	138.0.3351.83	mobile	Android	14.0.0	18
+Edge	92.0.902.67	desktop	Windows	10	18
+Opera	44.6.2246.127414	mobile	Android	8.1.0	18
+Safari	16.5	desktop	Macintosh	Intel 10.15	18
+Safari	17.3	mobile	iOS	17.3	18
+Safari	17.8.1	mobile	iOS	17.7.2	18
+YaBrowser	25.2.0.0	desktop	Linux	(not set)	18
+YaBrowser	25.6.2.108.00	mobile	Android	15	18
+YaBrowser	25.6.2.109.00	mobile	Android	14	18
+Android Webview	103.0.5060.129	mobile	Android	12	17
+Android Webview	137.0.7151.117	mobile	Android	9	17
+Chrome	114.0.0.0	desktop	Macintosh	Intel 10.15	17
+Chrome	127.0.6533.101	mobile	Android	15	17
+Chrome	130.0.0.0	desktop	Windows	11	17
+Chrome	131.0.6778.108	desktop	Linux	6.8.0	17
+Chrome	131.0.6778.81	mobile	Android	13.0.0	17
+Chrome	132.0.6834.110	desktop	Windows	10	17
+Chrome	132.0.6834.197	desktop	Windows	11	17
+Chrome	132.0.6834.207	desktop	Windows	10	17
+Chrome	132.0.6834.209	desktop	Windows	10	17
+Chrome	133.0.6943.137	mobile	Android	12.0.0	17
+Chrome	133.0.6943.137	mobile	Android	15.0.0	17
+Chrome	133.0.6943.35	desktop	Windows	10	17
+Chrome	134.0.6998.165	desktop	Linux	5.15.0	17
+Chrome	135.0.7049.79	mobile	Android	13.0.0	17
+Chrome	135.0.7049.95	desktop	Linux	5.15.0	17
+Chrome	136.0.7103.113	desktop	Windows	10	17
+Chrome	136.0.7103.142	desktop	Chrome OS	x86_64 16238.54.0	17
+Chrome	137.0.0.0	desktop	Linux	5.15.0	17
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 11.7	17
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 14.7	17
+Chrome	137.0.7151.117	mobile	Android	12	17
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 14.6	17
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 15.6	17
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 15.4	17
+Chrome	138.0.0.0	desktop	Linux	6.15.3	17
+Chrome	138.0.0.0	desktop	Macintosh	Intel 26.0	17
+Chrome	138.0.7204.100	desktop	Linux	6.15.4	17
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 14.5	17
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 12.7	17
+Chrome	138.0.7204.155	desktop	Chrome OS	x86_64 16295.51.0	17
+Chrome	138.0.7204.157	tablet	Android	13.0.0	17
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 13.5	17
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 13.6	17
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 13.6	17
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 12.7	17
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 14.1	17
+Chrome	138.0.7204.67	mobile	Android	10	17
+Chrome	138.0.7204.93	desktop	Windows	10	17
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 14.4	17
+Chrome	72.0.3626.121	mobile	Android	9	17
+Chrome	85.0.4183.127	mobile	Android	11	17
+Chrome	87.0.4280.141	desktop	Windows	Server 2003	17
+Safari	14.0	mobile	iOS	14.0	17
+Safari	17.8	mobile	iOS	17.7.1	17
+Safari	604.1	mobile	iOS	17.5.1	17
+YaBrowser	25.6.2.109.00	mobile	Android	15	17
+Android Webview	117.0.0.0	mobile	Android	13	16
+Android Webview	123.0.6312.118	mobile	Android	14	16
+Android Webview	134.0.6998.135	mobile	Android	9	16
+Android Webview	135.0.7049.100	mobile	Android	9	16
+Android Webview	135.0.7049.111	mobile	Android	14	16
+Android Webview	138.0.7204.35	mobile	Android	14	16
+Chrome	106.0.5249.126	mobile	Android	13.0.0	16
+Chrome	109.0.0.0	desktop	Windows	7	16
+Chrome	111.0.0.0	desktop	Linux	(not set)	16
+Chrome	123.0.6312.118	desktop	Linux	11.0.0	16
+Chrome	130.0.6723.116	desktop	Linux	6.8.0	16
+Chrome	131.0.6778.200	mobile	Android	10.0.0	16
+Chrome	131.0.6778.200	mobile	Android	14.0.0	16
+Chrome	131.0.6778.260	mobile	Android	13.0.0	16
+Chrome	132.0.6834.159	desktop	Windows	10	16
+Chrome	133.0.6943.126	desktop	Windows	10	16
+Chrome	133.0.6943.137	mobile	Android	11.0.0	16
+Chrome	134.0.6998.88	desktop	Windows	10	16
+Chrome	135.0.7049.100	mobile	Android	11.0.0	16
+Chrome	135.0.7049.100	mobile	Android	13.0.0	16
+Chrome	135.0.7049.38	mobile	Android	10.0.0	16
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 15.3	16
+Chrome	136.0.7103.156	desktop	Windows	10	16
+Chrome	137.0.0.0	desktop	Linux	5.10.134	16
+Chrome	137.0.7151.103	desktop	Linux	6.14.0	16
+Chrome	137.0.7151.103	desktop	Macintosh	Intel 15.4	16
+Chrome	137.0.7151.115	mobile	Android	9	16
+Chrome	137.0.7151.119	desktop	Linux	5.4.0	16
+Chrome	137.0.7151.137	desktop	Chrome OS	aarch64 16267.66.0	16
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 14.7	16
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 13.4	16
+Chrome	138.0.7204.100	desktop	Linux	6.12.27	16
+Chrome	138.0.7204.100	desktop	Linux	6.15.6	16
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 14.7	16
+Chrome	138.0.7204.119	mobile	iOS	18.4.1	16
+Chrome	138.0.7204.157	desktop	Linux	6.1.0	16
+Chrome	138.0.7204.157	mobile	Android	13	16
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 11.7	16
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 14.2	16
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 13.6	16
+Chrome	138.0.7204.63	mobile	Android	9	16
+Chrome	138.0.7204.63	tablet	Android	10.0.0	16
+Chrome	138.0.7204.64	mobile	Android	10.0.0	16
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 15.1	16
+Chrome	139.0.7258.31	desktop	Windows	10	16
+Chrome	139.0.7258.31	desktop	Windows	11	16
+Chrome	139.0.7258.32	mobile	Android	11.0.0	16
+Chrome	56.0.2924.87	mobile	Android	6.0.1	16
+Chrome	70.0.3538.80	mobile	Android	10	16
+Chrome	80.0.3987.99	mobile	Android	9	16
+Chrome	83.0.4103.101	mobile	Android	10	16
+Chrome	86.0.4240.198	desktop	Windows	10	16
+Chrome	87.0.4280.141	mobile	Android	15	16
+Chrome	91.0.4472.164	desktop	Linux	(not set)	16
+Edge	137.0.3296.92	desktop	Linux	(not set)	16
+Firefox	127.0	desktop	Windows	10	16
+Firefox	139.0	mobile	Android	10	16
+Safari	15.0	mobile	iOS	15.0	16
+Safari	17.2	desktop	Macintosh	Intel 10.15	16
+Safari (in-app)	(not set)	mobile	iOS	17.5.1	16
+Samsung Internet	27.0	desktop	Linux	(not set)	16
+Amazon Silk	136.7.3	tablet	Android	9	15
+Android Webview	102.0.5005.125	mobile	Android	12	15
+Android Webview	123.0.6312.118	mobile	Android	9	15
+Android Webview	130.0.6723.58	mobile	Android	15	15
+Android Webview	135.0.7049.111	mobile	Android	11	15
+Android Webview	135.0.7049.111	mobile	Android	13	15
+Android Webview	136.0.7103.60	mobile	Android	15	15
+Android Webview	137.0.7151.61	mobile	Android	10	15
+Chrome	116.0.5845.97	desktop	Windows	10	15
+Chrome	117.0.5938.60	mobile	Android	14.0.0	15
+Chrome	128.0.6613.85	desktop	Windows	10	15
+Chrome	129.0.6668.101	desktop	Windows	10	15
+Chrome	129.0.6668.59	desktop	Windows	10	15
+Chrome	130.0.6723.117	desktop	Windows	11	15
+Chrome	131.0.6778.109	desktop	Windows	11	15
+Chrome	131.0.6778.200	mobile	Android	12.0.0	15
+Chrome	132.0.0.0	desktop	Windows	11	15
+Chrome	132.0.6834.194	desktop	Windows	10	15
+Chrome	133.0.6943.126	desktop	Linux	5.15.0	15
+Chrome	133.0.6943.137	mobile	Android	10.0.0	15
+Chrome	133.0.6943.53	desktop	Linux	5.15.0	15
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 15.3	15
+Chrome	134.0.6998.95	mobile	Android	15.0.0	15
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 14.7	15
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 15.1	15
+Chrome	136.0.7103.168	desktop	Windows	10	15
+Chrome	137.0.0.0	mobile	Android	12.0.0	15
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 12.5	15
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 14.5	15
+Chrome	137.0.7151.120	desktop	Macintosh	 10.15	15
+Chrome	137.0.7151.120	mobile	Android	6.0	15
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 13.3	15
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 14.6	15
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 13.2	15
+Chrome	137.0.7151.90	mobile	Android	11.0.0	15
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 13.7	15
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 14.4	15
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 15.0	15
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 10.15	15
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 12.1	15
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 12.2	15
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 14.5	15
+Chrome	138.0.7204.119	mobile	iOS	17.6.1	15
+Chrome	138.0.7204.156	mobile	iOS	26.0.0	15
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 12.7	15
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 13.2	15
+Chrome	138.0.7204.35	mobile	Android	15.0.0	15
+Chrome	138.0.7204.63	tablet	Android	11.0.0	15
+Chrome	138.0.7204.68	mobile	Android	15	15
+Chrome	139.0.7258.31	desktop	Macintosh	Intel 15.5	15
+Chrome	139.0.7258.43	desktop	Chrome OS	x86_64 16328.25.0	15
+Chrome	55.0.2883.91	mobile	Android	5.1.1	15
+Chrome	70.0.3538.110	mobile	Android	8.0.0	15
+Chrome	91.0.4472.167	desktop	Chrome OS	x86_64 13904.97.0	15
+Chrome	95.0.4638.74	mobile	Android	12	15
+Edge	109.0.1518.140	desktop	Windows	7	15
+Edge	135.0.3179.85	desktop	Windows	10	15
+Firefox	115.0	desktop	Linux	(not set)	15
+Firefox	130.0	desktop	Linux	(not set)	15
+Firefox	132.0	desktop	Linux	(not set)	15
+Safari	604.1	mobile	iOS	18.0.0	15
+Safari	604.1	mobile	iOS	18.3.1	15
+Samsung Internet	17.0	mobile	Android	6.0.1	15
+Android Webview	119.0.6045.193	mobile	Android	7.1.1	14
+Android Webview	136.0.7103.127	mobile	Android	11	14
+Android Webview	137.0.7151.88	mobile	Android	12	14
+Android Webview	70.0.3538.110	mobile	Android	8.0.0	14
+Android Webview	96.0.4664.61	mobile	Android	12	14
+Chrome	105.0.0.0	desktop	Linux	(not set)	14
+Chrome	109.0.0.0	mobile	Android	11	14
+Chrome	123.0.6312.118	desktop	Linux	14.0.0	14
+Chrome	123.0.6312.118	mobile	Android	11.0.0	14
+Chrome	125.0.6422.72	mobile	Android	12.0.0	14
+Chrome	125.0.6422.77	desktop	Windows	10	14
+Chrome	131.0.6778.70	desktop	Windows	10	14
+Chrome	131.0.6778.81	mobile	Android	12.0.0	14
+Chrome	131.0.6778.81	mobile	Android	14.0.0	14
+Chrome	132.0.6834.163	mobile	Android	12.0.0	14
+Chrome	132.0.6834.84	desktop	Windows	11	14
+Chrome	133.0.6943.126	desktop	Linux	6.11.0	14
+Chrome	133.0.6943.141	desktop	Linux	5.15.0	14
+Chrome	133.0.6943.141	desktop	Linux	6.11.0	14
+Chrome	133.0.6943.142	desktop	Macintosh	Intel 15.5	14
+Chrome	134.0.6998.166	desktop	Windows	11	14
+Chrome	135.0.7049.38	mobile	Android	14.0.0	14
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 14.4	14
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 15.4	14
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 14.6	14
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 13.2	14
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 15.4	14
+Chrome	137.0.0.0	desktop	Linux	6.12.25	14
+Chrome	137.0.0.0	mobile	Android	11.0.0	14
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 12.6	14
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 13.0	14
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 14.6	14
+Chrome	137.0.7151.119	desktop	Linux	6.12.20	14
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 14.5	14
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 14.0	14
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 15.3	14
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 15.4	14
+Chrome	137.0.7151.57	desktop	Macintosh	Intel 15.3	14
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 13.7	14
+Chrome	137.0.7151.90	mobile	Android	13.0.0	14
+Chrome	138.0.0.0	desktop	Linux	6.15.6	14
+Chrome	138.0.0.0	desktop	Macintosh	Intel 15.0	14
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 11.6	14
+Chrome	138.0.7204.119	mobile	iOS	18.4.0	14
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 15.2	14
+Chrome	138.0.7204.157	tablet	Android	14.0.0	14
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 12.5	14
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 15.1	14
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 11.7	14
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 14.2	14
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 13.7	14
+Chrome	81.0.4044.138	mobile	Android	4.4.4	14
+Chrome	91.0.4472.88	desktop	Linux	(not set)	14
+Chrome	95.0.4638.74	mobile	Android	7.1	14
+Edge	135.0.3179.98	desktop	Windows	10	14
+Edge	137.0.3296.52	desktop	Windows	10	14
+Safari	15.5	mobile	iOS	15.5	14
+Safari	604.1	mobile	iOS	26.0.0	14
+Samsung Internet	23.0	mobile	Android	12	14
+Samsung Internet	7.4	mobile	Android	11	14
+Android Webview	119.0.6045.193	mobile	Android	7.1.2	13
+Android Webview	126.0.6478.110	tablet	Android	14	13
+Android Webview	128.0.6613.127	mobile	Android	14	13
+Android Webview	138.0.7204.139	mobile	Android	14	13
+Android Webview	138.0.7204.45	tablet	Android	14	13
+Android Webview	139.0.7258.3	mobile	Android	11	13
+Android Webview	80.0.3987.99	mobile	Android	10	13
+Chrome	103.0.0.0	desktop	Linux	(not set)	13
+Chrome	111.0.5563.101	mobile	iOS	16.7	13
+Chrome	118.0.0.0	desktop	Windows	11	13
+Chrome	125.0.6422.72	mobile	Android	11.0.0	13
+Chrome	126.0.6478.122	mobile	Android	12.0.0	13
+Chrome	128.0.6613.138	desktop	Windows	11	13
+Chrome	128.0.6613.85	desktop	Windows	11	13
+Chrome	129.0.6668.70	desktop	Linux	6.8.0	13
+Chrome	130.0.6723.91	desktop	Linux	6.8.0	13
+Chrome	131.0.6778.260	mobile	Android	10.0.0	13
+Chrome	131.0.6778.81	mobile	Android	10.0.0	13
+Chrome	131.0.6778.81	mobile	Android	11.0.0	13
+Chrome	132.0.6834.214	desktop	Windows	10	13
+Chrome	132.0.6834.225	desktop	Chrome OS	x86_64 16093.107.0	13
+Chrome	133.0.6943.121	mobile	Android	12.0.0	13
+Chrome	133.0.6943.121	mobile	Android	14.0.0	13
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 14.6	13
+Chrome	134.0.6998.35	desktop	Linux	6.11.0	13
+Chrome	134.0.6998.88	desktop	Linux	5.15.0	13
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 15.2	13
+Chrome	135.0.7049.79	mobile	Android	10.0.0	13
+Chrome	136.0.7103.60	mobile	Android	13.0.0	13
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 14.1	13
+Chrome	137.0.0.0	desktop	Macintosh	Intel 15.0	13
+Chrome	137.0.0.0	mobile	Android	14.0.0	13
+Chrome	137.0.7151.68	desktop	Linux	6.12.10	13
+Chrome	137.0.7151.89	mobile	Android	13	13
+Chrome	138.0.0.0	desktop	Macintosh	Intel 14.4	13
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 12.7	13
+Chrome	138.0.7204.101	desktop	Macintosh	 10.15	13
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 13.7	13
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 15.2	13
+Chrome	138.0.7204.119	mobile	iOS	18.1.1	13
+Chrome	138.0.7204.119	mobile	iOS	18.2.1	13
+Chrome	138.0.7204.143	desktop	Macintosh	Intel 15.5	13
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 14.4	13
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 13.4	13
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 15.0	13
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 14.3	13
+Chrome	138.0.7204.56	mobile	iOS	19.0.0	13
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 14.1	13
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 16.0	13
+Chrome	138.0.7204.97	desktop	Macintosh	Intel 14.4	13
+Chrome	138.0.7204.97	mobile	Windows	11	13
+Chrome	139.0.0.0	desktop	Windows	11	13
+Chrome	139.0.7258.41	mobile	Android	13.0.0	13
+Chrome	61.0.3163.98	mobile	Android	7.1.1	13
+Chrome	71.0.3578.99	mobile	Android	9	13
+Chrome	92.0.4515.105	mobile	Android	10	13
+Edge	135.0.3179.54	desktop	Windows	11	13
+Edge	135.0.3179.85	desktop	Windows	11	13
+Edge	136.0.3240.50	desktop	Windows	10	13
+Edge	136.0.3240.76	desktop	Macintosh	Intel 15.5	13
+Edge	138.0.0.0	desktop	Windows	10	13
+Edge	138.0.3351.66	mobile	Android	14.0.0	13
+Opera	92.0.2254.77878	mobile	Android	12	13
+Safari	18.2.1	mobile	iOS	18.2.1	13
+Safari	604.1	mobile	iOS	15.8.3	13
+Safari	604.1	mobile	iOS	18.4.0	13
+Android Webview	134.0.6998.135	mobile	Android	12	12
+Android Webview	136.0.7103.127	mobile	Android	14	12
+Android Webview	137.0.7151.115	mobile	Android	16	12
+Android Webview	137.0.7151.117	tablet	Android	14	12
+Android Webview	137.0.7151.118	tablet	Android	14	12
+Android Webview	138.0.7204.146	mobile	Android	12	12
+Android Webview	138.0.7204.146	mobile	Android	14	12
+Android Webview	95.0.4638.74	mobile	Android	6.0.1	12
+Chrome	125.0.6422.72	mobile	Android	14.0.0	12
+Chrome	127.0.6533.103	mobile	Android	13.0.0	12
+Chrome	129.0.0.0	desktop	Macintosh	Intel 15.5	12
+Chrome	131.0.6778.204	desktop	Linux	5.15.0	12
+Chrome	131.0.6778.205	desktop	Macintosh	Intel 15.5	12
+Chrome	133.0.6943.121	mobile	Android	13.0.0	12
+Chrome	133.0.6943.127	desktop	Macintosh	Intel 15.5	12
+Chrome	134.0.6998.117	desktop	Windows	10	12
+Chrome	134.0.6998.177	desktop	Windows	10	12
+Chrome	134.0.6998.95	mobile	Android	13.0.0	12
+Chrome	135.0.7049.111	mobile	Android	9.0.0	12
+Chrome	135.0.7049.52	desktop	Linux	5.15.0	12
+Chrome	135.0.7049.53	mobile	iOS	18.5.0	12
+Chrome	135.0.7049.95	desktop	Macintosh	Intel 14.7	12
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 15.3	12
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 13.3	12
+Chrome	136.0.7103.179	desktop	Macintosh	Intel 15.5	12
+Chrome	136.0.7103.60	mobile	Android	12.0.0	12
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 14.3	12
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 14.5	12
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 15.1	12
+Chrome	137.0.0.0	desktop	Linux	6.15.2	12
+Chrome	137.0.7151.103	desktop	Linux	5.4.0	12
+Chrome	137.0.7151.103	desktop	Macintosh	Intel 15.3	12
+Chrome	137.0.7151.107	mobile	iOS	17.5.1	12
+Chrome	137.0.7151.117	mobile	Android	10	12
+Chrome	137.0.7151.118	mobile	Android	11	12
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 14.7	12
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 11.2	12
+Chrome	137.0.7151.41	desktop	Macintosh	Intel 14.7	12
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 15.3	12
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 14.5	12
+Chrome	138.0.0.0	desktop	Linux	6.12.34	12
+Chrome	138.0.0.0	desktop	Linux	6.15.5	12
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 12.4	12
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 13.1	12
+Chrome	138.0.7204.101	mobile	Android	11.0	12
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 15.1	12
+Chrome	138.0.7204.157	mobile	Android	8.0.0	12
+Chrome	138.0.7204.157	tablet	Android	12.0.0	12
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 16.0	12
+Chrome	138.0.7204.45	tablet	Android	15.0.0	12
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 13.0	12
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 14.0	12
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 15.6	12
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 11.7	12
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 14.2	12
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 12.2	12
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 12.3	12
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 12.7	12
+Chrome	139.0.7246.0	desktop	Windows	10	12
+Chrome	139.0.7258.32	mobile	Android	12.0.0	12
+Chrome	139.0.7258.41	mobile	Android	14.0.0	12
+Chrome	140.0.7259.0	mobile	Android	12.0.0	12
+Chrome	64.0.3282.137	mobile	Android	7.0	12
+Edge	134.0.3124.54	desktop	Windows	11	12
+Edge	137.0.100.0	desktop	Macintosh	Intel 10.14	12
+Edge	137.0.3296.82	mobile	Android	15.0.0	12
+Edge	137.0.3296.93	desktop	Linux	6.11.0	12
+Edge	138.0.3351.65	desktop	Macintosh	Intel 15.3	12
+Edge	138.0.3351.65	desktop	Macintosh	Intel 15.4	12
+Firefox	136.0	desktop	Macintosh	Intel 10.15	12
+Opera	92.0.2254.77878	mobile	Android	13	12
+Opera	92.0.2254.77878	mobile	Android	15	12
+Opera	95.0.0.0	desktop	Windows	8.1	12
+Safari	16.4	desktop	Macintosh	Intel 10.15	12
+Safari	16.5	mobile	iOS	16.5	12
+Safari	604.1	mobile	iOS	18.0.1	12
+YaBrowser	25.2.0.0	desktop	Macintosh	Intel 10.15	12
+YaBrowser	25.4.3.182.00	mobile	Android	12	12
+YaBrowser	25.6.3.95.00	mobile	Android	15	12
+Amazon Silk	136.6.3	tablet	Android	9	11
+Android Webview	131.0.6778.200	mobile	Android	9	11
+Android Webview	135.0.7049.100	mobile	Android	13	11
+Android Webview	136.0.7103.127	mobile	Android	12	11
+Android Webview	137.0.7151.112	mobile	Android	16	11
+Android Webview	137.0.7151.112	mobile	Android	9	11
+Android Webview	137.0.7151.116	tablet	Android	14	11
+Android Webview	138.0.7204.67	tablet	Android	15	11
+Android Webview	62.0.3202.84	mobile	Android	8.1.0	11
+Chrome	103.0.5060.129	mobile	Android	13	11
+Chrome	107.0.0.0	desktop	Windows	10	11
+Chrome	114.0.5735.119	desktop	Chrome OS	x86_64 15437.42.0	11
+Chrome	114.0.5735.199	desktop	Windows	10	11
+Chrome	116.0.5845.97	desktop	Windows	11	11
+Chrome	119.0.6045.193	tablet	Android	7.1.1	11
+Chrome	123.0.6312.118	desktop	Linux	12.0.0	11
+Chrome	124.0.6367.119	desktop	Windows	11	11
+Chrome	124.0.6367.78	desktop	Windows	10	11
+Chrome	125.0.6422.113	desktop	Windows	10	11
+Chrome	125.0.6422.72	mobile	Android	13.0.0	11
+Chrome	126.0.6478.126	desktop	Linux	5.15.0	11
+Chrome	127.0.6533.101	mobile	Android	14	11
+Chrome	127.0.6533.103	mobile	Android	11.0.0	11
+Chrome	128.0.6613.119	desktop	Linux	6.8.0	11
+Chrome	129.0.6668.89	desktop	Linux	6.8.0	11
+Chrome	131.0.6778.135	mobile	Android	13.0.0	11
+Chrome	131.0.6778.200	mobile	Android	13.0.0	11
+Chrome	131.0.6778.260	mobile	Android	11.0.0	11
+Chrome	133.0.6943.142	desktop	Macintosh	Intel 15.3	11
+Chrome	133.0.6943.54	desktop	Macintosh	Intel 15.5	11
+Chrome	133.0.6943.98	desktop	Linux	6.11.0	11
+Chrome	133.0.6943.99	desktop	Windows	11	11
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 14.5	11
+Chrome	134.0.6998.196	desktop	Windows	10	11
+Chrome	134.0.6998.36	desktop	Windows	11	11
+Chrome	134.0.6998.95	mobile	Android	12.0.0	11
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 14.4	11
+Chrome	135.0.7049.116	desktop	Macintosh	Intel 15.4	11
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 11.7	11
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 14.0	11
+Chrome	137.0.0.0	desktop	Macintosh	Intel 14.6	11
+Chrome	137.0.0.0	mobile	Android	13.0.0	11
+Chrome	137.0.7151.103	desktop	Macintosh	Intel 10.15	11
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 14.0	11
+Chrome	137.0.7151.112	mobile	Android	14.0.0	11
+Chrome	137.0.7151.117	mobile	Android	8.0.0	11
+Chrome	137.0.7151.117	tablet	Android	15.0.0	11
+Chrome	137.0.7151.118	mobile	Android	10	11
+Chrome	137.0.7151.119	desktop	Linux	6.12.25	11
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 14.4	11
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 14.3	11
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 14.6	11
+Chrome	138.0.7204.101	mobile	Android	6.0	11
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 15.0	11
+Chrome	138.0.7204.119	mobile	iOS	17.5.1	11
+Chrome	138.0.7204.156	mobile	iOS	17.6.1	11
+Chrome	138.0.7204.157	desktop	Linux	6.12.10	11
+Chrome	138.0.7204.46	mobile	Android	8.0.0	11
+Chrome	138.0.7204.46	tablet	Android	14.0.0	11
+Chrome	138.0.7204.46	tablet	Android	15.0.0	11
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 14.0	11
+Chrome	138.0.7204.56	mobile	iOS	18.6.0	11
+Chrome	138.0.7204.64	mobile	Android	9.0.0	11
+Chrome	138.0.7204.68	mobile	Android	14	11
+Chrome	138.0.7204.92	desktop	Linux	5.4.0	11
+Chrome	138.0.7204.92	desktop	Linux	6.5.0	11
+Chrome	138.0.7204.97	mobile	Android	6.0	11
+Chrome	140.0.7299.0	desktop	Macintosh	Intel 15.5	11
+Chrome	54.0.2840.71	desktop	Windows	7	11
+Chrome	55.0.2883.91	mobile	Android	6.0.1	11
+Chrome	81.0.4044.138	mobile	Android	4.4.2	11
+Chrome	89.0.4389.116	mobile	Android	11	11
+Edge	132.0.2957.140	desktop	Windows	10	11
+Edge	135.0.3179.73	desktop	Windows	10	11
+Edge	135.0.3179.73	desktop	Windows	11	11
+Edge	137.0.3296.92	mobile	Android	16.0.0	11
+Edge	137.0.3296.93	desktop	Macintosh	Intel 15.3	11
+Edge	138.0.3351.66	mobile	Android	13.0.0	11
+Edge	138.0.3351.77	desktop	Linux	(not set)	11
+Firefox	113.0	desktop	Linux	(not set)	11
+Firefox	139.0	mobile	Android	13	11
+Meta Quest Browser	39.0.0.30.29.753867080	desktop	Linux	(not set)	11
+Safari	(not set)	smart tv	Playstation 4	(not set)	11
+Safari	12.1.2	tablet	iOS	12.5.7	11
+Safari	16.3	mobile	iOS	16.3	11
+Safari	16.4	mobile	iOS	16.4.1	11
+Safari	16.5.1	mobile	iOS	16.5.1	11
+Safari	17.1.2	desktop	Macintosh	Intel 10.15	11
+Safari	19.0	mobile	iOS	19.0.0	11
+Safari	604.1	mobile	iOS	18.3.0	11
+Safari (in-app)	(not set)	mobile	iOS	16.3.1	11
+Safari (in-app)	(not set)	mobile	iOS	18.4	11
+Samsung Internet	7.4	mobile	Android	10	11
+YaBrowser	25.6.1.101.00	mobile	Android	15	11
+Android Webview	128.0.6613.127	mobile	Android	13	10
+Android Webview	132.0.6834.163	mobile	Android	13	10
+Android Webview	134.0.6998.135	mobile	Android	11	10
+Android Webview	138.0.7204.32	mobile	Android	14	10
+Android Webview	68.0.3440.91	mobile	Android	8.0.0	10
+Android Webview	83.0.4103.106	mobile	Android	10	10
+Chrome	100.0.4896.127	desktop	Windows	7	10
+Chrome	110.0.0.0	desktop	Linux	(not set)	10
+Chrome	113.0.0.0	desktop	Windows	10	10
+Chrome	114.0.5735.196	tablet	Android	12.0.0	10
+Chrome	117.0.5938.150	desktop	Windows	10	10
+Chrome	118.0.0.0	desktop	Linux	(not set)	10
+Chrome	124.0.0.0	desktop	Windows	10	10
+Chrome	124.0.6367.61	desktop	Windows	10	10
+Chrome	125.0.6422.197	desktop	Chrome OS	x86_64 15853.67.0	10
+Chrome	126.0.0.0	mobile	Android	10	10
+Chrome	127.0.6533.100	desktop	Windows	10	10
+Chrome	127.0.6533.99	desktop	Linux	6.8.0	10
+Chrome	128.0.0.0	desktop	Windows	11	10
+Chrome	128.0.6613.120	desktop	Windows	10	10
+Chrome	128.0.6613.138	desktop	Macintosh	Intel 15.5	10
+Chrome	129.0.6668.100	desktop	Linux	6.8.0	10
+Chrome	129.0.6668.100	mobile	Android	14.0.0	10
+Chrome	129.0.6668.70	desktop	Linux	5.15.0	10
+Chrome	129.0.6668.81	mobile	Android	13.0.0	10
+Chrome	130.0.6723.58	desktop	Linux	6.8.0	10
+Chrome	130.0.6723.70	desktop	Macintosh	Intel 15.5	10
+Chrome	131.0.0.0	desktop	Windows	11	10
+Chrome	131.0.6778.104	mobile	Android	15.0.0	10
+Chrome	131.0.6778.108	desktop	Linux	5.15.0	10
+Chrome	131.0.6778.200	mobile	Android	9.0.0	10
+Chrome	131.0.6778.267	desktop	Windows	11	10
+Chrome	132.0.6834.159	desktop	Linux	5.15.0	10
+Chrome	132.0.6834.163	mobile	Android	10.0.0	10
+Chrome	132.0.6834.163	mobile	Android	11.0.0	10
+Chrome	133.0.6943.141	desktop	Windows	10	10
+Chrome	134.0.6998.117	desktop	Linux	6.8.0	10
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 14.4	10
+Chrome	134.0.6998.95	mobile	Android	14.0.0	10
+Chrome	135.0.7049.42	desktop	Macintosh	Intel 15.5	10
+Chrome	135.0.7049.79	mobile	Android	12.0.0	10
+Chrome	135.0.7049.79	mobile	Android	9.0.0	10
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 14.7	10
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 15.1	10
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 15.5	10
+Chrome	136.0.0.0	desktop	Windows	11	10
+Chrome	136.0.7103.113	desktop	Linux	5.4.0	10
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 15.1	10
+Chrome	136.0.7103.87	mobile	Android	8.1.0	10
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 15.0	10
+Chrome	137.0.0.0	desktop	Macintosh	Intel 14.5	10
+Chrome	137.0.0.0	desktop	Macintosh	Intel 14.7	10
+Chrome	137.0.7151.103	desktop	Linux	6.12.10	10
+Chrome	137.0.7151.103	desktop	Linux	6.5.0	10
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 13.3	10
+Chrome	137.0.7151.112	mobile	Android	15.0.0	10
+Chrome	137.0.7151.119	desktop	Linux	6.12.34	10
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 15.1	10
+Chrome	137.0.7151.120	mobile	Windows	10	10
+Chrome	137.0.7151.55	desktop	Linux	5.4.0	10
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 14.4	10
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 14.5	10
+Chrome	137.0.7151.57	desktop	Macintosh	Intel 15.1	10
+Chrome	137.0.7151.62	mobile	Android	15.0.0	10
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 14.6	10
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 13.3	10
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 14.0	10
+Chrome	137.0.7151.86	desktop	Chrome OS	aarch64 16267.43.0	10
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 15.2	10
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 14.4	10
+Chrome	138.0.7204.157	desktop	Linux	6.12.27	10
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 15.0	10
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 15.1	10
+Chrome	138.0.7204.46	tablet	Android	13.0.0	10
+Chrome	138.0.7204.49	desktop	Linux	6.12.25	10
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 12.6	10
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 12.5	10
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 13.5	10
+Chrome	138.0.7204.92	desktop	Linux	6.12.33	10
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 12.6	10
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 13.5	10
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 12.0	10
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 12.1	10
+Chrome	139.0.7258.41	mobile	Android	12.0.0	10
+Chrome	140.0.7299.0	desktop	Windows	10	10
+Chrome	81.0.4044.138	desktop	Windows	10	10
+Chrome	87.0.4280.141	mobile	Android	14	10
+Chrome	87.0.4280.141	mobile	Android	9	10
+Edge	135.0.3179.98	desktop	Windows	11	10
+Edge	136.0.3240.115	desktop	Windows	10	10
+Edge	137.0.3296.62	desktop	Macintosh	Intel 15.5	10
+Edge	138.0.3351.77	mobile	Android	14.0.0	10
+Edge	138.0.3351.83	mobile	Android	13.0.0	10
+Firefox	115.0	desktop	Windows	10	10
+Firefox	139.0	mobile	Android	12	10
+Firefox	70.0	desktop	Windows	10	10
+Opera	92.0.2254.77878	mobile	Android	11	10
+Safari	13.0.3	mobile	iOS	13.2.3	10
+Safari	14.0.2	desktop	Macintosh	Intel 10.15	10
+Safari	17.6	tablet	iOS	17.6.1	10
+Safari	18.0	tablet	iOS	18.5.0	10
+Safari	9.0	mobile	iOS	9.1	10
+Safari (in-app)	(not set)	mobile	iOS	15.8.4	10
+Safari (in-app)	(not set)	mobile	iOS	18.0	10
+Safari (in-app)	(not set)	mobile	iOS	18.2	10
+Samsung Internet	21.0	mobile	Android	13	10
+YaBrowser	24.12.0.0	desktop	Linux	(not set)	10
+YaBrowser	25.6.1.95.00	mobile	Android	15	10
+Amazon Silk	108.17.5	tablet	Android	5.1.1	9
+Android Webview	123.0.6312.118	mobile	Android	10	9
+Android Webview	133.0.6943.137	mobile	Android	11	9
+Android Webview	134.0.6998.135	mobile	Android	14	9
+Android Webview	135.0.7049.111	mobile	Android	12	9
+Android Webview	135.0.7049.79	mobile	Android	9	9
+Android Webview	136.0.7103.60	mobile	Android	9	9
+Android Webview	137.0.7151.115	tablet	Android	13	9
+Android Webview	138.0.7204.153	mobile	Android	15	9
+Android Webview	138.0.7204.32	mobile	Android	13	9
+Android Webview	138.0.7204.67	tablet	Android	13	9
+Android Webview	139.0.7258.3	mobile	Android	13	9
+Android Webview	55.0.2883.91	mobile	Android	6.0.1	9
+Chrome	103.0.5060.129	tablet	Android	12.0.0	9
+Chrome	109.0.5414.120	desktop	Windows	10	9
+Chrome	120.0.6099.224	desktop	Linux	6.8.0	9
+Chrome	120.0.6099.225	desktop	Windows	10	9
+Chrome	120.0.6099.225	desktop	Windows	11	9
+Chrome	122.0.6261.119	mobile	Android	11	9
+Chrome	122.0.6261.131	desktop	Windows	11	9
+Chrome	123.0.6312.106	desktop	Windows	10	9
+Chrome	123.0.6312.118	desktop	Linux	13.0.0	9
+Chrome	124.0.6367.61	desktop	Windows	11	9
+Chrome	125.0.6422.141	desktop	Linux	6.8.0	9
+Chrome	127.0.6533.103	mobile	Android	10.0.0	9
+Chrome	129.0.6668.100	desktop	Linux	5.15.0	9
+Chrome	129.0.6668.100	mobile	Android	12.0.0	9
+Chrome	129.0.6668.71	desktop	Windows	10	9
+Chrome	130.0.6723.102	mobile	Android	13.0.0	9
+Chrome	130.0.6723.102	mobile	Android	14.0.0	9
+Chrome	130.0.6723.117	desktop	Macintosh	Intel 15.5	9
+Chrome	130.0.6723.69	desktop	Linux	6.8.0	9
+Chrome	130.0.6723.92	desktop	Windows	11	9
+Chrome	131.0.6778.135	mobile	Android	11.0.0	9
+Chrome	131.0.6778.139	desktop	Linux	5.15.0	9
+Chrome	131.0.6778.260	mobile	Android	9.0.0	9
+Chrome	131.0.6778.260	tablet	Android	15.0.0	9
+Chrome	131.0.6778.264	desktop	Linux	6.11.0	9
+Chrome	131.0.6778.69	desktop	Linux	5.15.0	9
+Chrome	132.0.6834.163	mobile	Android	15.0.0	9
+Chrome	132.0.6834.83	desktop	Linux	6.11.0	9
+Chrome	133.0.6943.60	desktop	Windows	11	9
+Chrome	133.0.6943.98	desktop	Linux	5.15.0	9
+Chrome	134.0.0.0	desktop	Windows	11	9
+Chrome	134.0.6998.95	mobile	Android	10.0.0	9
+Chrome	136.0.0.0	desktop	Macintosh	Intel 15.3	9
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 15.3	9
+Chrome	136.0.7103.91	mobile	iOS	18.4.1	9
+Chrome	137.0.0.0	desktop	Linux	6.1.0	9
+Chrome	137.0.0.0	mobile	Android	10	9
+Chrome	137.0.7151.103	desktop	Linux	6.1.0	9
+Chrome	137.0.7151.103	desktop	Macintosh	Intel 14.4	9
+Chrome	137.0.7151.103	desktop	Macintosh	Intel 14.5	9
+Chrome	137.0.7151.103	desktop	Macintosh	Intel 14.6	9
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 15.1	9
+Chrome	137.0.7151.117	mobile	Android	16	9
+Chrome	137.0.7151.117	tablet	Android	14.0.0	9
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 15.2	9
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 11.3	9
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 10.15	9
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 11.6	9
+Chrome	137.0.7151.122	mobile	Android	11.0	9
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 14.5	9
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 14.7	9
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 15.2	9
+Chrome	137.0.7151.57	desktop	Macintosh	Intel 14.6	9
+Chrome	137.0.7151.68	desktop	Linux	5.4.0	9
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 12.5	9
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 13.6	9
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 15.3	9
+Chrome	137.0.7151.90	mobile	Android	13	9
+Chrome	138.0.0.0	desktop	Macintosh	Intel 13.7	9
+Chrome	138.0.0.0	desktop	Macintosh	Intel 15.6	9
+Chrome	138.0.0.0	mobile	Android	10	9
+Chrome	138.0.0.0	mobile	Android	10.0.0	9
+Chrome	138.0.7204.119	mobile	iOS	18.0.0	9
+Chrome	138.0.7204.143	desktop	Windows	10	9
+Chrome	138.0.7204.157	desktop	Linux	6.15.7	9
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 14.3	9
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 13.0	9
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 13.3	9
+Chrome	138.0.7204.158	mobile	Windows	11	9
+Chrome	138.0.7204.35	mobile	Android	13.0.0	9
+Chrome	138.0.7204.41	desktop	Chrome OS	x86_64 16295.27.0	9
+Chrome	138.0.7204.49	desktop	Linux	5.4.0	9
+Chrome	138.0.7204.49	desktop	Linux	6.12.20	9
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 13.1	9
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 12.6	9
+Chrome	138.0.7204.53	mobile	iOS	19.0.0	9
+Chrome	138.0.7204.63	mobile	Android	16	9
+Chrome	138.0.7204.64	mobile	Android	8.1.0	9
+Chrome	138.0.7204.92	desktop	Linux	6.12.34	9
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 12.4	9
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 14.2	9
+Chrome	138.0.7204.97	mobile	Windows	10	9
+Chrome	140.0.7259.0	mobile	Android	13.0.0	9
+Chrome	70.0.3538.110	desktop	Linux	(not set)	9
+Chrome	71.0.3578.141	mobile	Android	10	9
+Chrome	78.0.3904.108	mobile	Android	10	9
+Edge	132.0.2957.140	desktop	Windows	11	9
+Edge	134.0.3124.93	desktop	Windows	11	9
+Edge	136.0.0.0	desktop	Windows	10	9
+Edge	136.0.3240.92	desktop	Macintosh	Intel 15.5	9
+Edge	137.0.3296.65	mobile	Android	14.0.0	9
+Edge	137.0.3296.82	mobile	Android	13.0.0	9
+Edge	137.0.3296.93	desktop	Linux	6.8.0	9
+Edge	138.0.3351.55	desktop	Macintosh	Intel 15.4	9
+Edge	138.0.3351.65	desktop	Linux	6.11.0	9
+Edge	138.0.3351.83	desktop	Linux	(not set)	9
+Edge	138.0.3351.83	desktop	Macintosh	Intel 15.3	9
+Edge	140.0.3406.0	desktop	Windows	11	9
+Edge	140.0.3421.0	desktop	Windows	11	9
+Firefox	128.0	mobile	Android	10	9
+Firefox	133.0	desktop	Linux	(not set)	9
+Firefox	134.0	desktop	Windows	10	9
+Firefox	142.0	desktop	Macintosh	Intel 10.15	9
+Opera	114.0.0.0	desktop	Macintosh	Intel 10.15	9
+Opera	118.0.0.0	desktop	Macintosh	Intel 10.15	9
+Opera	88.0.0.0	mobile	Android	10	9
+Safari	14.1.1	desktop	Macintosh	Intel 10.15	9
+Safari	16.0	mobile	iOS	(not set)	9
+Safari	16.1	mobile	iOS	16.1	9
+Safari	16.2	desktop	Macintosh	Intel 10.15	9
+Safari	17.0.1	mobile	iOS	17.0.3	9
+Safari	17.1.2	mobile	iOS	17.1.2	9
+Safari	17.4	mobile	iOS	16.0	9
+Safari	26.0	tablet	iOS	19.0	9
+YaBrowser	25.6.1.95.00	mobile	Android	14	9
+YaBrowser	25.6.2.108.00	mobile	Android	13	9
+YaBrowser	25.6.2.109.00	mobile	Android	13	9
+Amazon Silk	136.6.3	tablet	Android	11	8
+Amazon Silk	136.7.3	tablet	Android	11	8
+Android Webview	110.0.5481.153	mobile	Android	12	8
+Android Webview	134.0.6998.135	mobile	Android	13	8
+Android Webview	134.0.6998.95	mobile	Android	9	8
+Android Webview	135.0.7049.38	mobile	Android	12	8
+Android Webview	136.0.7103.61	mobile	Android	14	8
+Android Webview	137.0.7151.109	mobile	Android	15	8
+Android Webview	137.0.7151.115	tablet	Android	15	8
+Android Webview	137.0.7151.84	mobile	Android	14	8
+Android Webview	137.0.7151.88	mobile	Android	10	8
+Android Webview	138.0.7204.139	mobile	Android	12	8
+Android Webview	138.0.7204.153	mobile	Android	14	8
+Android Webview	138.0.7204.35	mobile	Android	12	8
+Android Webview	138.0.7204.35	mobile	Android	13	8
+Android Webview	139.0.7258.41	mobile	Android	15	8
+Android Webview	90.0.4430.210	mobile	Android	11	8
+Android Webview	91.0.4472.114	mobile	Android	12	8
+Chrome	108.0.0.0	desktop	Linux	(not set)	8
+Chrome	109.0.0.0	desktop	Windows	10	8
+Chrome	114.0.5735.196	mobile	Android	9.0.0	8
+Chrome	116.0.0.0	desktop	Linux	(not set)	8
+Chrome	118.0.5993.71	desktop	Windows	10	8
+Chrome	119.0.6045.160	desktop	Windows	10	8
+Chrome	119.0.6045.193	tablet	Android	7.0.0	8
+Chrome	120.0.6099.71	desktop	Windows	10	8
+Chrome	121.0.6167.161	desktop	Windows	10	8
+Chrome	122.0.6261.119	mobile	Android	10	8
+Chrome	123.0.6312.118	mobile	Android	13.0.0	8
+Chrome	123.0.6312.52	mobile	iOS	17.4.1	8
+Chrome	123.0.6312.59	desktop	Windows	10	8
+Chrome	123.0.6312.86	desktop	Windows	10	8
+Chrome	124.0.6367.119	desktop	Windows	10	8
+Chrome	124.0.6367.91	desktop	Windows	10	8
+Chrome	125.0.0.0	desktop	Windows	11	8
+Chrome	126.0.6478.122	mobile	Android	13.0.0	8
+Chrome	128.0.6613.119	desktop	Linux	5.15.0	8
+Chrome	128.0.6613.137	desktop	Linux	6.8.0	8
+Chrome	129.0.6668.100	mobile	Android	13.0.0	8
+Chrome	129.0.6668.70	mobile	Android	13.0.0	8
+Chrome	129.0.6668.90	desktop	Windows	11	8
+Chrome	130.0.6723.102	mobile	Android	10.0.0	8
+Chrome	130.0.6723.102	mobile	Android	11.0.0	8
+Chrome	130.0.6723.102	mobile	Android	12.0.0	8
+Chrome	130.0.6723.59	desktop	Windows	10	8
+Chrome	130.0.6723.91	mobile	Android	13.0.0	8
+Chrome	130.0.6723.91	mobile	Android	15.0.0	8
+Chrome	131.0.6778.264	desktop	Linux	5.15.0	8
+Chrome	131.0.6778.265	desktop	Macintosh	Intel 15.5	8
+Chrome	131.0.6778.266	desktop	Windows	11	8
+Chrome	132.0.0.0	desktop	Linux	(not set)	8
+Chrome	132.0.6478.261	desktop	Windows	11	8
+Chrome	132.0.6834.159	desktop	Linux	6.11.0	8
+Chrome	132.0.6834.227	desktop	Chrome OS	x86_64 16093.109.0	8
+Chrome	133.0.6943.121	mobile	Android	11.0.0	8
+Chrome	133.0.6943.137	mobile	Android	9.0.0	8
+Chrome	133.0.6943.53	desktop	Linux	6.11.0	8
+Chrome	133.0.6943.54	desktop	Macintosh	Intel 15.3	8
+Chrome	134.0.6998.117	desktop	Linux	6.11.0	8
+Chrome	134.0.6998.135	mobile	Android	8.1.0	8
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 14.2	8
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 15.4	8
+Chrome	134.0.6998.167	desktop	Windows	11	8
+Chrome	134.0.6998.198	desktop	Chrome OS	x86_64 16181.61.0	8
+Chrome	134.0.6998.39	mobile	Android	13.0.0	8
+Chrome	135.0.0.0	desktop	Linux	6.12.9	8
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 14.3	8
+Chrome	135.0.7049.38	mobile	Android	13.0.0	8
+Chrome	135.0.7049.79	mobile	Android	11.0.0	8
+Chrome	135.0.7049.83	tablet	iOS	18.5.0	8
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 14.5	8
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 13.0	8
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 14.6	8
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 15.2	8
+Chrome	136.0.7103.177	desktop	Macintosh	Intel 15.5	8
+Chrome	136.0.7103.48	desktop	Macintosh	Intel 15.3	8
+Chrome	136.0.7103.60	mobile	Android	10.0.0	8
+Chrome	137.0.0.0	desktop	Macintosh	Intel 14.4	8
+Chrome	137.0.7151.103	desktop	Linux	6.14.9	8
+Chrome	137.0.7151.103	desktop	Linux	6.15.2	8
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 14.3	8
+Chrome	137.0.7151.107	mobile	iOS	18.2.1	8
+Chrome	137.0.7151.107	mobile	iOS	18.4.0	8
+Chrome	137.0.7151.118	mobile	Android	12	8
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 11.5	8
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 12.1	8
+Chrome	137.0.7151.137	mobile	Android	11.0	8
+Chrome	137.0.7151.40	desktop	Windows	10	8
+Chrome	137.0.7151.56	mobile	Android	13.0.0	8
+Chrome	137.0.7151.57	desktop	Macintosh	Intel 14.4	8
+Chrome	137.0.7151.68	desktop	Linux	6.1.0	8
+Chrome	137.0.7151.68	desktop	Linux	6.14.9	8
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 15.4	8
+Chrome	137.0.7151.73	mobile	Android	14.0.0	8
+Chrome	137.0.7151.89	mobile	Android	11	8
+Chrome	137.0.7151.89	mobile	Android	8.0.0	8
+Chrome	138.0.0.0	desktop	Linux	6.12.35	8
+Chrome	138.0.0.0	desktop	Macintosh	Intel 15.2	8
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 14.2	8
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 14.2	8
+Chrome	138.0.7204.157	mobile	Android	11	8
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 12.6	8
+Chrome	138.0.7204.158	mobile	Windows	10	8
+Chrome	138.0.7204.162	desktop	Windows	11	8
+Chrome	138.0.7204.45	tablet	Android	14.0.0	8
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 14.3	8
+Chrome	138.0.7204.55	desktop	Chrome OS	aarch64 16295.32.0	8
+Chrome	138.0.7204.56	tablet	iOS	18.5.0	8
+Chrome	138.0.7204.92	desktop	Linux	6.15.3	8
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 13.2	8
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 13.4	8
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 13.6	8
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 14.0	8
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 26.0	8
+Chrome	139.0.0.0	mobile	Android	15.0.0	8
+Chrome	140.0.7259.0	mobile	Android	11.0.0	8
+Chrome	140.0.7275.0	desktop	Windows	11	8
+Chrome	66.0.3359.126	mobile	Android	8.0.0	8
+Chrome	68.0.3440.91	mobile	Android	8.1.0	8
+Chrome	70.0.3538.80	mobile	Android	11	8
+Chrome	76.0.3809.136	desktop	Chrome OS	x86_64 12239.92.1	8
+Chrome	77.0.3865.116	mobile	Android	11	8
+Chrome	78.0.3904.96	mobile	Android	10	8
+Chrome	80.0.3987.132	desktop	Macintosh	Intel 10.15	8
+Chrome	85.0.4183.101	mobile	Android	10	8
+Chrome	87.0.3945.79	desktop	Linux	(not set)	8
+Chrome	89.0.4389.90	desktop	Windows	10	8
+Chrome	95.0.4638.74	mobile	Android	5.0.2	8
+Chrome	98.0.4758.102	desktop	Macintosh	Intel 10.15	8
+Chrome	99.0.4844.74	desktop	Macintosh	Intel 12.3	8
+Chrome	99.0.4844.88	desktop	Linux	(not set)	8
+Edge	109.0.1518.140	desktop	Windows	8.1	8
+Edge	131.0.2903.112	desktop	Windows	10	8
+Edge	133.0.3065.69	desktop	Windows	11	8
+Edge	137.0.3296.92	mobile	Android	10.0.0	8
+Edge	137.0.3296.93	desktop	Macintosh	Intel 14.7	8
+Edge	138.0.3351.52	desktop	Windows	11	8
+Edge	138.0.3351.55	desktop	Macintosh	Intel 14.6	8
+Edge	138.0.3351.55	desktop	Macintosh	Intel 15.3	8
+Edge	138.0.3351.66	desktop	Linux	(not set)	8
+Edge	138.0.3351.77	mobile	Android	12.0.0	8
+Edge	138.0.3351.77	mobile	Android	13.0.0	8
+Edge	138.0.3351.83	desktop	Macintosh	Intel 15.4	8
+Edge	138.0.3351.83	mobile	Android	12.0.0	8
+Firefox	115.0	desktop	Macintosh	Intel 10.14	8
+Firefox	131.0	desktop	Linux	(not set)	8
+Firefox	135.0	desktop	Macintosh	Intel 10.15	8
+Firefox	59.0	desktop	Windows	10	8
+Meta Quest Browser	39.2.0.13.62.759331196	desktop	Linux	(not set)	8
+Opera	117.0.0.0	desktop	Windows	10	8
+Opera	121.0.0.0	desktop	Windows	10	8
+Safari	13.0.3	desktop	Macintosh	Intel 10.14	8
+Safari	14.1.1	mobile	iOS	14.6	8
+Safari	15.4	mobile	iOS	15.4.1	8
+Safari	16.0	mobile	iOS	16.0.2	8
+Safari	16.6	mobile	iOS	16.7.8	8
+Safari	16.6.1	mobile	iOS	16.6.1	8
+Safari	18.3	mobile	iOS	17.7.2	8
+Safari	537.36	desktop	Linux	(not set)	8
+Safari	604.1	mobile	iOS	16.6.1	8
+Safari	605.1.15	mobile	iOS	18.3.2	8
+Safari (in-app)	(not set)	mobile	iOS	18.0.1	8
+YaBrowser	25.6.2.103.00	mobile	Android	15	8
+Android Webview	101.0.4951.54	mobile	Android	10	7
+Android Webview	120.0.6099.193	tablet	Android	14	7
+Android Webview	126.0.6478.122	mobile	Android	9	7
+Android Webview	134.0.6998.135	mobile	Android	10	7
+Android Webview	136.0.7103.61	mobile	Android	11	7
+Android Webview	137.0.7151.115	smart tv	Android	11	7
+Android Webview	137.0.7151.80	mobile	Android	14	7
+Android Webview	137.0.7151.89	mobile	Android	8.1.0	7
+Android Webview	138.0.7204.146	mobile	Android	11	7
+Android Webview	138.0.7204.35	mobile	Android	11	7
+Android Webview	139.0.7258.32	mobile	Android	13	7
+Android Webview	62.0.3202.84	mobile	Android	11	7
+Android Webview	66.0.3359.158	mobile	Android	7.1.2	7
+Android Webview	87.0.4280.141	tablet	Android	11	7
+Android Webview	95.0.4638.74	mobile	Android	6.0	7
+Chrome	106.0.0.0	desktop	Windows	10	7
+Chrome	109.0.5414.120	desktop	Windows	11	7
+Chrome	110.0.5481.153	mobile	Android	12.0.0	7
+Chrome	112.0.5615.136	mobile	Android	14	7
+Chrome	115.0.5790.171	desktop	Windows	10	7
+Chrome	120.0.6099.216	desktop	Linux	6.8.0	7
+Chrome	121.0.6167.140	desktop	Windows	10	7
+Chrome	121.0.6167.140	desktop	Windows	11	7
+Chrome	121.0.6167.86	desktop	Windows	11	7
+Chrome	123.0.6312.123	desktop	Windows	10	7
+Chrome	123.0.6312.58	desktop	Windows	11	7
+Chrome	123.0.6312.86	desktop	Linux	6.8.0	7
+Chrome	124.0.0.0	mobile	Android	15	7
+Chrome	124.0.6367.54	mobile	Android	10.0.0	7
+Chrome	125.0.0.0	desktop	Linux	(not set)	7
+Chrome	125.0.6422.142	desktop	Windows	11	7
+Chrome	125.0.6422.61	desktop	Windows	10	7
+Chrome	125.0.6422.61	desktop	Windows	11	7
+Chrome	126.0.6478.122	mobile	Android	14.0.0	7
+Chrome	126.0.6478.182	desktop	Linux	6.8.0	7
+Chrome	127.0.0.0	desktop	Windows	10	7
+Chrome	127.0.6533.119	desktop	Linux	6.8.0	7
+Chrome	128.0.6613.114	desktop	Windows	10	7
+Chrome	128.0.6613.114	desktop	Windows	11	7
+Chrome	128.0.6613.84	desktop	Linux	6.8.0	7
+Chrome	129.0.6668.101	desktop	Windows	11	7
+Chrome	129.0.6668.70	desktop	Windows	10	7
+Chrome	130.0.6723.103	mobile	Android	13.0.0	7
+Chrome	130.0.6723.116	desktop	Linux	5.15.0	7
+Chrome	130.0.6723.92	desktop	Macintosh	Intel 15.5	7
+Chrome	130.0.6723.92	desktop	Windows	10	7
+Chrome	131.0.6778.104	mobile	Android	12.0.0	7
+Chrome	131.0.6778.154	mobile	iOS	18.5.0	7
+Chrome	131.0.6778.69	desktop	Linux	6.8.0	7
+Chrome	131.0.6778.70	desktop	Windows	11	7
+Chrome	131.0.6778.85	desktop	Linux	5.15.0	7
+Chrome	131.0.6778.8622	desktop	Windows	10	7
+Chrome	132.0.6834.160	desktop	Macintosh	Intel 14.6	7
+Chrome	132.0.6834.160	desktop	Macintosh	Intel 15.3	7
+Chrome	132.0.6834.196	desktop	Windows	11	7
+Chrome	132.0.6834.84	desktop	Macintosh	Intel 15.5	7
+Chrome	133.0.0.0	mobile	Android	14.0.0	7
+Chrome	133.0.6943.120	mobile	iOS	18.5.0	7
+Chrome	133.0.6943.121	mobile	Android	15.0.0	7
+Chrome	133.0.6943.49	mobile	Android	11.0.0	7
+Chrome	133.0.6943.49	mobile	Android	14.0.0	7
+Chrome	133.0.6943.98	desktop	Windows	11	7
+Chrome	134.0.6998.108	mobile	Android	8.1.0	7
+Chrome	134.0.6998.118	desktop	Macintosh	Intel 15.5	7
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 15.2	7
+Chrome	134.0.6998.179	desktop	Windows	10	7
+Chrome	134.0.6998.179	desktop	Windows	11	7
+Chrome	134.0.6998.39	mobile	Android	10.0.0	7
+Chrome	134.0.6998.89	desktop	Macintosh	Intel 14.5	7
+Chrome	134.0.6998.95	mobile	Android	11.0.0	7
+Chrome	135.0.7049.111	mobile	Android	8.1.0	7
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 13.6	7
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 14.6	7
+Chrome	136.0.0.0	desktop	Linux	6.8.0	7
+Chrome	136.0.0.0	desktop	Windows	8	7
+Chrome	136.0.7103.102	desktop	Chrome OS	x86_64 16238.47.0	7
+Chrome	136.0.7103.113	desktop	Linux	6.1.0	7
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 13.1	7
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 14.4	7
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 14.5	7
+Chrome	136.0.7103.154	desktop	Macintosh	Intel 15.5	7
+Chrome	136.0.7103.48	desktop	Macintosh	Intel 15.4	7
+Chrome	136.0.7103.60	mobile	Android	11.0.0	7
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 12.7	7
+Chrome	137.0.0.0	desktop	Macintosh	Intel 16.0	7
+Chrome	137.0.7151.103	desktop	Linux	6.12.33	7
+Chrome	137.0.7151.103	desktop	Macintosh	Intel 15.1	7
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 12.0	7
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 15.2	7
+Chrome	137.0.7151.107	mobile	iOS	18.2.0	7
+Chrome	137.0.7151.107	tablet	iOS	18.4.1	7
+Chrome	137.0.7151.115	tablet	Android	8.1.0	7
+Chrome	137.0.7151.122	desktop	Macintosh	 10.15	7
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 12.2	7
+Chrome	137.0.7151.51	tablet	iOS	18.5.0	7
+Chrome	137.0.7151.55	desktop	Linux	6.14.0	7
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 14.3	7
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 14.6	7
+Chrome	137.0.7151.57	desktop	Macintosh	Intel 14.5	7
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 14.5	7
+Chrome	137.0.7151.68	mobile	Android	11.0	7
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 12.4	7
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 13.0	7
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 13.1	7
+Chrome	137.0.7151.73	mobile	Android	12.0.0	7
+Chrome	137.0.7151.73	mobile	Android	15.0.0	7
+Chrome	137.0.7151.89	tablet	Android	14.0.0	7
+Chrome	137.0.7151.90	mobile	Android	10.0.0	7
+Chrome	137.0.7151.90	mobile	Android	12	7
+Chrome	138.0.7204.100	desktop	Linux	5.4.0	7
+Chrome	138.0.7204.100	desktop	Linux	6.12.33	7
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 11.7	7
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 12.0	7
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 12.3	7
+Chrome	138.0.7204.101	mobile	Windows	10	7
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 11.7	7
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 13.4	7
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 15.6	7
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 26.0	7
+Chrome	138.0.7204.119	mobile	iOS	17.7.1	7
+Chrome	138.0.7204.119	mobile	iOS	18.0.1	7
+Chrome	138.0.7204.119	mobile	iOS	18.1.0	7
+Chrome	138.0.7204.119	mobile	iOS	18.3.0	7
+Chrome	138.0.7204.119	tablet	iOS	18.4.1	7
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 13.4	7
+Chrome	138.0.7204.157	mobile	Android	14	7
+Chrome	138.0.7204.157	tablet	Android	10.0.0	7
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 12.5	7
+Chrome	138.0.7204.33	tablet	iOS	18.5.0	7
+Chrome	138.0.7204.49	desktop	Linux	6.12.34	7
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 13.3	7
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 13.5	7
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 13.6	7
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 14.2	7
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 13.2	7
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 13.3	7
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 13.4	7
+Chrome	138.0.7204.67	mobile	Android	16	7
+Chrome	138.0.7204.68	mobile	Android	12	7
+Chrome	138.0.7204.92	desktop	Linux	6.15.5	7
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 14.3	7
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 11.6	7
+Chrome	139.0.0.0	mobile	Android	13.0.0	7
+Chrome	139.0.0.0	mobile	Android	14.0.0	7
+Chrome	139.0.7207.2	desktop	Windows	11	7
+Chrome	139.0.7258.3	mobile	Android	15	7
+Chrome	139.0.7258.32	mobile	Android	10.0.0	7
+Chrome	139.0.7258.42	desktop	Macintosh	Intel 15.5	7
+Chrome	139.0.7258.42	desktop	Windows	11	7
+Chrome	140.0.7281.0	desktop	Windows	10	7
+Chrome	140.0.7299.0	mobile	Android	15.0.0	7
+Chrome	66.0.3359.126	mobile	Android	8.1.0	7
+Chrome	71.0.3578.141	mobile	Android	7.0	7
+Chrome	71.0.3578.99	mobile	Android	8.1.0	7
+Chrome	73.0.3683.75	desktop	Macintosh	Intel 10.14	7
+Chrome	74.0.3729.108	desktop	Windows	7	7
+Chrome	84.0.4147.136	desktop	Chrome OS	armv7l 13099.110.0	7
+Chrome	87.0.4280.88	desktop	Macintosh	Intel 10.10	7
+Chrome	93.0.4577.62	mobile	Android	11	7
+Edge	131.0.2903.146	desktop	Windows	11	7
+Edge	133.0.3065.92	desktop	Windows	11	7
+Edge	134.0.3124.72	desktop	Windows	11	7
+Edge	137.0.0.0	desktop	Windows	10	7
+Edge	138.0.3351.65	desktop	Macintosh	Intel 14.7	7
+Edge	138.0.3351.66	mobile	Android	12.0.0	7
+Edge	138.0.3351.83	desktop	Macintosh	Intel 14.7	7
+Firefox	129.0	desktop	Linux	(not set)	7
+Firefox	133.0	desktop	Macintosh	Intel 10.15	7
+Opera	44.6.2246.127414	desktop	Linux	(not set)	7
+Opera	93.0.2254.78340	mobile	Android	14	7
+Safari	15.6.6	mobile	iOS	15.8	7
+Safari	16.5.2	desktop	Macintosh	Intel 10.15	7
+Safari	17.0	smart tv	(not set)	(not set)	7
+Safari	17.7.1	mobile	iOS	17.7.1	7
+Safari	604.1	mobile	iOS	18.1.0	7
+Safari	604.1	mobile	iOS	18.2.0	7
+Safari	604.1	mobile	iOS	18.2.1	7
+Safari	605.1.15	mobile	iOS	19.0	7
+Safari (in-app)	(not set)	mobile	iOS	17.4.1	7
+Samsung Internet	23.0	mobile	Android	15	7
+Samsung Internet	24.0	desktop	Linux	(not set)	7
+Samsung Internet	26.0	desktop	Linux	(not set)	7
+Whale Browser	4.32.315.22	desktop	Windows	10	7
+YaBrowser	25.6.2.108.00	mobile	Android	14	7
+YaBrowser	25.6.3.95.00	mobile	Android	14	7
+Aloha Browser	7.4.4	mobile	Android	10	6
+Amazon Silk	136.7.3	smart tv	Android	9	6
+Android Browser	537.36	mobile	Android	(not set)	6
+Android Webview	112.0.5615.135	mobile	Android	13	6
+Android Webview	119.0.6045.194	mobile	Android	7.0	6
+Android Webview	126.0.6478.71	tablet	Android	14	6
+Android Webview	127.0.6533.103	mobile	Android	14	6
+Android Webview	134.0.6998.39	mobile	Android	11	6
+Android Webview	135.0.7049.100	mobile	Android	11	6
+Android Webview	135.0.7049.113	mobile	Android	14	6
+Android Webview	135.0.7049.99	mobile	Android	11	6
+Android Webview	136.0.7103.126	mobile	Android	14	6
+Android Webview	136.0.7103.61	mobile	Android	12	6
+Android Webview	136.0.7103.61	mobile	Android	13	6
+Android Webview	136.0.7103.61	mobile	Android	15	6
+Android Webview	137.0.7151.115	tablet	Android	12	6
+Android Webview	137.0.7151.84	mobile	Android	11	6
+Android Webview	58.0.3029.83	mobile	Android	7.0	6
+Android Webview	66.0.3359.126	mobile	Android	8.0.0	6
+Chrome	106.0.5249.126	mobile	Android	8.1.0	6
+Chrome	106.0.5249.126	tablet	Android	6.0.1	6
+Chrome	107.0.0.0	desktop	Macintosh	Intel 10.15	6
+Chrome	108.0.5359.71	desktop	Linux	(not set)	6
+Chrome	112.0.5615.49	desktop	Macintosh	Intel 10.15	6
+Chrome	114.0.5735.134	desktop	Windows	10	6
+Chrome	117.0.0.0	desktop	Linux	(not set)	6
+Chrome	119.0.6045.160	desktop	Windows	11	6
+Chrome	120.0.0.0	desktop	Macintosh	Intel 10.15	6
+Chrome	120.0.6099.130	desktop	Windows	10	6
+Chrome	122.0.6261.113	desktop	Windows	11	6
+Chrome	123.0.6312.118	mobile	Android	10.0.0	6
+Chrome	124.0.0.0	mobile	Android	13	6
+Chrome	124.0.6367.79	desktop	Windows	11	6
+Chrome	125	mobile	iOS	(not set)	6
+Chrome	125.0.6422.113	desktop	Windows	11	6
+Chrome	125.0.6422.165	mobile	Android	13.0.0	6
+Chrome	125.0.6422.72	mobile	Android	10	6
+Chrome	126.0.6478.127	desktop	Macintosh	Intel 15.5	6
+Chrome	126.0.6478.182	desktop	Linux	5.15.0	6
+Chrome	127.0.6533.119	desktop	Linux	5.15.0	6
+Chrome	127.0.6533.89	desktop	Windows	11	6
+Chrome	128.0.6613.113	desktop	Linux	5.15.0	6
+Chrome	128.0.6613.127	mobile	Android	14.0.0	6
+Chrome	128.0.6613.146	mobile	Android	12.0.0	6
+Chrome	128.0.6613.146	mobile	Android	14.0.0	6
+Chrome	128.0.6613.99	mobile	Android	14.0.0	6
+Chrome	129.0.6668.100	desktop	Windows	10	6
+Chrome	129.0.6668.100	mobile	Android	10.0.0	6
+Chrome	129.0.6668.100	mobile	Android	11.0.0	6
+Chrome	129.0.6668.103	desktop	Windows	10	6
+Chrome	129.0.6668.58	desktop	Linux	6.8.0	6
+Chrome	129.0.6668.70	mobile	Android	12.0.0	6
+Chrome	129.0.6668.71	desktop	Windows	11	6
+Chrome	129.0.6668.81	mobile	Android	12.0.0	6
+Chrome	129.0.6668.89	desktop	Linux	5.15.0	6
+Chrome	130.0.0.0	desktop	Macintosh	Intel 15.5	6
+Chrome	130.0.6723.116	desktop	Linux	6.11.0	6
+Chrome	130.0.6723.58	desktop	Linux	6.1.0	6
+Chrome	130.0.6723.58	mobile	Android	12.0.0	6
+Chrome	130.0.6723.59	desktop	Macintosh	Intel 15.5	6
+Chrome	130.0.6723.73	mobile	Android	14.0.0	6
+Chrome	130.0.6723.86	mobile	Android	11.0.0	6
+Chrome	130.0.6723.86	mobile	Android	12.0.0	6
+Chrome	130.0.6723.86	mobile	Android	13.0.0	6
+Chrome	131.0.6778.135	mobile	Android	14.0.0	6
+Chrome	131.0.6778.139	desktop	Linux	6.11.0	6
+Chrome	131.0.6778.205	desktop	Macintosh	Intel 14.5	6
+Chrome	131.0.6778.260	mobile	Android	15	6
+Chrome	131.0.6778.264	desktop	Windows	10	6
+Chrome	131.0.6778.43	desktop	Windows	10	6
+Chrome	131.0.6778.86	desktop	Macintosh	Intel 15.5	6
+Chrome	132.0.0.0	desktop	Linux	6.2.0	6
+Chrome	132.0.0.0	mobile	Android	14.0.0	6
+Chrome	132.0.6834.163	mobile	Android	9.0.0	6
+Chrome	132.0.6834.164	mobile	Android	8.1.0	6
+Chrome	132.0.6834.165	mobile	Android	14.0.0	6
+Chrome	132.0.6834.197	desktop	Windows	10	6
+Chrome	132.0.6834.78	mobile	iOS	18.5.0	6
+Chrome	132.0.6834.79	mobile	Android	11.0.0	6
+Chrome	132.0.6834.83	desktop	Linux	5.15.0	6
+Chrome	133.0.0.0	desktop	Macintosh	Intel 15.5	6
+Chrome	133.0.0.0	desktop	Windows	11	6
+Chrome	133.0.6943.121	mobile	Android	10.0.0	6
+Chrome	133.0.6943.121	mobile	Android	9.0.0	6
+Chrome	133.0.6943.137	mobile	Android	8.1.0	6
+Chrome	133.0.6943.138	mobile	Android	14.0.0	6
+Chrome	133.0.6943.142	desktop	Macintosh	Intel 14.3	6
+Chrome	133.0.6943.184	desktop	Chrome OS	x86_64 16151.61.0	6
+Chrome	133.0.6943.49	mobile	Android	15.0.0	6
+Chrome	133.0.6943.50	mobile	Android	10.0.0	6
+Chrome	133.0.6943.50	mobile	Android	12.0.0	6
+Chrome	133.0.6943.89	mobile	Android	13.0.0	6
+Chrome	133.0.6943.99	desktop	Macintosh	Intel 15.5	6
+Chrome	134.0.6998.108	mobile	Android	12.0.0	6
+Chrome	134.0.6998.108	mobile	Android	14.0.0	6
+Chrome	134.0.6998.135	mobile	Android	9.0.0	6
+Chrome	134.0.6998.136	mobile	Android	11.0.0	6
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 13.5	6
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 15.0	6
+Chrome	134.0.6998.177	desktop	Windows	11	6
+Chrome	134.0.6998.36	desktop	Linux	5.13.0	6
+Chrome	134.0.6998.39	mobile	Android	12.0.0	6
+Chrome	134.0.6998.45	desktop	Macintosh	Intel 15.5	6
+Chrome	134.0.6998.89	desktop	Macintosh	Intel 15.4	6
+Chrome	135.0.7049.100	mobile	Android	9.0.0	6
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 13.2	6
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 13.4	6
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 14.1	6
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 14.2	6
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 15.0	6
+Chrome	135.0.7049.116	desktop	Macintosh	Intel 14.4	6
+Chrome	135.0.7049.117	desktop	Windows	10	6
+Chrome	135.0.7049.39	mobile	Android	14.0.0	6
+Chrome	135.0.7049.42	desktop	Macintosh	Intel 14.5	6
+Chrome	135.0.7049.42	desktop	Macintosh	Intel 15.3	6
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 15.1	6
+Chrome	136.0.7103.113	desktop	Linux	6.5.0	6
+Chrome	136.0.7103.113	desktop	Windows	11	6
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 12.6	6
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 14.7	6
+Chrome	136.0.7103.127	mobile	Android	15.0.0	6
+Chrome	136.0.7103.48	desktop	Macintosh	Intel 12.7	6
+Chrome	136.0.7103.49	desktop	Macintosh	Intel 15.5	6
+Chrome	136.0.7103.88	mobile	Android	13.0.0	6
+Chrome	136.0.7103.88	mobile	Android	14.0.0	6
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 13.0	6
+Chrome	137.0.0.0	mobile	Android	10.0.0	6
+Chrome	137.0.7151.103	desktop	Macintosh	Intel 15.0	6
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 12.2	6
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 12.4	6
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 14.4	6
+Chrome	137.0.7151.107	mobile	iOS	17.7.1	6
+Chrome	137.0.7151.107	mobile	iOS	18.1.1	6
+Chrome	137.0.7151.107	tablet	iOS	16.7.11	6
+Chrome	137.0.7151.112	mobile	Android	15	6
+Chrome	137.0.7151.116	mobile	Android	16	6
+Chrome	137.0.7151.119	desktop	Linux	6.2.0	6
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 15.0	6
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 14.6	6
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 12.4	6
+Chrome	137.0.7151.122	mobile	Android	6.0	6
+Chrome	137.0.7151.122	mobile	Windows	10	6
+Chrome	137.0.7151.122	mobile	Windows	11	6
+Chrome	137.0.7151.123	desktop	Macintosh	 10.15	6
+Chrome	137.0.7151.123	desktop	Macintosh	Intel 10.15	6
+Chrome	137.0.7151.132	desktop	Macintosh	Intel 10.15	6
+Chrome	137.0.7151.41	desktop	Macintosh	Intel 15.3	6
+Chrome	137.0.7151.55	desktop	Linux	6.12.10	6
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 12.7	6
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 14.1	6
+Chrome	137.0.7151.61	mobile	Android	13.0.0	6
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 12.6	6
+Chrome	137.0.7151.79	tablet	iOS	18.5.0	6
+Chrome	137.0.7151.89	mobile	Android	12	6
+Chrome	137.0.7151.90	mobile	Android	12.0.0	6
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 10.15	6
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 14.1	6
+Chrome	138.0.7204.101	mobile	Macintosh	 15.5	6
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 14.3	6
+Chrome	138.0.7204.119	tablet	iOS	17.7.8	6
+Chrome	138.0.7204.156	mobile	iOS	18.3.1	6
+Chrome	138.0.7204.156	mobile	iOS	18.3.2	6
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 14.1	6
+Chrome	138.0.7204.25	mobile	Android	15.0.0	6
+Chrome	138.0.7204.42	mobile	Android	15.0.0	6
+Chrome	138.0.7204.49	desktop	Linux	6.12.27	6
+Chrome	138.0.7204.49	desktop	Linux	6.2.0	6
+Chrome	138.0.7204.49	desktop	Linux	6.5.0	6
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 12.2	6
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 14.1	6
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 15.6	6
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 11.7	6
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 12.2	6
+Chrome	138.0.7204.51	mobile	Windows	11	6
+Chrome	138.0.7204.64	tablet	Android	15.0.0	6
+Chrome	138.0.7204.68	mobile	Android	13	6
+Chrome	138.0.7204.92	desktop	Linux	6.15.6	6
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 13.3	6
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 15.0	6
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 15.2	6
+Chrome	139.0.7207.2	desktop	Windows	10	6
+Chrome	139.0.7246.2	desktop	Macintosh	Intel 15.5	6
+Chrome	139.0.7258.0	desktop	Chrome OS	x86_64 16328.2.0	6
+Chrome	139.0.7258.3	mobile	Android	16.0.0	6
+Chrome	139.0.7258.42	desktop	Windows	10	6
+Chrome	140.0.7281.0	mobile	Android	11.0	6
+Chrome	18.0.1025.133	mobile	Android	9	6
+Chrome	61.0.3163.128	mobile	Android	8.1.0	6
+Chrome	67.0.3239.108	desktop	Linux	(not set)	6
+Chrome	77.0.3865.90	desktop	Macintosh	Intel 10.15	6
+Chrome	79.0.3945.116	mobile	Android	10	6
+Chrome	79.0.3945.79	desktop	Linux	(not set)	6
+Chrome	83.0.4103.116	desktop	Windows	10	6
+Chrome	88.0.4324.181	mobile	Android	11	6
+Chrome	88.0.4324.182	desktop	Windows	7	6
+Chrome	88.0.4324.93	mobile	Android	10	6
+Chrome	89.0.4389.116	mobile	Android	10	6
+Chrome	89.0.4389.116	mobile	Android	12	6
+Chrome	91.0.4472.164	desktop	Windows	10	6
+Chrome	95.0.4638.74	tablet	Android	5.1.1	6
+Edge	133.0.3065.82	desktop	Windows	11	6
+Edge	134.0.3124.51	desktop	Windows	10	6
+Edge	134.0.3124.51	desktop	Windows	11	6
+Edge	136.0.3240.131	desktop	Windows	10	6
+Edge	136.0.3240.64	desktop	Macintosh	Intel 15.5	6
+Edge	137.0.3296.82	mobile	Android	14.0.0	6
+Edge	137.0.3296.93	desktop	Macintosh	Intel 14.6	6
+Edge	137.0.3296.93	desktop	Macintosh	Intel 15.2	6
+Edge	138.0.3351.55	desktop	Macintosh	Intel 14.7	6
+Edge	138.0.3351.55	mobile	Windows	11	6
+Edge	138.0.3351.65	desktop	Linux	6.8.0	6
+Edge	138.0.3351.65	desktop	Macintosh	Intel 14.6	6
+Edge	138.0.3351.77	desktop	Macintosh	Intel 14.7	6
+Edge	138.0.3351.83	desktop	Linux	6.8.0	6
+Firefox	115.0	desktop	Macintosh	Intel 10.12	6
+Firefox	115.0	desktop	Macintosh	Intel 10.13	6
+Firefox	132.0	desktop	Windows	10	6
+Firefox	141.0	mobile	Android	14	6
+Opera	85.0.0.0	mobile	Android	10	6
+Opera	92.0.2254.77878	mobile	Android	10	6
+Safari	15.3	desktop	Macintosh	Intel 12.3	6
+Safari	15.6.6	mobile	iOS	15.8.2	6
+Safari	16.5.2	mobile	iOS	16.5.1	6
+Safari	17.6	mobile	iOS	17.6	6
+Safari	18.0	mobile	iOS	18.6.0	6
+Safari	604.1	mobile	iOS	16.3.1	6
+Safari	604.1	mobile	iOS	16.7.10	6
+Safari	604.1	mobile	iOS	17.4.1	6
+Samsung Internet	21.0	mobile	Android	12	6
+YaBrowser	25.4.6.49.00	mobile	Android	15	6
+YaBrowser	25.6.3.95.00	mobile	Android	13	6
+Android Webview	121.0.6167.178	mobile	Android	14	5
+Android Webview	130.0.6723.86	tablet	Android	15	5
+Android Webview	131.0.6778.104	mobile	Android	14	5
+Android Webview	131.0.6778.135	mobile	Android	14	5
+Android Webview	131.0.6778.260	mobile	Android	13	5
+Android Webview	132.0.6834.163	mobile	Android	14	5
+Android Webview	133.0.6943.137	mobile	Android	14	5
+Android Webview	135.0.7049.100	mobile	Android	10	5
+Android Webview	135.0.7049.111	mobile	Android	10	5
+Android Webview	135.0.7049.111	mobile	Android	15	5
+Android Webview	135.0.7049.37	mobile	Android	14	5
+Android Webview	135.0.7049.38	mobile	Android	13	5
+Android Webview	135.0.7049.38	mobile	Android	14	5
+Android Webview	136.0.7103.125	mobile	Android	8.1.0	5
+Android Webview	136.0.7103.127	mobile	Android	15	5
+Android Webview	137.0.7151.115	smart tv	Android	9	5
+Android Webview	137.0.7151.118	tablet	Android	15	5
+Android Webview	137.0.7151.52	mobile	Android	15	5
+Android Webview	137.0.7151.80	mobile	Android	15	5
+Android Webview	137.0.7151.84	mobile	Android	12	5
+Android Webview	137.0.7151.89	tablet	Android	14	5
+Android Webview	137.0.7151.90	mobile	Android	9	5
+Android Webview	137.0.7151.90	tablet	Android	14	5
+Android Webview	138.0.0.0	mobile	Android	15	5
+Android Webview	138.0.7204.139	mobile	Android	13	5
+Android Webview	138.0.7204.146	mobile	Android	13	5
+Android Webview	138.0.7204.157	tablet	Android	14	5
+Android Webview	138.0.7204.42	mobile	Android	10	5
+Android Webview	138.0.7204.42	mobile	Android	9	5
+Android Webview	138.0.7204.46	mobile	Android	8.1.0	5
+Android Webview	138.0.7204.46	mobile	Android	9	5
+Android Webview	138.0.7204.55	mobile	Android	14	5
+Android Webview	138.0.7204.55	mobile	Android	15	5
+Android Webview	139.0.7258.32	mobile	Android	12	5
+Android Webview	139.0.7258.32	mobile	Android	14	5
+Android Webview	99.0.4844.88	tablet	Android	12	5
+Chrome	101.0.4951.64	desktop	Windows	10	5
+Chrome	102.0.0.0	desktop	Linux	(not set)	5
+Chrome	103.0.5060.129	mobile	Android	11.0.0	5
+Chrome	103.0.5060.53	desktop	Chrome OS	x86_64 14816.64.0	5
+Chrome	104.0.0.0	desktop	Windows	10	5
+Chrome	105.0.5195.134	desktop	Chrome OS	x86_64 14989.107.0	5
+Chrome	106.0.5249.126	tablet	Android	6.0.0	5
+Chrome	107.0.0.0	desktop	Windows	11	5
+Chrome	108.0.0.0	mobile	Android	14	5
+Chrome	109.0.0.0	desktop	Windows	8.1	5
+Chrome	110.0.5481.153	mobile	Android	12	5
+Chrome	113.0.5672.93	desktop	Windows	10	5
+Chrome	114.0.5735.196	tablet	Android	10.0.0	5
+Chrome	115.0.5790.110	desktop	Windows	10	5
+Chrome	116.0.5845.188	desktop	Windows	10	5
+Chrome	117.0.5938.150	desktop	Windows	11	5
+Chrome	117.0.5938.92	desktop	Windows	10	5
+Chrome	119.0.0.0	desktop	Windows	10	5
+Chrome	119.0.6045.124	desktop	Windows	10	5
+Chrome	119.0.6045.124	desktop	Windows	11	5
+Chrome	120.0.0.0	desktop	Linux	5.10.0	5
+Chrome	120.0.6099.119	mobile	iOS	18.5	5
+Chrome	120.0.6099.130	desktop	Windows	11	5
+Chrome	120.0.6099.193	tablet	Android	14.0.0	5
+Chrome	120.0.6099.210	mobile	Android	12.0.0	5
+Chrome	121.0.6167.139	desktop	Linux	5.15.0	5
+Chrome	121.0.6167.178	mobile	Android	14	5
+Chrome	121.0.6167.86	desktop	Windows	10	5
+Chrome	123.0.6312.118	mobile	Android	9.0.0	5
+Chrome	123.0.6312.123	desktop	Windows	11	5
+Chrome	123.0.6312.58	desktop	Windows	10	5
+Chrome	124.0.6328.0	mobile	Android	10.0.0	5
+Chrome	124.0.6367.60	desktop	Windows	10	5
+Chrome	124.0.6367.63	desktop	Windows	11	5
+Chrome	124.0.6367.78	desktop	Windows	11	5
+Chrome	124.0.6367.79	desktop	Windows	10	5
+Chrome	124.0.6367.93	desktop	Macintosh	Intel 10.15	5
+Chrome	125.0.0.0	desktop	Windows	10	5
+Chrome	126.0.0.0	desktop	Macintosh	Intel 10.15	5
+Chrome	126.0.6478.110	tablet	Android	14.0.0	5
+Chrome	126.0.6478.61	desktop	Linux	6.8.0	5
+Chrome	126.0.6478.62	desktop	Macintosh	Intel 15.5	5
+Chrome	126.0.6478.71	mobile	Android	14	5
+Chrome	127.0.6533.103	mobile	Android	12.0.0	5
+Chrome	127.0.6533.103	mobile	Android	14.0.0	5
+Chrome	127.0.6533.120	desktop	Windows	11	5
+Chrome	127.0.6533.64	mobile	Android	14	5
+Chrome	127.0.6533.73	desktop	Windows	10	5
+Chrome	127.0.6533.73	desktop	Windows	11	5
+Chrome	127.0.6533.88	desktop	Linux	5.15.0	5
+Chrome	127.0.6533.89	desktop	Windows	10	5
+Chrome	128.0.6613.113	desktop	Linux	6.8.0	5
+Chrome	128.0.6613.120	desktop	Windows	11	5
+Chrome	128.0.6613.146	mobile	Android	15.0.0	5
+Chrome	128.0.6613.147	mobile	Android	13.0.0	5
+Chrome	128.0.6613.84	desktop	Windows	10	5
+Chrome	128.0.6613.99	mobile	Android	11.0.0	5
+Chrome	129.0.0.0	desktop	Linux	(not set)	5
+Chrome	129.0.6668.58	desktop	Linux	5.15.0	5
+Chrome	129.0.6668.60	desktop	Windows	11	5
+Chrome	129.0.6668.70	desktop	Windows	11	5
+Chrome	129.0.6668.70	mobile	Android	14.0.0	5
+Chrome	129.0.6668.81	mobile	Android	14.0.0	5
+Chrome	129.0.6668.90	desktop	Macintosh	Intel 15.5	5
+Chrome	130.0.6723.126	desktop	Chrome OS	x86_64 16033.58.0	5
+Chrome	130.0.6723.58	mobile	Android	14.0.0	5
+Chrome	130.0.6723.59	desktop	Windows	11	5
+Chrome	130.0.6723.73	mobile	Android	13.0.0	5
+Chrome	130.0.6723.86	mobile	Android	10.0.0	5
+Chrome	130.0.6723.86	mobile	Android	15	5
+Chrome	131.0.0.0	desktop	Macintosh	Intel 10.15	5
+Chrome	131.0.0.0	mobile	Android	12.0.0	5
+Chrome	131.0.0.0	mobile	Android	15.0.0	5
+Chrome	131.0.6778.104	mobile	Android	10.0.0	5
+Chrome	131.0.6778.140	desktop	Macintosh	Intel 15.5	5
+Chrome	131.0.6778.267	desktop	Windows	10	5
+Chrome	131.0.6778.85	desktop	Windows	10	5
+Chrome	132.0.6834.100	mobile	iOS	18.5.0	5
+Chrome	132.0.6834.122	mobile	Android	10.0.0	5
+Chrome	132.0.6834.208	desktop	Chrome OS	x86_64 16093.92.0	5
+Chrome	132.0.6834.79	mobile	Android	10.0.0	5
+Chrome	133.0.0.0	desktop	Macintosh	Intel 10.15	5
+Chrome	133.0.6943.127	desktop	Macintosh	Intel 15.3	5
+Chrome	133.0.6943.128	desktop	Windows	11	5
+Chrome	133.0.6943.84	mobile	iOS	18.5.0	5
+Chrome	134.0.6998.108	mobile	Android	15.0.0	5
+Chrome	134.0.6998.119	desktop	Windows	10	5
+Chrome	134.0.6998.136	mobile	Android	13.0.0	5
+Chrome	134.0.6998.136	mobile	Android	15.0.0	5
+Chrome	134.0.6998.165	desktop	Linux	5.4.0	5
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 13.3	5
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 14.1	5
+Chrome	134.0.6998.39	mobile	Android	14.0.0	5
+Chrome	135.0.0.0	desktop	Linux	6.11.0	5
+Chrome	135.0.7049.100	mobile	Android	8.1.0	5
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 12.7	5
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 14.0	5
+Chrome	135.0.7049.120	desktop	Chrome OS	x86_64 16209.59.0	5
+Chrome	135.0.7049.38	mobile	Android	12.0.0	5
+Chrome	135.0.7049.84	desktop	Windows	11	5
+Chrome	135.0.7049.86	desktop	Windows	11	5
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 14.2	5
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 14.4	5
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 15.0	5
+Chrome	136.0.0.0	desktop	Linux	5.10.134	5
+Chrome	136.0.0.0	desktop	Macintosh	Intel 10.15	5
+Chrome	136.0.7103.113	desktop	Linux	6.12.10	5
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 12.3	5
+Chrome	136.0.7103.125	mobile	Android	11	5
+Chrome	136.0.7103.125	mobile	Android	8.0.0	5
+Chrome	136.0.7103.125	tablet	Android	14.0.0	5
+Chrome	136.0.7103.179	mobile	Android	15.0.0	5
+Chrome	136.0.7103.56	mobile	iOS	18.4.1	5
+Chrome	136.0.7103.88	mobile	Android	12.0.0	5
+Chrome	136.0.7103.91	mobile	iOS	18.6.0	5
+Chrome	136.0.7103.91	tablet	iOS	18.5.0	5
+Chrome	137.0.0.0	desktop	Linux	6.12.33	5
+Chrome	137.0.0.0	desktop	Linux	6.12.34	5
+Chrome	137.0.0.0	desktop	Linux	6.14.10	5
+Chrome	137.0.0.0	desktop	Linux	6.14.9	5
+Chrome	137.0.0.0	desktop	Macintosh	Intel 10.14	5
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 13.1	5
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 12.7	5
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 13.3	5
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 13.5	5
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 13.7	5
+Chrome	137.0.7151.107	mobile	iOS	16.6.1	5
+Chrome	137.0.7151.107	mobile	iOS	16.7.10	5
+Chrome	137.0.7151.107	mobile	iOS	18.0.0	5
+Chrome	137.0.7151.107	mobile	iOS	18.0.1	5
+Chrome	137.0.7151.107	mobile	iOS	18.1.0	5
+Chrome	137.0.7151.107	mobile	iOS	18.3.0	5
+Chrome	137.0.7151.107	tablet	iOS	19.0.0	5
+Chrome	137.0.7151.112	mobile	Android	12.0.0	5
+Chrome	137.0.7151.112	mobile	Android	14	5
+Chrome	137.0.7151.116	mobile	Android	14.0.0	5
+Chrome	137.0.7151.116	mobile	Android	15.0.0	5
+Chrome	137.0.7151.117	tablet	Android	11.0.0	5
+Chrome	137.0.7151.117	tablet	Android	12.0.0	5
+Chrome	137.0.7151.119	desktop	Linux	5.10.0	5
+Chrome	137.0.7151.119	desktop	Linux	6.15.4	5
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 11.1	5
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 11.4	5
+Chrome	137.0.7151.120	mobile	Macintosh	 15.5	5
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 14.4	5
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 14.5	5
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 14.7	5
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 12.0	5
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 12.3	5
+Chrome	137.0.7151.122	mobile	Macintosh	 15.5	5
+Chrome	137.0.7151.132	desktop	Macintosh	 10.15	5
+Chrome	137.0.7151.34	mobile	iOS	18.5.0	5
+Chrome	137.0.7151.41	desktop	Macintosh	Intel 14.3	5
+Chrome	137.0.7151.55	desktop	Linux	6.15.2	5
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 15.1	5
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 12.5	5
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 13.5	5
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 15.1	5
+Chrome	137.0.7151.57	desktop	Macintosh	Intel 14.0	5
+Chrome	137.0.7151.57	desktop	Macintosh	Intel 14.7	5
+Chrome	137.0.7151.61	mobile	Android	14.0.0	5
+Chrome	137.0.7151.62	mobile	Android	13.0.0	5
+Chrome	137.0.7151.68	desktop	Linux	5.14.0	5
+Chrome	137.0.7151.68	desktop	Linux	6.5.0	5
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 13.4	5
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 14.7	5
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 11.7	5
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 14.4	5
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 14.7	5
+Chrome	137.0.7151.72	mobile	Android	8.0.0	5
+Chrome	138.0.0.0	desktop	Linux	6.12.10	5
+Chrome	138.0.0.0	desktop	Macintosh	Intel 14.1	5
+Chrome	138.0.0.0	mobile	Android	15.0.0	5
+Chrome	138.0.7204.100	desktop	Linux	6.5.0	5
+Chrome	138.0.7204.100	desktop	Macintosh	 10.15	5
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 13.2	5
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 13.4	5
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 14.3	5
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 15.6	5
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 11.2	5
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 13.5	5
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 14.2	5
+Chrome	138.0.7204.119	tablet	iOS	19.0.0	5
+Chrome	138.0.7204.157	desktop	Linux	6.11.1	5
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 12.5	5
+Chrome	138.0.7204.157	mobile	Android	12	5
+Chrome	138.0.7204.157	tablet	Android	11.0.0	5
+Chrome	138.0.7204.158	mobile	Android	6.0	5
+Chrome	138.0.7204.31	desktop	Chrome OS	x86_64 16295.23.0	5
+Chrome	138.0.7204.33	mobile	iOS	19.0.0	5
+Chrome	138.0.7204.42	mobile	Android	15	5
+Chrome	138.0.7204.45	mobile	Android	16	5
+Chrome	138.0.7204.46	mobile	Android	9	5
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 12.1	5
+Chrome	138.0.7204.64	tablet	Android	13.0.0	5
+Chrome	138.0.7204.68	mobile	Android	11	5
+Chrome	138.0.7204.92	desktop	Linux	6.12.20	5
+Chrome	138.0.7204.92	desktop	Linux	6.12.30	5
+Chrome	138.0.7204.92	desktop	Linux	6.14.9	5
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 12.0	5
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 12.5	5
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 26.0	5
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 10.15	5
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 11.5	5
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 14.3	5
+Chrome	138.0.7204.97	mobile	Android	11.0	5
+Chrome	139.0.0.0	mobile	Android	11.0.0	5
+Chrome	139.0.7233.0	desktop	Chrome OS	x86_64 16317.0.0	5
+Chrome	139.0.7258.3	mobile	Android	14	5
+Chrome	139.0.7258.41	mobile	Android	11.0.0	5
+Chrome	139.0.7258.8	desktop	Chrome OS	aarch64 16328.6.0	5
+Chrome	140.0.0.0	desktop	Macintosh	Intel 15.5	5
+Chrome	140.0.0.0	desktop	Windows	11	5
+Chrome	140.0.7259.2	desktop	Macintosh	Intel 13.7	5
+Chrome	140.0.7261.0	desktop	Macintosh	Intel 15.5	5
+Chrome	140.0.7281.0	desktop	Macintosh	Intel 15.5	5
+Chrome	140.0.7283.0	desktop	Macintosh	Intel 15.5	5
+Chrome	140.0.7284.0	desktop	Windows	11	5
+Chrome	140.0.7296.0	desktop	Macintosh	Intel 15.5	5
+Chrome	140.0.7301.0	desktop	Windows	10	5
+Chrome	68.0.3440.91	mobile	Android	8.0.0	5
+Chrome	74.0.3729.136	mobile	Android	11	5
+Chrome	77.0.3865.120	desktop	Chrome OS	armv7l 12371.89.0	5
+Chrome	78.0.3904.108	desktop	Windows	10	5
+Chrome	79.0.3945.147	mobile	Android	10	5
+Chrome	81.0.4044.138	mobile	Android	5.0	5
+Chrome	81.0.4044.138	tablet	Android	4.4.2	5
+Chrome	87.0.4280.141	mobile	Android	10	5
+Chrome	91.0.4472.88	mobile	Android	8.1.0	5
+Chrome	92.0.4515.90	mobile	iOS	12.5	5
+Chrome	93.0.4577.10	desktop	Chrome OS	x86_64 14092.9.0	5
+Chrome	93.0.4577.69	desktop	Chrome OS	x86_64 14092.46.0	5
+Chrome	95.0.4638.74	mobile	Android	5.0	5
+Chrome	99.0.4844.84	desktop	Windows	10	5
+Edge	131.0.2903.146	desktop	Windows	10	5
+Edge	131.0.2903.99	desktop	Windows	10	5
+Edge	133.0.3065.82	desktop	Windows	10	5
+Edge	136.0.3240.124	desktop	Windows	11	5
+Edge	137.0.3296.83	desktop	Macintosh	Intel 14.5	5
+Edge	137.0.3296.83	desktop	Macintosh	Intel 14.7	5
+Edge	137.0.3296.83	desktop	Macintosh	Intel 15.3	5
+Edge	137.0.3296.83	desktop	Macintosh	Intel 15.4	5
+Edge	137.0.3296.92	mobile	Android	11.0.0	5
+Edge	137.0.3296.93	desktop	Macintosh	Intel 13.7	5
+Edge	137.0.3296.93	desktop	Macintosh	Intel 14.5	5
+Edge	138.0.0.0	mobile	Android	6.0	5
+Edge	138.0.3351.55	desktop	Linux	6.8.0	5
+Edge	138.0.3351.55	mobile	Android	15.0.0	5
+Edge	138.0.3351.77	desktop	Linux	6.11.0	5
+Edge	138.0.3351.77	desktop	Macintosh	Intel 15.3	5
+Edge	138.0.3351.77	desktop	Macintosh	Intel 15.4	5
+Edge	138.0.3351.83	mobile	Android	16.0.0	5
+Edge	138.0.3351.95	desktop	Macintosh	Intel 15.4	5
+Edge	139.0.3402.0	desktop	Windows	11	5
+Edge	89.0.774.63	desktop	Windows	10	5
+Firefox	131.0	desktop	Macintosh	Intel 10.15	5
+Firefox	141.0	mobile	Android	13	5
+Firefox	70.0	desktop	Macintosh	Intel 10.14	5
+Opera	112.0.0.0	desktop	Windows	10	5
+Opera	91.0.0.0	mobile	Android	10	5
+Opera	92.0.2254.77856	mobile	Android	13	5
+Safari	15.3	mobile	iOS	15.3.1	5
+Safari	15.6	mobile	iOS	15.6	5
+Safari	16.3.1	mobile	iOS	16.3.1	5
+Safari	16.6	tablet	iOS	16.6	5
+Safari	17.1	mobile	iOS	17.1	5
+Safari	17.2.1	mobile	iOS	17.2.1	5
+Safari	17.4	mobile	iOS	17.4	5
+Safari	17.5	mobile	iOS	17.5	5
+Safari	17.7.2	mobile	iOS	17.7.2	5
+Safari	605.1.15	mobile	iOS	16.7.11	5
+Safari (in-app)	(not set)	mobile	iOS	15.8.3	5
+Safari (in-app)	(not set)	mobile	iOS	17.7.2	5
+Safari (in-app)	(not set)	mobile	iOS	18.1	5
+Safari (in-app)	(not set)	mobile	iOS	18.2.1	5
+Samsung Internet	17.0	desktop	Linux	(not set)	5
+Samsung Internet	23.0	mobile	Android	11	5
+Samsung Internet	23.0	mobile	Android	13	5
+Samsung Internet	25.0	desktop	Linux	(not set)	5
+Samsung Internet	3.0	mobile	Tizen	5.5	5
+UC Browser	12.12.10.1228	mobile	Android	11	5
+UC Browser	12.12.10.1228	mobile	Android	14	5
+YaBrowser	24.7.0.0	desktop	Linux	(not set)	5
+YaBrowser	25.4.0.1973	desktop	Windows	10	5
+YaBrowser	25.4.6.49.00	mobile	Android	14	5
+YaBrowser	25.6.1.95.00	mobile	Android	11	5
+YaBrowser	25.6.4.102.00	mobile	Android	15	5
+Aloha Browser	7.3.1	mobile	Android	10	4
+Amazon Silk	97.1.79	tablet	Android	10	4
+Android Runtime	2.1.0	mobile	Android	12	4
+Android Webview	101.0.4951.54	mobile	Android	11	4
+Android Webview	111.0.5563.116	mobile	Android	12	4
+Android Webview	111.0.5563.116	tablet	Android	13	4
+Android Webview	127.0.6533.103	mobile	Android	9	4
+Android Webview	128.0.6613.127	mobile	Android	15	4
+Android Webview	130.0.6723.107	mobile	Android	11	4
+Android Webview	131.0.6778.260	mobile	Android	10	4
+Android Webview	133.0.6943.121	mobile	Android	9	4
+Android Webview	133.0.6943.137	mobile	Android	15	4
+Android Webview	135.0.7049.100	mobile	Android	14	4
+Android Webview	136.0.7103.125	tablet	Android	14	4
+Android Webview	136.0.7103.60	mobile	Android	10	4
+Android Webview	137.0.7151.118	mobile	Android	16	4
+Android Webview	137.0.7151.52	mobile	Android	13	4
+Android Webview	137.0.7151.72	mobile	Android	8.1.0	4
+Android Webview	137.0.7151.84	mobile	Android	15	4
+Android Webview	138.0.7204.143	mobile	Android	14	4
+Android Webview	138.0.7204.153	mobile	Android	13	4
+Android Webview	138.0.7204.157	tablet	Android	13	4
+Android Webview	138.0.7204.42	mobile	Android	16	4
+Android Webview	138.0.7204.63	tablet	Android	15	4
+Android Webview	138.0.7204.67	smart tv	Android	11	4
+Android Webview	138.0.7204.67	tablet	Android	11	4
+Android Webview	139.0.7258.3	mobile	Android	10	4
+Android Webview	55.0.2883.91	mobile	Android	6.0	4
+Android Webview	64.0.3282.137	mobile	Android	7.0	4
+Android Webview	77.0.3865.92	mobile	Android	9	4
+Android Webview	83.0.4103.101	mobile	Android	10	4
+Android Webview	83.0.4103.120	mobile	Android	11	4
+Android Webview	85.0.4183.101	mobile	Android	9	4
+Android Webview	87.0.4280.141	mobile	Android	8.1.0	4
+Android Webview	88.0.4324.93	mobile	Android	10	4
+Android Webview	93.0.4577.62	mobile	Android	11	4
+Android Webview	95.0.4638.74	mobile	Android	5.1	4
+Chrome	(not set)	desktop	Linux	12.0.0	4
+Chrome	100.0.4896.127	mobile	Android	8.1.0	4
+Chrome	100.0.4896.127	mobile	Android	9	4
+Chrome	104.0.0.0	desktop	Linux	(not set)	4
+Chrome	107.0.0.0	mobile	Android	12.0.0	4
+Chrome	108.0.5359.128	mobile	Android	10.0.0	4
+Chrome	109.0.0.0	desktop	Linux	(not set)	4
+Chrome	109.0.5414.123	mobile	Android	13.0.0	4
+Chrome	109.0.5414.132	desktop	Windows	7	4
+Chrome	109.0.5414.149	desktop	Windows	8.1	4
+Chrome	111.0.0.0	desktop	Windows	10	4
+Chrome	111.0.5563.110	desktop	Linux	6.8.0	4
+Chrome	112.0.5615.135	mobile	Android	13.0.0	4
+Chrome	112.0.5615.136	mobile	Android	13	4
+Chrome	113.0.5672.126	desktop	Windows	10	4
+Chrome	114.0.0.0	desktop	(not set)	(not set)	4
+Chrome	115.0.0.0	desktop	Windows	11	4
+Chrome	116.0.5845.210	desktop	Chrome OS	aarch64 15509.81.0	4
+Chrome	118.0.0.0	desktop	Macintosh	Intel 10.15	4
+Chrome	118.0.5993.118	desktop	Windows	10	4
+Chrome	119.0.0.0	mobile	Android	11.0.0	4
+Chrome	119.0.6045.159	desktop	Linux	6.8.0	4
+Chrome	119.0.6045.193	mobile	Android	7.0	4
+Chrome	119.0.6045.194	mobile	Android	7.1.1	4
+Chrome	119.0.6045.200	desktop	Windows	11	4
+Chrome	120.0.6099.110	desktop	Windows	11	4
+Chrome	120.0.6099.129	desktop	Linux	6.8.0	4
+Chrome	120.0.6099.216	desktop	Linux	5.15.0	4
+Chrome	121.0.0.0	desktop	Linux	(not set)	4
+Chrome	121.0.0.0	desktop	Linux	6.8.0	4
+Chrome	121.0.6167.178	mobile	Android	13.0.0	4
+Chrome	122.0.6261.119	mobile	Android	13	4
+Chrome	122.0.6261.128	desktop	Windows	10	4
+Chrome	122.0.6261.58	desktop	Windows	11	4
+Chrome	122.0.6261.95	desktop	Windows	7	4
+Chrome	123.0.6312.105	desktop	Linux	5.15.0	4
+Chrome	123.0.6312.118	desktop	Linux	8.1.0	4
+Chrome	123.0.6312.124	desktop	Macintosh	Intel 15.5	4
+Chrome	124.0.6315.2	desktop	Windows	10	4
+Chrome	124.0.6367.118	desktop	Linux	6.8.0	4
+Chrome	124.0.6367.92	desktop	Windows	10	4
+Chrome	125.0.6422.112	desktop	Linux	5.15.0	4
+Chrome	125.0.6422.112	desktop	Linux	6.8.0	4
+Chrome	125.0.6422.112	desktop	Windows	10	4
+Chrome	126.0.6478.108	mobile	iOS	18.5	4
+Chrome	126.0.6478.122	mobile	Android	10.0.0	4
+Chrome	126.0.6478.127	desktop	Macintosh	Intel 15.4	4
+Chrome	126.0.6478.182	desktop	Windows	10	4
+Chrome	126.0.6478.182	desktop	Windows	11	4
+Chrome	126.0.6478.185	desktop	Windows	10	4
+Chrome	126.0.6478.62	desktop	Macintosh	Intel 14.5	4
+Chrome	127.0.6533.122	desktop	Windows	10	4
+Chrome	127.0.6533.84	mobile	Android	11.0.0	4
+Chrome	127.0.6533.88	desktop	Linux	6.8.0	4
+Chrome	127.0.6533.99	desktop	Linux	5.4.284	4
+Chrome	128.0.0.0	desktop	Linux	(not set)	4
+Chrome	128.0.6613.119	desktop	Windows	11	4
+Chrome	128.0.6613.127	mobile	Android	15.0.0	4
+Chrome	128.0.6613.146	mobile	Android	11.0.0	4
+Chrome	128.0.6613.146	mobile	Android	13.0.0	4
+Chrome	128.0.6613.85	desktop	Macintosh	Intel 15.5	4
+Chrome	128.0.6613.86	desktop	Windows	10	4
+Chrome	128.0.6613.99	mobile	Android	10.0.0	4
+Chrome	129.0.6668.101	desktop	Macintosh	Intel 15.5	4
+Chrome	129.0.6668.54	mobile	Android	14.0.0	4
+Chrome	129.0.6668.69	mobile	iOS	16.7	4
+Chrome	130.0.6723.58	desktop	Linux	6.11.0	4
+Chrome	130.0.6723.58	mobile	Android	13.0.0	4
+Chrome	130.0.6723.69	desktop	Linux	5.15.0	4
+Chrome	130.0.6723.73	mobile	Android	11.0.0	4
+Chrome	130.0.6723.73	mobile	Android	12.0.0	4
+Chrome	130.0.6723.91	mobile	Android	11.0.0	4
+Chrome	131.0.0.0	desktop	Macintosh	 10.15	4
+Chrome	131.0.0.0	desktop	Macintosh	Intel 15.5	4
+Chrome	131.0.0.0	mobile	Android	10.0.0	4
+Chrome	131.0.0.0	mobile	Android	13.0.0	4
+Chrome	131.0.0.0	mobile	Android	14.0.0	4
+Chrome	131.0.0.0	mobile	iOS	15.0	4
+Chrome	131.0.6778.103	mobile	iOS	18.5.0	4
+Chrome	131.0.6778.104	mobile	Android	11.0.0	4
+Chrome	131.0.6778.108	desktop	Windows	10	4
+Chrome	131.0.6778.109	desktop	Macintosh	Intel 15.5	4
+Chrome	131.0.6778.135	mobile	Android	12.0.0	4
+Chrome	131.0.6778.135	mobile	Android	15.0.0	4
+Chrome	131.0.6778.205	desktop	Macintosh	Intel 14.4	4
+Chrome	131.0.6778.261	mobile	Android	13.0.0	4
+Chrome	131.0.6778.261	mobile	Android	9.0.0	4
+Chrome	131.0.6778.39	mobile	Android	10.0.0	4
+Chrome	131.0.6778.70	desktop	Macintosh	Intel 14.7	4
+Chrome	131.0.6778.81	mobile	Android	15.0.0	4
+Chrome	131.0.6778.85	desktop	Linux	6.5.0	4
+Chrome	131.0.6778.85	desktop	Windows	11	4
+Chrome	131.0.6778.86	desktop	Macintosh	Intel 14.7	4
+Chrome	132.0.0.0	mobile	Android	11.0.0	4
+Chrome	132.0.0.0	mobile	Android	15.0.0	4
+Chrome	132.0.6834.110	desktop	Linux	5.4.0	4
+Chrome	132.0.6834.110	desktop	Linux	6.11.0	4
+Chrome	132.0.6834.111	desktop	Macintosh	Intel 15.5	4
+Chrome	132.0.6834.122	mobile	Android	13.0.0	4
+Chrome	132.0.6834.122	mobile	Android	14.0.0	4
+Chrome	132.0.6834.160	desktop	Macintosh	Intel 14.7	4
+Chrome	132.0.6834.165	mobile	Android	10.0.0	4
+Chrome	132.0.6834.165	mobile	Android	11.0.0	4
+Chrome	132.0.6834.196	desktop	Windows	10	4
+Chrome	132.0.6834.83	desktop	Macintosh	Intel 10.15	4
+Chrome	133	desktop	Windows	10	4
+Chrome	133.0.6943.138	mobile	Android	11.0.0	4
+Chrome	133.0.6943.138	mobile	Android	15.0.0	4
+Chrome	133.0.6943.142	desktop	Macintosh	Intel 13.5	4
+Chrome	133.0.6943.142	desktop	Macintosh	Intel 15.1	4
+Chrome	133.0.6943.143	desktop	Windows	11	4
+Chrome	133.0.6943.49	mobile	Android	13.0.0	4
+Chrome	133.0.6943.50	mobile	Android	11.0.0	4
+Chrome	134.0.6998.108	mobile	Android	11.0.0	4
+Chrome	134.0.6998.108	mobile	Android	13.0.0	4
+Chrome	134.0.6998.117	desktop	Windows	11	4
+Chrome	134.0.6998.118	desktop	Macintosh	Intel 15.3	4
+Chrome	134.0.6998.130	desktop	Chrome OS	x86_64 16181.47.0	4
+Chrome	134.0.6998.136	mobile	Android	12.0.0	4
+Chrome	134.0.6998.136	mobile	Android	14.0.0	4
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 13.0	4
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 14.7	4
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 15.1	4
+Chrome	134.0.6998.33	mobile	iOS	18.5.0	4
+Chrome	134.0.6998.37	desktop	Windows	10	4
+Chrome	134.0.6998.45	desktop	Macintosh	Intel 15.3	4
+Chrome	134.0.6998.89	desktop	Macintosh	Intel 12.7	4
+Chrome	134.0.6998.89	desktop	Macintosh	Intel 14.7	4
+Chrome	134.0.6998.89	desktop	Macintosh	Intel 15.1	4
+Chrome	134.0.6998.96	mobile	Android	14.0.0	4
+Chrome	134.0.6998.96	mobile	Android	15.0.0	4
+Chrome	135.0.0.0	desktop	Macintosh	Intel 10.15	4
+Chrome	135.0.0.0	desktop	Macintosh	Intel 13.7	4
+Chrome	135.0.0.0	desktop	Macintosh	Intel 14.7	4
+Chrome	135.0.0.0	desktop	Macintosh	Intel 15.4	4
+Chrome	135.0.0.0	desktop	Windows	11	4
+Chrome	135.0.7049.101	mobile	Android	14.0.0	4
+Chrome	135.0.7049.104	desktop	Chrome OS	x86_64 16209.50.0	4
+Chrome	135.0.7049.113	mobile	Android	13.0.0	4
+Chrome	135.0.7049.113	mobile	Android	15.0.0	4
+Chrome	135.0.7049.114	desktop	Linux	6.1.0	4
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 12.5	4
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 12.6	4
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 13.5	4
+Chrome	135.0.7049.116	desktop	Macintosh	Intel 14.3	4
+Chrome	135.0.7049.116	desktop	Macintosh	Intel 14.6	4
+Chrome	135.0.7049.116	desktop	Macintosh	Intel 15.0	4
+Chrome	135.0.7049.116	desktop	Macintosh	Intel 15.3	4
+Chrome	135.0.7049.117	desktop	Windows	11	4
+Chrome	135.0.7049.42	desktop	Macintosh	Intel 14.7	4
+Chrome	135.0.7049.43	desktop	Windows	10	4
+Chrome	135.0.7049.79	mobile	Android	8.1.0	4
+Chrome	135.0.7049.80	mobile	Android	12.0.0	4
+Chrome	135.0.7049.80	mobile	Android	14.0.0	4
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 14.3	4
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 15.0	4
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 15.2	4
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 12.6	4
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 14.3	4
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 15.2	4
+Chrome	135.0.7049.97	desktop	Windows	11	4
+Chrome	136	mobile	iOS	(not set)	4
+Chrome	136.0.0.0	desktop	Linux	6.14.6	4
+Chrome	136.0.7103.102	desktop	Chrome OS	aarch64 16238.47.0	4
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 11.6	4
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 12.5	4
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 13.6	4
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 15.0	4
+Chrome	136.0.7103.127	mobile	Android	14.0.0	4
+Chrome	136.0.7103.168	desktop	Windows	11	4
+Chrome	136.0.7103.177	desktop	Macintosh	Intel 14.4	4
+Chrome	136.0.7103.179	desktop	Windows	10	4
+Chrome	136.0.7103.42	mobile	iOS	18.5.0	4
+Chrome	136.0.7103.49	desktop	Macintosh	Intel 15.1	4
+Chrome	136.0.7103.56	mobile	iOS	17.5.1	4
+Chrome	136.0.7103.59	desktop	Linux	5.4.0	4
+Chrome	136.0.7103.59	desktop	Linux	6.14.4	4
+Chrome	136.0.7103.60	mobile	Android	8.1.0	4
+Chrome	136.0.7103.91	mobile	iOS	18.1.1	4
+Chrome	136.0.7103.92	desktop	Linux	5.4.0	4
+Chrome	136.0.7103.92	desktop	Linux	6.14.0	4
+Chrome	136.0.7103.92	desktop	Linux	6.14.5	4
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 13.4	4
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 13.5	4
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 13.7	4
+Chrome	136.0.7103.94	desktop	Windows	10	4
+Chrome	136.0.7103.990	mobile	Android	14.0.0	4
+Chrome	137.0.0.0	desktop	Linux	5.4.0	4
+Chrome	137.0.0.0	desktop	Linux	6.12.32	4
+Chrome	137.0.0.0	desktop	Linux	6.14.11	4
+Chrome	137.0.0.0	desktop	Macintosh	Intel 13.4	4
+Chrome	137.0.0.0	desktop	Macintosh	Intel 14.1	4
+Chrome	137.0.0.0	desktop	Macintosh	Intel 15.2	4
+Chrome	137.0.0.0	desktop	Macintosh	Intel 15.6	4
+Chrome	137.0.7151.103	desktop	Linux	6.2.0	4
+Chrome	137.0.7151.103	desktop	Linux	6.9.0	4
+Chrome	137.0.7151.103	desktop	Macintosh	Intel 12.5	4
+Chrome	137.0.7151.103	desktop	Macintosh	Intel 14.2	4
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 11.4	4
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 12.3	4
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 11.7	4
+Chrome	137.0.7151.107	mobile	iOS	16.7.2	4
+Chrome	137.0.7151.112	mobile	Android	13	4
+Chrome	137.0.7151.112	mobile	Android	13.0.0	4
+Chrome	137.0.7151.115	tablet	Android	9.0.0	4
+Chrome	137.0.7151.116	mobile	Android	12.0.0	4
+Chrome	137.0.7151.119	desktop	Linux	6.15.2	4
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 13.7	4
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 26.0	4
+Chrome	137.0.7151.120	mobile	Macintosh	 10.15	4
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 13.0	4
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 11.3	4
+Chrome	137.0.7151.51	mobile	iOS	16.7.11	4
+Chrome	137.0.7151.55	desktop	Linux	6.9.3	4
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 13.4	4
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 13.3	4
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 13.7	4
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 14.0	4
+Chrome	137.0.7151.56	mobile	Android	12.0.0	4
+Chrome	137.0.7151.57	desktop	Macintosh	Intel 15.0	4
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 13.5	4
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 14.3	4
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 12.2	4
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 12.6	4
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 12.7	4
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 13.0	4
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 14.1	4
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 15.0	4
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 15.1	4
+Chrome	137.0.7151.72	tablet	Android	14.0.0	4
+Chrome	137.0.7151.73	mobile	Android	11.0.0	4
+Chrome	137.0.7151.73	mobile	Android	13.0.0	4
+Chrome	137.0.7151.86	desktop	Macintosh	 10.15	4
+Chrome	137.0.7151.86	desktop	Macintosh	Intel 10.15	4
+Chrome	138.0.0.0	desktop	Linux	6.12.33	4
+Chrome	138.0.0.0	desktop	Linux	6.12.37	4
+Chrome	138.0.7204.100	desktop	Linux	5.10.0	4
+Chrome	138.0.7204.100	desktop	Linux	6.12.37	4
+Chrome	138.0.7204.100	desktop	Linux	6.14.5	4
+Chrome	138.0.7204.100	desktop	Linux	6.15.3	4
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 13.5	4
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 16.0	4
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 12.6	4
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 13.2	4
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 13.6	4
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 14.0	4
+Chrome	138.0.7204.119	mobile	iOS	17.4.1	4
+Chrome	138.0.7204.119	mobile	iOS	17.7.0	4
+Chrome	138.0.7204.119	mobile	iOS	17.7.2	4
+Chrome	138.0.7204.156	mobile	iOS	18.3.0	4
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 11.7	4
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 12.6	4
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 13.3	4
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 26.0	4
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 12.4	4
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 13.1	4
+Chrome	138.0.7204.158	mobile	Android	11.0	4
+Chrome	138.0.7204.158	mobile	Macintosh	 10.15	4
+Chrome	138.0.7204.33	mobile	iOS	18.6.0	4
+Chrome	138.0.7204.35	mobile	Android	11.0.0	4
+Chrome	138.0.7204.35	mobile	Android	14.0.0	4
+Chrome	138.0.7204.45	tablet	Android	12.0.0	4
+Chrome	138.0.7204.45	tablet	Android	13.0.0	4
+Chrome	138.0.7204.46	tablet	Android	10.0.0	4
+Chrome	138.0.7204.46	tablet	Android	11.0.0	4
+Chrome	138.0.7204.46	tablet	Android	12.0.0	4
+Chrome	138.0.7204.49	desktop	Linux	6.14.11	4
+Chrome	138.0.7204.49	desktop	Linux	6.14.5	4
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 10.15	4
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 12.4	4
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 13.2	4
+Chrome	138.0.7204.49	mobile	Android	6.0	4
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 13.4	4
+Chrome	138.0.7204.50	mobile	Windows	10	4
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 15.6	4
+Chrome	138.0.7204.56	mobile	iOS	18.4.0	4
+Chrome	138.0.7204.67	mobile	Android	15.0.0	4
+Chrome	138.0.7204.92	desktop	Linux	6.12.25	4
+Chrome	138.0.7204.92	desktop	Linux	6.12.35	4
+Chrome	138.0.7204.92	desktop	Linux	6.4.0	4
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 13.0	4
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 15.6	4
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 11.4	4
+Chrome	138.0.7204.93	mobile	Android	6.0	4
+Chrome	138.0.7204.93	mobile	Macintosh	 15.5	4
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 11.7	4
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 12.6	4
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 13.2	4
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 13.4	4
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 13.5	4
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 13.6	4
+Chrome	138.0.7204.97	desktop	Macintosh	 10.15	4
+Chrome	138.0.7204.97	desktop	Macintosh	Intel 10.15	4
+Chrome	139.0.0.0	desktop	Windows	10	4
+Chrome	139.0.0.0	mobile	Android	10.0.0	4
+Chrome	139.0.7232.3	desktop	Windows	11	4
+Chrome	139.0.7246.0	mobile	Android	13.0.0	4
+Chrome	140.0.7259.2	desktop	Linux	6.11.0	4
+Chrome	140.0.7259.2	desktop	Linux	6.8.0	4
+Chrome	140.0.7259.2	desktop	Macintosh	Intel 15.4	4
+Chrome	140.0.7280.0	desktop	Windows	11	4
+Chrome	140.0.7291.0	desktop	Windows	11	4
+Chrome	140.0.7296.0	desktop	Windows	11	4
+Chrome	140.0.7298.0	desktop	Macintosh	Intel 15.5	4
+Chrome	140.0.7299.0	mobile	Android	13.0.0	4
+Chrome	140.0.7300.0	desktop	Macintosh	Intel 15.5	4
+Chrome	140.0.7300.0	desktop	Windows	10	4
+Chrome	55.0.2883.91	mobile	Android	7.0	4
+Chrome	57.0.2987.133	desktop	Windows	7	4
+Chrome	61.0.3163.128	mobile	Android	12	4
+Chrome	65.0.3325.181	desktop	Macintosh	Intel 10.9	4
+Chrome	66.0.3359.158	mobile	Android	7.1.2	4
+Chrome	67.0.3396.99	desktop	Macintosh	Intel 10.13	4
+Chrome	69.0.3497.100	mobile	Android	8.1.0	4
+Chrome	81.0.4044.0	desktop	Macintosh	Intel 10.14	4
+Chrome	81.0.4044.138	tablet	Android	10	4
+Chrome	84.0.4147.105	desktop	Macintosh	Intel 10.15	4
+Chrome	85.0.4183.83	desktop	Windows	10	4
+Chrome	86.0.4240.198	mobile	Android	15	4
+Chrome	87.0.4280.141	mobile	Android	6.0	4
+Chrome	87.0.4280.88	desktop	Windows	10	4
+Chrome	88.0.4324.150	desktop	Windows	10	4
+Chrome	88.0.4324.181	mobile	Android	10	4
+Chrome	88.0.4324.93	desktop	Windows	10	4
+Chrome	90.0.3112.116	tablet	Android	10	4
+Chrome	91.0.4472.124	desktop	Linux	6.8.0	4
+Chrome	91.0.4472.88	mobile	Android	9	4
+Chrome	93.0.4577.107	mobile	Android	6.0	4
+Chrome	93.0.4577.63	desktop	Macintosh	Intel 10.15	4
+Edge	100.0.1185.36	desktop	Windows	11	4
+Edge	125.0.2535.92	desktop	Windows	10	4
+Edge	129.0.2792.89	desktop	Windows	10	4
+Edge	131.0.2903.51	desktop	Windows	11	4
+Edge	131.0.2903.70	desktop	Windows	11	4
+Edge	133.0.3065.59	desktop	Windows	10	4
+Edge	133.0.3065.59	desktop	Windows	11	4
+Edge	134.0.3124.72	desktop	Windows	10	4
+Edge	134.0.3124.83	desktop	Windows	10	4
+Edge	134.0.3124.85	desktop	Windows	11	4
+Edge	135.0.3179.66	desktop	Windows	11	4
+Edge	136.0.3240.115	desktop	Windows	11	4
+Edge	137.0.100.0	desktop	Windows	10	4
+Edge	137.0.3296.68	desktop	Linux	6.11.0	4
+Edge	137.0.3296.82	mobile	Android	10.0.0	4
+Edge	137.0.3296.83	desktop	Linux	6.8.0	4
+Edge	137.0.3296.93	desktop	Macintosh	Intel 14.4	4
+Edge	137.0.3296.93	desktop	Macintosh	Intel 15.1	4
+Edge	137.0.3296.93	mobile	Windows	11	4
+Edge	138.0.3351.55	mobile	Android	6.0	4
+Edge	138.0.3351.65	desktop	Macintosh	Intel 13.7	4
+Edge	138.0.3351.66	mobile	Android	16.0.0	4
+Edge	138.0.3351.77	desktop	Linux	6.8.0	4
+Edge	138.0.3351.83	desktop	Macintosh	Intel 14.6	4
+Edge	138.0.3351.95	desktop	Macintosh	Intel 14.7	4
+Edge	139.0.3398.0	desktop	Linux	(not set)	4
+Edge	139.0.3405.0	desktop	Windows	11	4
+Edge	139.0.3405.21	desktop	Windows	10	4
+Edge	140.0.3420.0	desktop	Windows	11	4
+Edge	140.0.3446.0	desktop	Windows	11	4
+Edge	90.0.818.66	desktop	Windows	10	4
+Firefox	115.0	desktop	Windows	8	4
+Firefox	124.0	desktop	Windows	10	4
+Firefox	130.0	desktop	Windows	10	4
+Firefox	131.0	desktop	Windows	10	4
+Firefox	139.0	mobile	Android	16	4
+Firefox	141.0	mobile	Android	15	4
+Opera	108.0.0.0	desktop	Windows	10	4
+Opera	113.0.0.0	desktop	Windows	10	4
+Opera	116.0.0.0	desktop	Windows	10	4
+Opera	117.0.0.0	desktop	Macintosh	Intel 10.15	4
+Opera	118.0.0.0	desktop	Linux	(not set)	4
+Opera	44.12.2246.133431	mobile	Android	5.1.1	4
+Opera	62.0.3331.116	desktop	Windows	10	4
+Opera	83.0.0.0	mobile	Android	10	4
+Safari	10.0	mobile	iOS	15.0	4
+Safari	11.1.2	desktop	(not set)	(not set)	4
+Safari	12.0	mobile	iOS	12.0	4
+Safari	15.1	mobile	iOS	15.1	4
+Safari	15.3	desktop	Macintosh	Intel 10.15	4
+Safari	15.6	mobile	iOS	15.7	4
+Safari	15.6.3	mobile	iOS	15.7.1	4
+Safari	15.6.4	mobile	iOS	15.7.3	4
+Safari	15.6.7	tablet	iOS	15.8.4	4
+Safari	16.0.2	mobile	iOS	16.0.2	4
+Safari	16.1.1	mobile	iOS	16.1.1	4
+Safari	16.5.1	desktop	Macintosh	Intel 10.15	4
+Safari	16.6	mobile	iOS	16.7	4
+Safari	16.6	mobile	iOS	16.7.7	4
+Safari	16.7.10	mobile	iOS	16.7.10	4
+Safari	17.0	mobile	iOS	17.0	4
+Safari	17.1	tablet	iOS	17.1	4
+Safari	17.5	mobile	iOS	15.0	4
+Safari	17.6.1	desktop	Macintosh	Intel 10.15	4
+Safari	18.0	mobile	iOS	18.4.1	4
+Safari	18.0	mobile	iOS	18.5	4
+Safari	18.4	tablet	iOS	18.4.1	4
+Safari	26.0	mobile	iOS	26.0.0	4
+Safari	60.5	desktop	Linux	(not set)	4
+Safari	604.1	mobile	iOS	17.7.0	4
+Safari	605.1.15	mobile	iOS	13.6	4
+Safari	605.1.15	mobile	iOS	18.6	4
+Safari	605.1.15	mobile	iOS	26.0	4
+Safari	8.0	desktop	Macintosh	Intel 10.10	4
+Safari (in-app)	(not set)	mobile	iOS	11.3	4
+Safari (in-app)	(not set)	mobile	iOS	16.1.1	4
+Safari (in-app)	(not set)	mobile	iOS	16.7.10	4
+Safari (in-app)	(not set)	mobile	iOS	18.3	4
+Samsung Internet	16.0	mobile	Android	12	4
+Samsung Internet	16.2	mobile	Android	12	4
+Samsung Internet	21.0	mobile	Android	11	4
+Samsung Internet	21.0	mobile	Android	14	4
+Samsung Internet	22.0	mobile	Android	11	4
+Samsung Internet	28.1	mobile	Android	10	4
+Samsung Internet	7.2	mobile	Android	8.0.0	4
+Samsung Internet	7.4	mobile	Android	12	4
+UC Browser	14.7.2.1365	mobile	Android	14	4
+YaBrowser	18.0	tablet	iOS	18.5.0	4
+YaBrowser	23.7.1.1266	desktop	Windows	10	4
+YaBrowser	24.10.0.0	desktop	Linux	(not set)	4
+YaBrowser	25.6.1.95.00	mobile	Android	13	4
+YaBrowser	25.6.2.108.00	mobile	Android	12	4
+YaBrowser	25.6.4.102.00	mobile	Android	14	4
+Aloha Browser	7.3.2	mobile	Android	10	3
+Amazon Silk	124.3.2	tablet	Android	9	3
+Android Browser	5.0	mobile	Android	(not set)	3
+Android Webview	100.0.4896.60	mobile	Android	11	3
+Android Webview	114.0.5735.196	tablet	Android	12	3
+Android Webview	119.0.6045.163	mobile	Android	13	3
+Android Webview	125.0.6422.72	mobile	Android	14	3
+Android Webview	126.0.6478.134	mobile	Android	14	3
+Android Webview	127.0.6533.103	mobile	Android	13	3
+Android Webview	128.0.6613.88	mobile	Android	15	3
+Android Webview	129.0.6668.81	mobile	Android	9	3
+Android Webview	130.0.6723.107	mobile	Android	13	3
+Android Webview	130.0.6723.73	mobile	Android	9	3
+Android Webview	131.0.6778.135	mobile	Android	13	3
+Android Webview	131.0.6778.81	mobile	Android	9	3
+Android Webview	132.0.6834.209	tablet	Android	9	3
+Android Webview	134.0.6998.135	mobile	Android	15	3
+Android Webview	134.0.6998.136	mobile	Android	14	3
+Android Webview	134.0.6998.136	mobile	Android	15	3
+Android Webview	134.0.6998.207	tablet	Android	11	3
+Android Webview	134.0.6998.39	mobile	Android	14	3
+Android Webview	135.0.7049.100	mobile	Android	12	3
+Android Webview	135.0.7049.110	mobile	Android	11	3
+Android Webview	135.0.7049.111	mobile	Android	8.1.0	3
+Android Webview	135.0.7049.113	mobile	Android	11	3
+Android Webview	135.0.7049.38	mobile	Android	11	3
+Android Webview	136.0.7103.126	mobile	Android	10	3
+Android Webview	136.0.7103.127	mobile	Android	10	3
+Android Webview	136.0.7103.88	mobile	Android	9	3
+Android Webview	137.0.7151.109	mobile	Android	12	3
+Android Webview	137.0.7151.109	mobile	Android	14	3
+Android Webview	137.0.7151.112	tablet	Android	15	3
+Android Webview	137.0.7151.116	tablet	Android	15	3
+Android Webview	137.0.7151.117	tablet	Android	13	3
+Android Webview	137.0.7151.118	tablet	Android	11	3
+Android Webview	137.0.7151.52	mobile	Android	11	3
+Android Webview	137.0.7151.84	mobile	Android	13	3
+Android Webview	137.0.7151.88	mobile	Android	15	3
+Android Webview	137.0.7151.89	tablet	Android	13	3
+Android Webview	137.0.7151.91	mobile	Android	15	3
+Android Webview	138.0.0.0	mobile	Android	14	3
+Android Webview	138.0.7204.139	mobile	Android	11	3
+Android Webview	138.0.7204.143	mobile	Android	15	3
+Android Webview	138.0.7204.150	mobile	Android	15	3
+Android Webview	138.0.7204.157	mobile	Android	8.1.0	3
+Android Webview	138.0.7204.157	tablet	Android	15	3
+Android Webview	138.0.7204.32	mobile	Android	10	3
+Android Webview	138.0.7204.32	mobile	Android	12	3
+Android Webview	138.0.7204.35	mobile	Android	10	3
+Android Webview	138.0.7204.63	tablet	Android	14	3
+Android Webview	138.0.7204.68	tablet	Android	13	3
+Android Webview	138.0.7204.68	tablet	Android	14	3
+Android Webview	139.0.7258.32	mobile	Android	11	3
+Android Webview	139.0.7258.41	mobile	Android	11	3
+Android Webview	139.0.7258.41	mobile	Android	13	3
+Android Webview	55.0.2883.91	mobile	Android	7.0	3
+Android Webview	57.0.2987.132	mobile	Android	7.1.1	3
+Android Webview	62.0.3202.84	mobile	Android	10	3
+Android Webview	62.0.3202.84	mobile	Android	12	3
+Android Webview	62.0.3202.84	mobile	Android	9	3
+Android Webview	64.0.3282.137	mobile	Android	7.1.1	3
+Android Webview	66.0.3359.158	mobile	Android	9	3
+Android Webview	68.0.3440.91	mobile	Android	8.1.0	3
+Android Webview	69.0.3497.100	mobile	Android	8.0.0	3
+Android Webview	69.0.3497.100	mobile	Android	8.1.0	3
+Android Webview	70.0.3538.110	tablet	Android	8.0.0	3
+Android Webview	78.0.3904.108	mobile	Android	10	3
+Android Webview	83.0.4103.120	mobile	Android	12	3
+Android Webview	87.0.4280.141	mobile	Android	12	3
+Android Webview	87.0.4280.141	mobile	Android	14	3
+Android Webview	92.0.4515.131	mobile	Android	11	3
+Chrome	(not set)	desktop	Windows	Server 2003	3
+Chrome	100.0.4896.127	mobile	Android	13	3
+Chrome	102.0.5005.125	desktop	Chrome OS	x86_64 14695.107.0	3
+Chrome	103.0.5060.15	desktop	Chrome OS	x86_64 14816.17.0	3
+Chrome	105.0.5195.127	desktop	Windows	10	3
+Chrome	105.0.5195.136	mobile	Android	12	3
+Chrome	106.0.0.0	desktop	Windows	7	3
+Chrome	107.0.0.0	desktop	Linux	(not set)	3
+Chrome	107.0.0.0	mobile	Android	15.0.0	3
+Chrome	107.0.5304.105	mobile	Android	12.0.0	3
+Chrome	107.0.5304.107	desktop	Windows	10	3
+Chrome	108.0.5359.125	desktop	Windows	8.1	3
+Chrome	109.0.5414.75	desktop	Windows	11	3
+Chrome	110.0.0.0	desktop	Windows	10	3
+Chrome	110.0.5481.77	desktop	Linux	5.10.0	3
+Chrome	111.0.5563.116	mobile	Android	12.0.0	3
+Chrome	112.0.5615.138	desktop	Windows	10	3
+Chrome	112.0.5615.138	desktop	Windows	11	3
+Chrome	113.0.5672.126	desktop	Linux	5.15.0	3
+Chrome	114.0.5735.110	desktop	Windows	10	3
+Chrome	114.0.5735.110	desktop	Windows	11	3
+Chrome	114.0.5735.130	mobile	Android	12	3
+Chrome	114.0.5735.134	desktop	Windows	11	3
+Chrome	114.0.5735.196	mobile	Android	11.0.0	3
+Chrome	114.0.5735.199	desktop	Windows	11	3
+Chrome	114.0.5735.60	mobile	Android	13	3
+Chrome	115.0.5790.138	mobile	Android	12.0.0	3
+Chrome	115.0.5790.166	mobile	Android	11.0.0	3
+Chrome	115.0.5790.168	mobile	Android	14.0.0	3
+Chrome	115.0.5790.168	mobile	Android	9	3
+Chrome	116.0.5845.110	desktop	Linux	5.15.77	3
+Chrome	116.0.5845.190	desktop	Windows	10	3
+Chrome	118.0.5993.118	desktop	Windows	11	3
+Chrome	118.0.5993.89	desktop	Windows	11	3
+Chrome	119.0.6045.159	desktop	Linux	5.15.0	3
+Chrome	119.0.6045.194	mobile	Android	7.0.0	3
+Chrome	119.0.6045.194	mobile	Android	7.1.2	3
+Chrome	119.0.6045.199	desktop	Linux	6.8.0	3
+Chrome	120.0.6099.110	desktop	Windows	10	3
+Chrome	120.0.6099.115	mobile	Android	11.0.0	3
+Chrome	120.0.6099.144	mobile	Android	13.0.0	3
+Chrome	120.0.6099.199	desktop	Windows	10	3
+Chrome	120.0.6099.216	desktop	Windows	11	3
+Chrome	120.0.6099.217	desktop	Windows	11	3
+Chrome	120.0.6099.224	desktop	Windows	10	3
+Chrome	120.0.6099.230	mobile	Android	10.0.0	3
+Chrome	120.0.6099.71	desktop	Windows	11	3
+Chrome	121.0.6167.160	desktop	Linux	6.8.0	3
+Chrome	121.0.6167.161	desktop	Windows	11	3
+Chrome	121.0.6167.178	mobile	Android	12.0.0	3
+Chrome	121.0.6167.184	desktop	Linux	6.8.0	3
+Chrome	122.0.0.0	mobile	Android	10	3
+Chrome	122.0.6261.111	desktop	Linux	6.8.0	3
+Chrome	122.0.6261.112	desktop	Macintosh	Intel 15.5	3
+Chrome	122.0.6261.113	desktop	Windows	10	3
+Chrome	122.0.6261.119	mobile	Android	10.0.0	3
+Chrome	122.0.6261.119	mobile	Android	14	3
+Chrome	122.0.6261.119	mobile	Android	9	3
+Chrome	122.0.6261.131	desktop	Windows	10	3
+Chrome	122.0.6261.70	desktop	Windows	10	3
+Chrome	123.0.6312.105	desktop	Linux	6.8.0	3
+Chrome	123.0.6312.118	desktop	Linux	9.0.0	3
+Chrome	123.0.6312.122	desktop	Windows	10	3
+Chrome	123.0.6312.122	desktop	Windows	11	3
+Chrome	123.0.6312.124	desktop	Macintosh	Intel 14.5	3
+Chrome	123.0.6312.124	desktop	Windows	11	3
+Chrome	123.0.6312.59	desktop	Windows	11	3
+Chrome	123.0.6312.60	desktop	Windows	10	3
+Chrome	123.0.6312.80	mobile	Android	13.0.0	3
+Chrome	123.0.6312.86	desktop	Linux	5.15.0	3
+Chrome	123.0.6312.86	desktop	Windows	11	3
+Chrome	124.0.0.0	mobile	Android	10.0.0	3
+Chrome	124.0.0.0	mobile	Android	11	3
+Chrome	124.0.0.0	mobile	Android	13.0.0	3
+Chrome	124.0.0.0	mobile	Android	9	3
+Chrome	124.0.6327.1	mobile	Android	10.0.0	3
+Chrome	124.0.6327.2	mobile	Android	10.0.0	3
+Chrome	124.0.6367.113	mobile	Android	10.0.0	3
+Chrome	124.0.6367.18	mobile	Android	12.0.0	3
+Chrome	124.0.6367.201	desktop	Windows	10	3
+Chrome	124.0.6367.208	desktop	Windows	10	3
+Chrome	124.61.1.50292	desktop	Macintosh	Intel 15.5	3
+Chrome	125.0.6422.113	mobile	Android	11.0.0	3
+Chrome	125.0.6422.141	desktop	Linux	5.15.0	3
+Chrome	125.0.6422.142	desktop	Macintosh	Intel 15.5	3
+Chrome	125.0.6422.165	mobile	Android	12.0.0	3
+Chrome	125.0.6422.165	mobile	Android	8.1.0	3
+Chrome	125.0.6422.165	mobile	Android	9.0.0	3
+Chrome	125.0.6422.60	desktop	Windows	10	3
+Chrome	125.0.6422.72	mobile	Android	8.1.0	3
+Chrome	125.0.6422.78	desktop	Windows	11	3
+Chrome	126.0.0.0	desktop	Linux	6.6.72	3
+Chrome	126.0.6478.114	desktop	Windows	11	3
+Chrome	126.0.6478.115	desktop	Windows	11	3
+Chrome	126.0.6478.127	desktop	Macintosh	Intel 14.4	3
+Chrome	126.0.6478.127	desktop	Macintosh	Intel 14.5	3
+Chrome	126.0.6478.153	mobile	iOS	18.5	3
+Chrome	126.0.6478.186	mobile	Android	12.0.0	3
+Chrome	126.0.6478.57	desktop	Windows	10	3
+Chrome	126.0.6478.61	desktop	Linux	5.15.0	3
+Chrome	126.0.6478.62	desktop	Windows	10	3
+Chrome	126.0.6478.71	mobile	Android	13	3
+Chrome	126.0.6478.71	tablet	Android	14.0.0	3
+Chrome	127.0.0.0	mobile	Android	14.0.0	3
+Chrome	127.0.6533.100	desktop	Windows	11	3
+Chrome	127.0.6533.101	mobile	Android	13	3
+Chrome	127.0.6533.103	mobile	Android	15	3
+Chrome	127.0.6533.103	mobile	Android	8.1.0	3
+Chrome	127.0.6533.72	desktop	Linux	5.15.0	3
+Chrome	127.0.6533.73	desktop	Macintosh	Intel 15.5	3
+Chrome	127.0.6533.84	mobile	Android	12.0.0	3
+Chrome	127.0.6533.89	desktop	Macintosh	Intel 15.5	3
+Chrome	128.0.6613.120	desktop	Macintosh	Intel 14.6	3
+Chrome	128.0.6613.120	desktop	Macintosh	Intel 15.5	3
+Chrome	128.0.6613.128	mobile	Android	10.0.0	3
+Chrome	128.0.6613.138	desktop	Macintosh	Intel 15.4	3
+Chrome	128.0.6613.147	mobile	Android	14.0.0	3
+Chrome	128.0.6613.148	desktop	Macintosh	Intel 10.15	3
+Chrome	129.0.6668.100	mobile	Android	15.0.0	3
+Chrome	129.0.6668.58	desktop	Linux	6.11.0	3
+Chrome	129.0.6668.58	desktop	Windows	10	3
+Chrome	129.0.6668.70	mobile	Android	10.0.0	3
+Chrome	129.0.6668.89	desktop	Windows	10	3
+Chrome	130.0.6723.102	mobile	Android	9.0.0	3
+Chrome	130.0.6723.103	mobile	Android	11.0.0	3
+Chrome	130.0.6723.116	desktop	Linux	6.2.0	3
+Chrome	130.0.6723.40	mobile	Android	11.0.0	3
+Chrome	130.0.6723.58	mobile	Android	10.0.0	3
+Chrome	130.0.6723.60	desktop	Macintosh	Intel 15.5	3
+Chrome	130.0.6723.69	desktop	Linux	6.11.0	3
+Chrome	130.0.6723.73	mobile	Android	10.0.0	3
+Chrome	130.0.6723.87	mobile	Android	14.0.0	3
+Chrome	130.0.6723.91	desktop	Linux	5.4.0	3
+Chrome	130.0.6723.91	mobile	Android	14.0.0	3
+Chrome	130.0.6723.92	desktop	Macintosh	Intel 14.6	3
+Chrome	131.0.0.0	mobile	Android	10	3
+Chrome	131.0.6778.104	mobile	Android	14	3
+Chrome	131.0.6778.108	desktop	Linux	6.11.0	3
+Chrome	131.0.6778.135	mobile	Android	10.0.0	3
+Chrome	131.0.6778.135	mobile	Android	8.1.0	3
+Chrome	131.0.6778.139	desktop	Linux	5.4.0	3
+Chrome	131.0.6778.139	desktop	Linux	6.6.68	3
+Chrome	131.0.6778.139	desktop	Windows	10	3
+Chrome	131.0.6778.200	mobile	Android	15.0.0	3
+Chrome	131.0.6778.200	mobile	Android	8.1.0	3
+Chrome	131.0.6778.205	desktop	Macintosh	Intel 14.6	3
+Chrome	131.0.6778.205	desktop	Macintosh	Intel 15.1	3
+Chrome	131.0.6778.260	mobile	Android	8.1.0	3
+Chrome	131.0.6778.261	mobile	Android	11.0.0	3
+Chrome	131.0.6778.261	mobile	Android	12.0.0	3
+Chrome	131.0.6778.261	mobile	Android	14.0.0	3
+Chrome	131.0.6778.261	mobile	Android	15.0.0	3
+Chrome	131.0.6778.265	desktop	Macintosh	Intel 14.3	3
+Chrome	131.0.6778.2658	desktop	Windows	10	3
+Chrome	131.0.6778.266	desktop	Windows	10	3
+Chrome	131.0.6778.39	mobile	Android	12.0.0	3
+Chrome	131.0.6778.39	mobile	Android	14.0.0	3
+Chrome	131.0.6778.69	desktop	Linux	5.4.0	3
+Chrome	131.0.6778.69	desktop	Linux	6.11.0	3
+Chrome	131.0.6778.85	desktop	Linux	6.11.0	3
+Chrome	131.0.6778.85	desktop	Linux	6.2.0	3
+Chrome	131.0.6778.86	desktop	Macintosh	Intel 14.5	3
+Chrome	132.0.0.0	desktop	Macintosh	Intel 15.5	3
+Chrome	132.0.6834.110	desktop	Linux	6.5.0	3
+Chrome	132.0.6834.122	mobile	Android	12.0.0	3
+Chrome	132.0.6834.122	mobile	Android	15.0.0	3
+Chrome	132.0.6834.159	desktop	Linux	5.4.0	3
+Chrome	132.0.6834.206	desktop	Chrome OS	x86_64 16093.91.0	3
+Chrome	132.0.6834.227	desktop	Chrome OS	aarch64 16093.109.0	3
+Chrome	132.0.6834.578	mobile	Android	15.0.0	3
+Chrome	132.0.6834.79	mobile	Android	13.0.0	3
+Chrome	132.0.6834.79	mobile	Android	14.0.0	3
+Chrome	132.0.6834.80	mobile	Android	13.0.0	3
+Chrome	132.0.6834.83	desktop	Linux	6.15.2	3
+Chrome	133	desktop	Macintosh	Intel 14.2	3
+Chrome	133.0.0.0	desktop	Linux	6.12.13	3
+Chrome	133.0.0.0	desktop	Macintosh	Intel 15.3	3
+Chrome	133.0.0.0	mobile	Android	10	3
+Chrome	133.0.0.0	mobile	Android	10.0.0	3
+Chrome	133.0.6943.127	desktop	Macintosh	Intel 13.5	3
+Chrome	133.0.6943.127	desktop	Macintosh	Intel 15.0	3
+Chrome	133.0.6943.127	desktop	Macintosh	Intel 15.1	3
+Chrome	133.0.6943.128	desktop	Windows	10	3
+Chrome	133.0.6943.132	desktop	Chrome OS	x86_64 16151.47.0	3
+Chrome	133.0.6943.138	mobile	Android	10.0.0	3
+Chrome	133.0.6943.141	desktop	Windows	11	3
+Chrome	133.0.6943.142	desktop	Macintosh	Intel 13.4	3
+Chrome	133.0.6943.142	desktop	Macintosh	Intel 14.6	3
+Chrome	133.0.6943.142	desktop	Macintosh	Intel 15.0	3
+Chrome	133.0.6943.143	desktop	Macintosh	Intel 15.5	3
+Chrome	133.0.6943.49	mobile	Android	10.0.0	3
+Chrome	133.0.6943.50	mobile	Android	15.0.0	3
+Chrome	133.0.6943.53	desktop	Linux	6.5.0	3
+Chrome	133.0.6943.55	desktop	Macintosh	Intel 14.4	3
+Chrome	133.0.6943.59	desktop	Windows	10	3
+Chrome	133.0.6943.59	desktop	Windows	11	3
+Chrome	133.0.6943.89	mobile	Android	12.0.0	3
+Chrome	133.0.6943.98	desktop	Macintosh	Intel 15.3	3
+Chrome	133.0.6943.99	desktop	Macintosh	Intel 14.3	3
+Chrome	133.0.6943.99	desktop	Macintosh	Intel 15.3	3
+Chrome	134.0.0.0	mobile	Android	6.0	3
+Chrome	134.0.6998.109	mobile	Android	14.0.0	3
+Chrome	134.0.6998.117	desktop	Macintosh	Intel 10.15	3
+Chrome	134.0.6998.118	desktop	Macintosh	Intel 13.4	3
+Chrome	134.0.6998.118	desktop	Macintosh	Intel 14.5	3
+Chrome	134.0.6998.118	desktop	Macintosh	Intel 14.7	3
+Chrome	134.0.6998.118	desktop	Macintosh	Intel 15.1	3
+Chrome	134.0.6998.205	desktop	Macintosh	Intel 15.4	3
+Chrome	134.0.6998.39	mobile	Android	15.0.0	3
+Chrome	134.0.6998.39	mobile	Android	8.1.0	3
+Chrome	134.0.6998.44	desktop	Macintosh	Intel 14.4	3
+Chrome	134.0.6998.44	desktop	Macintosh	Intel 15.5	3
+Chrome	134.0.6998.88	desktop	Linux	6.13.6	3
+Chrome	134.0.6998.89	desktop	Macintosh	Intel 12.6	3
+Chrome	134.0.6998.89	desktop	Macintosh	Intel 13.2	3
+Chrome	134.0.6998.89	desktop	Macintosh	Intel 14.3	3
+Chrome	134.0.6998.89	desktop	Macintosh	Intel 14.4	3
+Chrome	134.0.6998.89	desktop	Macintosh	Intel 14.6	3
+Chrome	134.0.6998.89	desktop	Macintosh	Intel 15.0	3
+Chrome	134.0.6998.895	mobile	Android	13.0.0	3
+Chrome	134.0.6998.895	mobile	Android	15.0.0	3
+Chrome	134.0.6998.96	mobile	Android	12.0.0	3
+Chrome	135	mobile	iOS	(not set)	3
+Chrome	135.0.0.0	desktop	Macintosh	Intel 14.2	3
+Chrome	135.0.7049.101	mobile	Android	10.0.0	3
+Chrome	135.0.7049.101	mobile	Android	13.0.0	3
+Chrome	135.0.7049.104	desktop	Chrome OS	aarch64 16209.50.0	3
+Chrome	135.0.7049.113	mobile	Android	12.0.0	3
+Chrome	135.0.7049.113	mobile	Android	14.0.0	3
+Chrome	135.0.7049.114	desktop	Linux	5.19.0	3
+Chrome	135.0.7049.114	desktop	Macintosh	Intel 14.5	3
+Chrome	135.0.7049.114	desktop	Macintosh	Intel 15.0	3
+Chrome	135.0.7049.114	desktop	Windows	11	3
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 13.7	3
+Chrome	135.0.7049.116	desktop	Macintosh	Intel 14.2	3
+Chrome	135.0.7049.116	desktop	Macintosh	Intel 14.5	3
+Chrome	135.0.7049.38	mobile	Android	11.0.0	3
+Chrome	135.0.7049.38	mobile	Android	15.0.0	3
+Chrome	135.0.7049.39	mobile	Android	12.0.0	3
+Chrome	135.0.7049.41	desktop	Windows	11	3
+Chrome	135.0.7049.42	desktop	Macintosh	Intel 14.4	3
+Chrome	135.0.7049.42	desktop	Macintosh	Intel 14.6	3
+Chrome	135.0.7049.42	desktop	Macintosh	Intel 15.1	3
+Chrome	135.0.7049.42	desktop	Macintosh	Intel 15.4	3
+Chrome	135.0.7049.52	desktop	Linux	6.12.10	3
+Chrome	135.0.7049.80	mobile	Android	15.0.0	3
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 14.5	3
+Chrome	135.0.7049.95	desktop	Linux	6.14.0	3
+Chrome	135.0.7049.95	desktop	Windows	11	3
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 12.7	3
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 13.6	3
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 14.7	3
+Chrome	136.0.0.0	desktop	Linux	5.15.0	3
+Chrome	136.0.0.0	desktop	Linux	6.11.0	3
+Chrome	136.0.0.0	desktop	Linux	6.12.10	3
+Chrome	136.0.0.0	mobile	Android	10.0.0	3
+Chrome	136.0.7103.113	desktop	Linux	5.19.0	3
+Chrome	136.0.7103.113	desktop	Linux	6.12.25	3
+Chrome	136.0.7103.113	desktop	Linux	6.12.34	3
+Chrome	136.0.7103.113	desktop	Linux	6.14.6	3
+Chrome	136.0.7103.113	desktop	Linux	6.14.7	3
+Chrome	136.0.7103.113	desktop	Linux	6.9.3	3
+Chrome	136.0.7103.113	desktop	Macintosh	Intel 15.3	3
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 12.1	3
+Chrome	136.0.7103.115	desktop	Macintosh	Intel 15.5	3
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 14.3	3
+Chrome	136.0.7103.127	mobile	Android	11.0.0	3
+Chrome	136.0.7103.127	mobile	Android	12.0.0	3
+Chrome	136.0.7103.127	mobile	Android	13.0.0	3
+Chrome	136.0.7103.127	mobile	Android	8.1.0	3
+Chrome	136.0.7103.142	desktop	Chrome OS	aarch64 16238.54.0	3
+Chrome	136.0.7103.150	desktop	Chrome OS	aarch64 16238.62.0	3
+Chrome	136.0.7103.158	desktop	Chrome OS	aarch64 16238.64.0	3
+Chrome	136.0.7103.1838	mobile	iOS	18.5.0	3
+Chrome	136.0.7103.204	mobile	Android	15.0.0	3
+Chrome	136.0.7103.48	desktop	Macintosh	Intel 14.2	3
+Chrome	136.0.7103.48	desktop	Macintosh	Intel 14.5	3
+Chrome	136.0.7103.49	desktop	Macintosh	Intel 14.7	3
+Chrome	136.0.7103.49	desktop	Macintosh	Intel 15.4	3
+Chrome	136.0.7103.56	tablet	iOS	18.5.0	3
+Chrome	136.0.7103.60	mobile	Android	13	3
+Chrome	136.0.7103.61	mobile	Android	13.0.0	3
+Chrome	136.0.7103.88	mobile	Android	15.0.0	3
+Chrome	136.0.7103.896	mobile	Android	13.0.0	3
+Chrome	136.0.7103.91	mobile	iOS	16.7.11	3
+Chrome	136.0.7103.91	mobile	iOS	17.4.1	3
+Chrome	136.0.7103.91	mobile	iOS	18.3.1	3
+Chrome	136.0.7103.92	desktop	Macintosh	Intel 15.3	3
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 12.2	3
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 13.2	3
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 13.6	3
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 14.2	3
+Chrome	136.0.7103.94	desktop	Macintosh	Intel 15.5	3
+Chrome	136.0.7103.94	desktop	Windows	11	3
+Chrome	136.0.7103.961	mobile	Android	13.0.0	3
+Chrome	136.0.7103.990	mobile	Android	15.0.0	3
+Chrome	137.0.0.0	desktop	Linux	5.14.0	3
+Chrome	137.0.0.0	desktop	Linux	6.12.28	3
+Chrome	137.0.0.0	desktop	Linux	6.14.0	3
+Chrome	137.0.0.0	desktop	Linux	6.6.84	3
+Chrome	137.0.0.0	desktop	Macintosh	Intel 12.7	3
+Chrome	137.0.0.0	desktop	Macintosh	Intel 14.2	3
+Chrome	137.0.0.0	desktop	Macintosh	Intel 14.3	3
+Chrome	137.0.0.0	mobile	Android	11.0	3
+Chrome	137.0.3296.92	mobile	iOS	19.0.0	3
+Chrome	137.0.7117.2	desktop	Windows	10	3
+Chrome	137.0.7151.100	mobile	Android	13.0.0	3
+Chrome	137.0.7151.103	desktop	Macintosh	Intel 13.7	3
+Chrome	137.0.7151.103	desktop	Macintosh	Intel 15.2	3
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 15.6	3
+Chrome	137.0.7151.104	mobile	Android	11.0	3
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 12.3	3
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 13.0	3
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 13.2	3
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 14.2	3
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 15.0	3
+Chrome	137.0.7151.107	mobile	iOS	16.1.0	3
+Chrome	137.0.7151.107	mobile	iOS	16.1.1	3
+Chrome	137.0.7151.107	mobile	iOS	16.3.1	3
+Chrome	137.0.7151.107	mobile	iOS	17.2.1	3
+Chrome	137.0.7151.107	tablet	iOS	17.6.1	3
+Chrome	137.0.7151.107	tablet	iOS	17.7.8	3
+Chrome	137.0.7151.107	tablet	iOS	18.3.2	3
+Chrome	137.0.7151.112	mobile	Android	12	3
+Chrome	137.0.7151.115	desktop	Linux	(not set)	3
+Chrome	137.0.7151.115	tablet	Android	16.0.0	3
+Chrome	137.0.7151.115	tablet	Android	8.0.0	3
+Chrome	137.0.7151.117	tablet	Android	13.0.0	3
+Chrome	137.0.7151.119	desktop	Linux	5.10.134	3
+Chrome	137.0.7151.119	desktop	Linux	6.14.6	3
+Chrome	137.0.7151.119	desktop	Linux	6.14.9	3
+Chrome	137.0.7151.119	desktop	Linux	6.5.0	3
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 10.15	3
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 12.7	3
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 13.5	3
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 14.1	3
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 14.2	3
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 14.3	3
+Chrome	137.0.7151.120	desktop	Macintosh	Intel 11.0	3
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 13.6	3
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 13.7	3
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 15.2	3
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 11.2	3
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 11.5	3
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 13.1	3
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 26.0	3
+Chrome	137.0.7151.40	desktop	Macintosh	Intel 15.5	3
+Chrome	137.0.7151.41	desktop	Macintosh	Intel 15.0	3
+Chrome	137.0.7151.41	desktop	Macintosh	Intel 15.2	3
+Chrome	137.0.7151.41	desktop	Macintosh	Intel 15.4	3
+Chrome	137.0.7151.51	mobile	iOS	18.6.0	3
+Chrome	137.0.7151.55	desktop	Linux	6.1.0	3
+Chrome	137.0.7151.55	desktop	Linux	6.12.28	3
+Chrome	137.0.7151.55	desktop	Linux	6.14.9	3
+Chrome	137.0.7151.55	desktop	Linux	6.5.0	3
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 13.7	3
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 15.0	3
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 12.6	3
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 13.2	3
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 14.2	3
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 15.0	3
+Chrome	137.0.7151.56	mobile	Android	10.0.0	3
+Chrome	137.0.7151.57	desktop	Macintosh	Intel 14.1	3
+Chrome	137.0.7151.57	desktop	Macintosh	Intel 15.2	3
+Chrome	137.0.7151.57	desktop	Macintosh	Intel 15.4	3
+Chrome	137.0.7151.62	mobile	Android	10.0.0	3
+Chrome	137.0.7151.62	mobile	Android	11.0.0	3
+Chrome	137.0.7151.62	mobile	Android	14.0.0	3
+Chrome	137.0.7151.68	desktop	Linux	4.18.0	3
+Chrome	137.0.7151.68	desktop	Linux	6.12.25	3
+Chrome	137.0.7151.68	desktop	Linux	6.14.10	3
+Chrome	137.0.7151.68	desktop	Linux	6.15.4	3
+Chrome	137.0.7151.68	desktop	Linux	6.6.87	3
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 15.2	3
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 16.0	3
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 11.7	3
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 13.7	3
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 14.2	3
+Chrome	137.0.7151.73	mobile	Android	10.0.0	3
+Chrome	137.0.7151.79	mobile	iOS	16.7.11	3
+Chrome	137.0.7151.79	mobile	iOS	18.3.1	3
+Chrome	137.0.7151.79	mobile	iOS	18.3.2	3
+Chrome	137.0.7151.80	mobile	Android	14	3
+Chrome	137.0.7151.80	mobile	Android	14.0.0	3
+Chrome	137.0.7151.89	mobile	Android	10	3
+Chrome	137.0.7151.89	tablet	Android	11.0.0	3
+Chrome	137.0.7151.90	mobile	Android	11	3
+Chrome	137.0.7151.90	mobile	Android	8.1.0	3
+Chrome	137.0.7151.90	mobile	Android	9.0.0	3
+Chrome	138.0.0.0	desktop	Linux	6.6.76	3
+Chrome	138.0.0.0	desktop	Macintosh	Intel 14.2	3
+Chrome	138.0.0.0	desktop	Macintosh	Intel 14.3	3
+Chrome	138.0.0.0	mobile	Android	11.0	3
+Chrome	138.0.7178.0	mobile	Android	14.0.0	3
+Chrome	138.0.7204.100	desktop	Linux	6.11.1	3
+Chrome	138.0.7204.100	desktop	Linux	6.2.0	3
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 14.0	3
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 11.1	3
+Chrome	138.0.7204.101	mobile	Macintosh	 10.15	3
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 13.0	3
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 14.1	3
+Chrome	138.0.7204.102	mobile	Android	11.0	3
+Chrome	138.0.7204.119	mobile	iOS	17.1.1	3
+Chrome	138.0.7204.119	mobile	iOS	17.1.2	3
+Chrome	138.0.7204.119	mobile	iOS	18.2.0	3
+Chrome	138.0.7204.119	tablet	iOS	17.6.1	3
+Chrome	138.0.7204.139	mobile	Android	14.0.0	3
+Chrome	138.0.7204.143	desktop	Linux	6.15.4	3
+Chrome	138.0.7204.156	mobile	iOS	18.1.1	3
+Chrome	138.0.7204.157	desktop	Linux	5.14.0	3
+Chrome	138.0.7204.157	desktop	Linux	6.12.39	3
+Chrome	138.0.7204.157	desktop	Linux	6.15.4	3
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 11.6	3
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 13.5	3
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 15.6	3
+Chrome	138.0.7204.157	mobile	Android	10	3
+Chrome	138.0.7204.162	desktop	Macintosh	Intel 15.5	3
+Chrome	138.0.7204.162	desktop	Windows	10	3
+Chrome	138.0.7204.33	mobile	iOS	18.3.2	3
+Chrome	138.0.7204.4	desktop	Macintosh	Intel 15.5	3
+Chrome	138.0.7204.42	mobile	Android	14	3
+Chrome	138.0.7204.42	mobile	Android	14.0.0	3
+Chrome	138.0.7204.45	tablet	Android	11.0.0	3
+Chrome	138.0.7204.49	desktop	Linux	4.18.0	3
+Chrome	138.0.7204.49	desktop	Linux	5.10.0	3
+Chrome	138.0.7204.49	desktop	Linux	5.14.0	3
+Chrome	138.0.7204.49	desktop	Linux	6.11.9	3
+Chrome	138.0.7204.49	desktop	Linux	6.12.32	3
+Chrome	138.0.7204.49	desktop	Linux	6.12.33	3
+Chrome	138.0.7204.49	desktop	Linux	6.14.6	3
+Chrome	138.0.7204.49	desktop	Linux	6.15.0	3
+Chrome	138.0.7204.49	desktop	Linux	6.15.2	3
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 11.2	3
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 11.4	3
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 12.3	3
+Chrome	138.0.7204.49	mobile	Macintosh	 15.5	3
+Chrome	138.0.7204.49	mobile	Windows	11	3
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 10.15	3
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 13.0	3
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 14.0	3
+Chrome	138.0.7204.50	mobile	Android	6.0	3
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 11.6	3
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 12.1	3
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 13.1	3
+Chrome	138.0.7204.51	mobile	Android	11.0	3
+Chrome	138.0.7204.51	mobile	Android	6.0	3
+Chrome	138.0.7204.51	mobile	Windows	10	3
+Chrome	138.0.7204.53	tablet	iOS	18.5.0	3
+Chrome	138.0.7204.56	mobile	iOS	17.5.1	3
+Chrome	138.0.7204.56	mobile	iOS	18.3.2	3
+Chrome	138.0.7204.56	mobile	iOS	18.4.1	3
+Chrome	138.0.7204.63	tablet	Android	8.1.0	3
+Chrome	138.0.7204.63	tablet	Android	9.0.0	3
+Chrome	138.0.7204.64	tablet	Android	12.0.0	3
+Chrome	138.0.7204.92	desktop	Linux	5.10.0	3
+Chrome	138.0.7204.92	desktop	Linux	6.12.36	3
+Chrome	138.0.7204.92	desktop	Linux	6.2.0	3
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 12.2	3
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 11.1	3
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 11.2	3
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 12.2	3
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 13.3	3
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 14.0	3
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 14.1	3
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 15.6	3
+Chrome	139.0.0.0	tablet	Android	14.0.0	3
+Chrome	139.0.7232.3	desktop	Macintosh	Intel 15.5	3
+Chrome	139.0.7258.3	mobile	Android	13	3
+Chrome	139.0.7258.32	mobile	Android	14	3
+Chrome	139.0.7258.32	mobile	Android	15	3
+Chrome	139.0.7258.32	mobile	Android	16.0.0	3
+Chrome	139.0.7258.33	desktop	Chrome OS	aarch64 16328.18.0	3
+Chrome	139.0.7258.41	mobile	Android	15	3
+Chrome	139.0.7258.41	mobile	Android	16.0.0	3
+Chrome	139.0.7258.5	desktop	Macintosh	Intel 12.7	3
+Chrome	140.0.7259.0	mobile	Android	10.0.0	3
+Chrome	140.0.7259.0	mobile	Android	16.0.0	3
+Chrome	140.0.7259.2	desktop	Macintosh	Intel 15.3	3
+Chrome	140.0.7260.0	desktop	Macintosh	Intel 15.5	3
+Chrome	140.0.7261.0	desktop	Windows	11	3
+Chrome	140.0.7265.0	desktop	Macintosh	Intel 15.5	3
+Chrome	140.0.7277.0	desktop	Macintosh	Intel 15.5	3
+Chrome	140.0.7280.0	desktop	Macintosh	Intel 15.5	3
+Chrome	140.0.7281.0	desktop	Macintosh	Intel 10.15	3
+Chrome	140.0.7282.0	desktop	Macintosh	Intel 15.5	3
+Chrome	140.0.7282.0	desktop	Windows	11	3
+Chrome	140.0.7284.0	desktop	Macintosh	Intel 15.5	3
+Chrome	140.0.7297.0	desktop	Macintosh	Intel 15.5	3
+Chrome	140.0.7302.0	desktop	Windows	11	3
+Chrome	140.0.7308.0	desktop	Macintosh	Intel 15.5	3
+Chrome	18.0.1025.133	mobile	Android	8.1.0	3
+Chrome	56.0.2924.87	mobile	Android	7.1.1	3
+Chrome	59.0.3071.92	mobile	Android	5.1	3
+Chrome	63.0.3239.111	mobile	Android	8.0.0	3
+Chrome	66.0.3359.158	desktop	Windows	10	3
+Chrome	77.0.3865.92	mobile	Android	9	3
+Chrome	80.0.3987.149	mobile	Android	10	3
+Chrome	83.0.4103.106	desktop	Windows	10	3
+Chrome	83.0.4103.116	desktop	Macintosh	Intel 10.15	3
+Chrome	85.0.4183.127	mobile	Android	10	3
+Chrome	86.0.4240.198	mobile	Android	14	3
+Chrome	87.0.4280.141	mobile	Android	7.0	3
+Chrome	89.0.4389.105	mobile	Android	5.1.1	3
+Chrome	90.0.4430.72	desktop	Linux	(not set)	3
+Chrome	92.0.4515.105	mobile	Android	12	3
+Chrome	92.0.4515.159	desktop	Windows	10	3
+Chrome	92.0.4515.90	tablet	iOS	12.5	3
+Chrome	93.0.4577.36	desktop	Chrome OS	x86_64 14092.28.0	3
+Chrome	93.0.4577.95	desktop	Chrome OS	x86_64 14092.66.0	3
+Chrome	95.0.4638.54	desktop	Windows	10	3
+Chrome	95.0.4638.74	desktop	Linux	(not set)	3
+Chrome	95.0.4638.74	mobile	Android	5.0.1	3
+Chrome	97.0.4692.98	mobile	Android	12	3
+Chrome	97.0.4692.99	desktop	Windows	8.1	3
+Chrome	98.0.4758.107	desktop	Chrome OS	x86_64 14388.61.0	3
+Chrome	98.0.4758.82	desktop	Windows	10	3
+Chrome	99.0.4844.88	mobile	Android	10	3
+Chrome	99.0.4844.88	tablet	Android	12	3
+Edge	121.0.2277.128	desktop	Windows	10	3
+Edge	121.0.2277.98	desktop	Windows	11	3
+Edge	126.0.2592.68	desktop	Windows	10	3
+Edge	129.0.2792.79	desktop	Windows	10	3
+Edge	130.0.2849.56	desktop	Macintosh	Intel 15.5	3
+Edge	130.0.2849.56	desktop	Windows	11	3
+Edge	130.0.2849.80	desktop	Windows	10	3
+Edge	131.0.2903.112	desktop	Windows	11	3
+Edge	132.0.2957.115	desktop	Windows	10	3
+Edge	133.0.3065.51	desktop	Windows	11	3
+Edge	133.0.3065.69	desktop	Windows	10	3
+Edge	133.0.3065.92	desktop	Windows	10	3
+Edge	134.0.3124.66	desktop	Windows	10	3
+Edge	134.0.3124.66	desktop	Windows	11	3
+Edge	134.0.3124.68	desktop	Windows	11	3
+Edge	134.0.3124.83	desktop	Windows	11	3
+Edge	135.0.3179.85	mobile	Android	15.0.0	3
+Edge	135.0.3179.98	desktop	Macintosh	Intel 15.5	3
+Edge	136.0.3240.91	mobile	Android	13.0.0	3
+Edge	137.0.3296.52	desktop	Macintosh	Intel 15.5	3
+Edge	137.0.3296.68	desktop	Linux	6.8.0	3
+Edge	137.0.3296.68	desktop	Macintosh	Intel 14.4	3
+Edge	137.0.3296.68	desktop	Macintosh	Intel 14.5	3
+Edge	137.0.3296.82	desktop	Linux	(not set)	3
+Edge	137.0.3296.82	mobile	Android	12.0.0	3
+Edge	137.0.3296.83	desktop	Macintosh	Intel 14.6	3
+Edge	137.0.3296.92	mobile	Android	8.1.0	3
+Edge	137.0.3296.93	desktop	Linux	6.14.0	3
+Edge	138.0.0.0	mobile	iOS	16.6	3
+Edge	138.0.3351.34	desktop	Windows	11	3
+Edge	138.0.3351.55	desktop	Macintosh	Intel 12.7	3
+Edge	138.0.3351.55	desktop	Macintosh	Intel 14.5	3
+Edge	138.0.3351.55	desktop	Macintosh	Intel 16.0	3
+Edge	138.0.3351.55	mobile	Android	11.0	3
+Edge	138.0.3351.62	desktop	Windows	11	3
+Edge	138.0.3351.65	desktop	Linux	6.15.4	3
+Edge	138.0.3351.65	desktop	Macintosh	Intel 12.7	3
+Edge	138.0.3351.66	mobile	Android	11.0.0	3
+Edge	138.0.3351.77	desktop	Macintosh	Intel 15.2	3
+Edge	138.0.3351.77	mobile	Android	11.0.0	3
+Edge	138.0.3351.77	mobile	Android	16.0.0	3
+Edge	138.0.3351.83	desktop	Macintosh	Intel 13.7	3
+Edge	138.0.3351.83	desktop	Macintosh	Intel 14.3	3
+Edge	138.0.3351.83	desktop	Macintosh	Intel 15.0	3
+Edge	138.0.3351.83	desktop	Macintosh	Intel 15.1	3
+Edge	138.0.3351.95	desktop	Linux	6.14.0	3
+Edge	138.0.3351.95	desktop	Macintosh	Intel 15.3	3
+Edge	138.0.3351.95	mobile	Windows	11	3
+Edge	139.0.3405.36	desktop	Windows	10	3
+Edge	140.0.3413.0	desktop	Windows	11	3
+Edge	140.0.3427.0	desktop	Windows	11	3
+Edge	140.0.3430.1	desktop	Macintosh	Intel 15.5	3
+Edge	140.0.3430.1	desktop	Windows	11	3
+Edge	140.0.3436.0	desktop	Windows	11	3
+Edge	140.0.3439.0	desktop	Windows	11	3
+Edge	89.0.774.68	desktop	Windows	10	3
+Firefox	131.0	mobile	Android	13	3
+Firefox	138.0	mobile	Android	12	3
+Firefox	138.0	mobile	Android	14	3
+Firefox	141.0	mobile	Android	12	3
+Firefox	142.0	mobile	Android	15	3
+Firefox	78.0	desktop	Macintosh	Intel 10.9	3
+Firefox	91.0	desktop	Linux	(not set)	3
+Internet Explorer	11.0	desktop	Windows	8.1	3
+Internet Explorer	7.0	desktop	Windows	8	3
+Meta Quest Browser	39.0.0.20.29.749791054	desktop	Linux	(not set)	3
+Opera	102.0.0.0	desktop	Windows	10	3
+Opera	109.0.0.0	desktop	Windows	10	3
+Opera	114.0.0.0	desktop	Linux	(not set)	3
+Opera	117.0.0.0	desktop	Linux	(not set)	3
+Opera	119.0.5497.29	desktop	Linux	(not set)	3
+Opera	73.2.3844.71002	mobile	Android	13	3
+Opera	74.2.3922.71802	mobile	Android	13	3
+Opera	74.2.3922.71802	mobile	Android	14	3
+Opera	86.0.0.0	mobile	Android	10	3
+Opera	93.0.2254.78340	mobile	Android	11	3
+Opera	93.0.2254.78340	mobile	Android	12	3
+Opera	95.0.0.0	desktop	Windows	8	3
+Opera	99.0.0.0	desktop	Windows	10	3
+Safari	14.1	desktop	Macintosh	Intel 10.15	3
+Safari	14.1.2	desktop	Macintosh	Intel 10.14	3
+Safari	15.3.1	mobile	iOS	15.3.1	3
+Safari	15.6	desktop	Macintosh	Intel 10.15	3
+Safari	15.8	mobile	iOS	15.8.4	3
+Safari	15.8.3	mobile	iOS	15.8.3	3
+Safari	16.0	mobile	iOS	16.0.3	3
+Safari	16.6	mobile	iOS	16.7.1	3
+Safari	16.7	mobile	iOS	16.7.11	3
+Safari	17.0	mobile	iOS	17.0.2	3
+Safari	17.0.2	mobile	iOS	17.0.2	3
+Safari	17.2	mobile	iOS	17.2	3
+Safari	17.8	desktop	Macintosh	Intel 10.15	3
+Safari	18.6	tablet	iOS	18.6	3
+Safari	604.1	mobile	iOS	15.5.0	3
+Safari	604.1	mobile	iOS	16.1	3
+Safari	604.1	mobile	iOS	17.2.1	3
+Safari	604.1	mobile	iOS	17.3.1	3
+Safari	604.1	mobile	iOS	17.7.1	3
+Safari	604.1	tablet	iOS	17.7.8	3
+Safari	604.1	tablet	iOS	18.5	3
+Safari	605.1.15	mobile	iOS	15.8.4	3
+Safari	605.1.15	mobile	iOS	17.6.1	3
+Safari	605.1.15	mobile	iOS	18.1.1	3
+Safari	605.1.15	mobile	iOS	18.4.1	3
+Safari	7.0	mobile	iOS	7.0.5	3
+Safari	7.0.3	desktop	Macintosh	Intel 10.9	3
+Safari (in-app)	(not set)	mobile	iOS	16.6.1	3
+Safari (in-app)	(not set)	mobile	iOS	17.2.1	3
+Safari (in-app)	(not set)	mobile	iOS	17.3.1	3
+Safari (in-app)	(not set)	mobile	iOS	17.7	3
+Safari (in-app)	(not set)	mobile	iOS	26.0	3
+Samsung Internet	11.0	mobile	Android	10	3
+Samsung Internet	20.0	mobile	Android	12	3
+Samsung Internet	28.0	desktop	Windows	10	3
+Samsung Internet	6.4	mobile	Android	7.1.1	3
+Samsung Internet	7.0	mobile	Android	8.0.0	3
+Samsung Internet	9.0	mobile	Android	9	3
+UC Browser	12.12.10.1228	mobile	Android	10	3
+UC Browser	14.7.0.1364	mobile	Android	15	3
+YaBrowser	18.0	mobile	iOS	18.3.2	3
+YaBrowser	18.0	mobile	iOS	18.4.1	3
+YaBrowser	24.4.0.0	desktop	Linux	(not set)	3
+YaBrowser	24.7.0.0	desktop	Windows	10	3
+YaBrowser	25.3.0.33.00	mobile	Android	13	3
+YaBrowser	25.4.2.107.00	mobile	Android	11	3
+YaBrowser	25.4.3.182.01	mobile	Android	12	3
+YaBrowser	25.4.6.49.00	mobile	Android	13	3
+YaBrowser	25.6.0.2370	desktop	Windows	10	3
+YaBrowser	25.6.0.271.00	mobile	Android	13	3
+YaBrowser	25.6.1.101.00	mobile	Android	12	3
+YaBrowser	25.6.1.101.00	mobile	Android	14	3
+YaBrowser	25.6.1.95.00	mobile	Android	12	3
+YaBrowser	25.6.2.103.00	mobile	Android	14	3
+YaBrowser	25.6.2.109.00	mobile	Android	12	3
+YaBrowser	25.6.4.102.00	mobile	Android	13	3
+YaBrowser	25.6.4.107.00	mobile	Android	15	3
+YaBrowser	4.0	mobile	Android	11	3
+Aloha Browser	4.7.0.0	desktop	Windows	10	2
+Amazon Silk	136.3.3	smart tv	Android	9	2
+Android Browser	534.30	mobile	Android	(not set)	2
+Android Webview	101.0.4951.61	mobile	Android	13	2
+Android Webview	114.0.5735.196	tablet	Android	10	2
+Android Webview	119.0.6045.163	mobile	Android	14	2
+Android Webview	119.0.6045.163	mobile	Android	15	2
+Android Webview	119.0.6045.193	mobile	Android	13	2
+Android Webview	120.0.6099.230	mobile	Android	12	2
+Android Webview	120.0.6099.230	mobile	Android	13	2
+Android Webview	120.0.6099.230	mobile	Android	14	2
+Android Webview	120.0.6099.230	smart tv	Android	11	2
+Android Webview	121.0.6167.71	mobile	Android	15	2
+Android Webview	122.0.6261.119	mobile	Android	9	2
+Android Webview	124.0.6367.123	mobile	Android	13	2
+Android Webview	124.0.6367.82	mobile	Android	9	2
+Android Webview	125.0.6422.165	mobile	Android	13	2
+Android Webview	125.0.6422.165	mobile	Android	9	2
+Android Webview	125.0.6422.72	mobile	Android	13	2
+Android Webview	128.0.6613.146	mobile	Android	13	2
+Android Webview	128.0.6613.146	mobile	Android	15	2
+Android Webview	129.0.6668.100	mobile	Android	9	2
+Android Webview	129.0.6668.70	mobile	Android	9	2
+Android Webview	129.0.6668.82	mobile	Android	14	2
+Android Webview	130.0.6723.102	mobile	Android	9	2
+Android Webview	130.0.6723.58	mobile	Android	13	2
+Android Webview	130.0.6723.86	mobile	Android	12	2
+Android Webview	131.0.6778.135	mobile	Android	12	2
+Android Webview	131.0.6778.93	mobile	Android	10	2
+Android Webview	132.0.6834.163	mobile	Android	10	2
+Android Webview	132.0.6834.163	mobile	Android	12	2
+Android Webview	133.0.6943.121	mobile	Android	11	2
+Android Webview	133.0.6943.121	mobile	Android	14	2
+Android Webview	133.0.6943.137	mobile	Android	13	2
+Android Webview	133.0.6943.138	mobile	Android	10	2
+Android Webview	134.0.6998.108	mobile	Android	11	2
+Android Webview	134.0.6998.108	mobile	Android	9	2
+Android Webview	134.0.6998.207	tablet	Android	9	2
+Android Webview	134.0.6998.39	mobile	Android	12	2
+Android Webview	134.0.6998.39	mobile	Android	13	2
+Android Webview	134.0.6998.39	tablet	Android	14	2
+Android Webview	134.0.6998.40	mobile	Android	13	2
+Android Webview	134.0.6998.40	mobile	Android	15	2
+Android Webview	135.0.7049.110	mobile	Android	13	2
+Android Webview	135.0.7049.113	mobile	Android	10	2
+Android Webview	135.0.7049.113	mobile	Android	13	2
+Android Webview	135.0.7049.113	mobile	Android	15	2
+Android Webview	135.0.7049.37	mobile	Android	12	2
+Android Webview	135.0.7049.37	mobile	Android	15	2
+Android Webview	135.0.7049.38	mobile	Android	9	2
+Android Webview	135.0.7049.39	mobile	Android	9	2
+Android Webview	135.0.7049.99	mobile	Android	10	2
+Android Webview	136.0.7103.60	tablet	Android	14	2
+Android Webview	136.0.7103.61	tablet	Android	14	2
+Android Webview	137.0.7151.115	smart tv	Android	12	2
+Android Webview	137.0.7151.115	tablet	Android	11	2
+Android Webview	137.0.7151.117	mobile	Android	8.1.0	2
+Android Webview	137.0.7151.118	tablet	Android	13	2
+Android Webview	137.0.7151.14	mobile	Android	14	2
+Android Webview	137.0.7151.44	mobile	Android	13	2
+Android Webview	137.0.7151.44	mobile	Android	14	2
+Android Webview	137.0.7151.52	mobile	Android	12	2
+Android Webview	137.0.7151.52	mobile	Android	14	2
+Android Webview	137.0.7151.61	tablet	Android	14	2
+Android Webview	137.0.7151.72	mobile	Android	15	2
+Android Webview	137.0.7151.80	mobile	Android	11	2
+Android Webview	137.0.7151.80	mobile	Android	12	2
+Android Webview	137.0.7151.80	mobile	Android	13	2
+Android Webview	137.0.7151.89	smart tv	Android	11	2
+Android Webview	137.0.7151.90	tablet	Android	15	2
+Android Webview	137.0.7151.91	mobile	Android	12	2
+Android Webview	138.0.7204.139	mobile	Android	10	2
+Android Webview	138.0.7204.143	mobile	Android	12	2
+Android Webview	138.0.7204.143	mobile	Android	13	2
+Android Webview	138.0.7204.153	mobile	Android	11	2
+Android Webview	138.0.7204.153	mobile	Android	12	2
+Android Webview	138.0.7204.42	tablet	Android	14	2
+Android Webview	138.0.7204.45	tablet	Android	15	2
+Android Webview	138.0.7204.63	mobile	Android	8.0.0	2
+Android Webview	138.0.7204.63	tablet	Android	12	2
+Android Webview	138.0.7204.67	tablet	Android	12	2
+Android Webview	138.0.7204.68	tablet	Android	12	2
+Android Webview	138.0.7204.68	tablet	Android	15	2
+Android Webview	139.0.7258.41	mobile	Android	14	2
+Android Webview	58.0.3029.125	mobile	Android	8.1.0	2
+Android Webview	62.0.3202.84	mobile	Android	7.0	2
+Android Webview	64.0.3282.137	mobile	Android	7.1.2	2
+Android Webview	64.0.3282.137	mobile	Android	8.0.0	2
+Android Webview	65.0.3325.109	mobile	Android	8.1.0	2
+Android Webview	66.0.3359.158	smart tv	Android	9	2
+Android Webview	71.0.3578.99	mobile	Android	9	2
+Android Webview	77.0.3865.92	mobile	Android	10	2
+Android Webview	83.0.4103.106	mobile	Android	11	2
+Android Webview	92.0.4515.105	tablet	Android	10	2
+Android Webview	95.0.4638.74	mobile	Android	5.1.1	2
+Android Webview	97.0.4692.98	mobile	Android	12	2
+BlackBerry	26.0	tablet	BlackBerry	(not set)	2
+Chrome	(not set)	desktop	Linux	14.0.0	2
+Chrome	(not set)	desktop	Linux	9.0.0	2
+Chrome	100.0.4896.127	desktop	Linux	(not set)	2
+Chrome	100.0.4896.127	mobile	Android	10.0.0	2
+Chrome	100.0.4896.127	mobile	Android	7.1.1	2
+Chrome	100.0.4896.127	mobile	Android	7.1.2	2
+Chrome	100.0.4896.58	mobile	Android	12	2
+Chrome	100.0.4896.58	mobile	Android	15	2
+Chrome	101.0.4951.64	desktop	Windows	11	2
+Chrome	102.0.5005.115	desktop	Windows	10	2
+Chrome	102.0.5005.78	mobile	Android	10.0.0	2
+Chrome	103.0.0.0	desktop	Windows	10	2
+Chrome	103.0.5013.1	mobile	Android	13.0.0	2
+Chrome	103.0.5060.129	desktop	Windows	Server 2003	2
+Chrome	103.0.5060.132	mobile	Chrome OS	x86_64 14816.131.0	2
+Chrome	104.0.5112.102	desktop	Windows	10	2
+Chrome	104.0.5112.97	mobile	Android	11.0.0	2
+Chrome	105.0.0.0	desktop	Windows	10	2
+Chrome	105.0.0.0	mobile	Android	10.0.0	2
+Chrome	105.0.5195.125	desktop	Linux	5.15.0	2
+Chrome	106.0.0.0	desktop	Windows	11	2
+Chrome	106.0.5249.126	mobile	Android	12.0.0	2
+Chrome	106.0.5249.126	mobile	Android	7.1.0	2
+Chrome	106.0.5249.126	mobile	Android	8.0.0	2
+Chrome	107.0.0.0	mobile	Android	11.0.0	2
+Chrome	107.0.0.0	mobile	Android	13.0.0	2
+Chrome	107.0.0.0	mobile	Android	14.0.0	2
+Chrome	107.0.5304.101	mobile	iOS	16.0	2
+Chrome	107.0.5304.63	desktop	Windows	10	2
+Chrome	108.0.0.0	desktop	Windows	10	2
+Chrome	108.0.0.0	mobile	Android	12	2
+Chrome	108.0.0.0	mobile	Android	13	2
+Chrome	108.0.5359.124	desktop	Linux	4.15.0	2
+Chrome	108.0.5359.124	desktop	Macintosh	Intel 15.3	2
+Chrome	108.0.5359.124	desktop	Macintosh	Intel 15.5	2
+Chrome	108.0.5359.125	desktop	Windows	10	2
+Chrome	108.0.5359.128	mobile	Android	11.0.0	2
+Chrome	108.0.5359.128	mobile	Android	8.1.0	2
+Chrome	108.0.5359.215	desktop	Windows	10	2
+Chrome	108.0.5359.95	desktop	Windows	10	2
+Chrome	109.0.0.0	desktop	Windows	8	2
+Chrome	109.0.5414.117	mobile	Android	11.0.0	2
+Chrome	109.0.5414.120	desktop	Windows	8.1	2
+Chrome	109.0.5414.165	desktop	Windows	7	2
+Chrome	109.0.5414.75	desktop	Windows	8.1	2
+Chrome	109.0.5414.85	mobile	Android	12.0.0	2
+Chrome	110.0.5481.178	desktop	Windows	10	2
+Chrome	110.0.5481.61	mobile	Android	10.0.0	2
+Chrome	110.0.5481.65	mobile	Android	10.0.0	2
+Chrome	110.0.5481.65	mobile	Android	13.0.0	2
+Chrome	111.0.0.0	mobile	Android	11.0.0	2
+Chrome	111.0.0.0	mobile	Android	13.0.0	2
+Chrome	111.0.5563.116	tablet	Android	13.0.0	2
+Chrome	111.0.5563.146	smart tv	Linux	(not set)	2
+Chrome	112.0.0.0	desktop	Linux	(not set)	2
+Chrome	112.0.0.0	desktop	Linux	6.15.3	2
+Chrome	112.0.0.0	desktop	Windows	10	2
+Chrome	112.0.5615.121	desktop	Windows	10	2
+Chrome	112.0.5615.135	mobile	Android	11.0.0	2
+Chrome	112.0.5615.47	mobile	Android	11.0.0	2
+Chrome	112.0.5615.70	mobile	iOS	14.4	2
+Chrome	113.0.5672.127	desktop	Windows	11	2
+Chrome	113.0.5672.162	mobile	Android	11.0.0	2
+Chrome	113.0.5672.162	mobile	Android	12.0.0	2
+Chrome	114.0.5735.131	mobile	Android	11.0.0	2
+Chrome	114.0.5735.198	desktop	Linux	5.15.0	2
+Chrome	114.0.5735.90	desktop	Macintosh	Intel 14.6	2
+Chrome	114.0.5735.91	desktop	Windows	10	2
+Chrome	115.0.0.0	desktop	Linux	(not set)	2
+Chrome	115.0.0.0	desktop	Linux	5.15.0	2
+Chrome	115.0.5790.110	desktop	Windows	11	2
+Chrome	115.0.5790.160	mobile	iOS	18.5	2
+Chrome	115.0.5790.166	mobile	Android	10.0.0	2
+Chrome	115.0.5790.166	mobile	Android	12.0.0	2
+Chrome	115.0.5790.168	desktop	UNIX	(not set)	2
+Chrome	115.0.5790.168	mobile	Android	11	2
+Chrome	115.0.5790.168	mobile	Android	14	2
+Chrome	116.0.0.0	desktop	Macintosh	Intel 10.15	2
+Chrome	116.0.0.0	desktop	Windows	10	2
+Chrome	116.0.5845.110	desktop	Macintosh	Intel 12.7	2
+Chrome	116.0.5845.120	mobile	Android	13	2
+Chrome	116.0.5845.141	desktop	Windows	11	2
+Chrome	116.0.5845.163	mobile	Android	10.0.0	2
+Chrome	116.0.5845.163	mobile	Android	8.0.0	2
+Chrome	116.0.5845.172	mobile	Android	11.0.0	2
+Chrome	116.0.5845.172	mobile	Android	13.0.0	2
+Chrome	116.0.5845.173	mobile	Android	11.0.0	2
+Chrome	116.0.5845.179	desktop	Linux	6.8.0	2
+Chrome	116.0.5845.187	desktop	Macintosh	Intel 12.7	2
+Chrome	116.0.5845.190	desktop	Windows	11	2
+Chrome	116.0.5845.96	desktop	Macintosh	Intel 15.5	2
+Chrome	117.0.0.0	desktop	Macintosh	Intel 10.15	2
+Chrome	117.0.0.0	desktop	Macintosh	Intel 15.4	2
+Chrome	117.0.0.0	desktop	Windows	10	2
+Chrome	117.0.0.0	desktop	Windows	11	2
+Chrome	117.0.5938.132	desktop	Linux	6.8.0	2
+Chrome	117.0.5938.149	desktop	Windows	10	2
+Chrome	117.0.5938.153	mobile	Android	11.0.0	2
+Chrome	117.0.5938.60	mobile	Android	9.0.0	2
+Chrome	117.0.5938.89	desktop	Windows	10	2
+Chrome	117.0.5938.92	desktop	Macintosh	Intel 13.7	2
+Chrome	118.0.5993.70	desktop	Windows	10	2
+Chrome	118.0.5993.71	desktop	Windows	11	2
+Chrome	119.0.6045.163	mobile	Android	10.0.0	2
+Chrome	119.0.6045.163	mobile	Android	12.0.0	2
+Chrome	119.0.6045.163	mobile	Android	13.0.0	2
+Chrome	119.0.6045.200	desktop	Windows	10	2
+Chrome	120.0.0.0	desktop	Windows	10	2
+Chrome	120.0.6099.115	mobile	Android	12.0.0	2
+Chrome	120.0.6099.119	mobile	iOS	18.2	2
+Chrome	120.0.6099.129	desktop	Linux	5.15.0	2
+Chrome	120.0.6099.129	desktop	Windows	11	2
+Chrome	120.0.6099.144	mobile	Android	10.0.0	2
+Chrome	120.0.6099.144	mobile	Android	11.0.0	2
+Chrome	120.0.6099.193	mobile	Android	12.0.0	2
+Chrome	120.0.6099.210	mobile	Android	13.0.0	2
+Chrome	120.0.6099.216	desktop	Linux	5.14.0	2
+Chrome	120.0.6099.217	desktop	Windows	10	2
+Chrome	120.0.6099.230	desktop	Linux	(not set)	2
+Chrome	120.0.6099.230	mobile	Android	11.0.0	2
+Chrome	120.0.6099.230	mobile	Android	13.0.0	2
+Chrome	120.0.6099.63	desktop	Windows	10	2
+Chrome	120.0.6099.71	desktop	Linux	5.15.0	2
+Chrome	120.0.6099.71	desktop	Linux	6.8.0	2
+Chrome	121.0.0.0	desktop	Windows	10	2
+Chrome	121.0.6167.101	mobile	Android	9.0.0	2
+Chrome	121.0.6167.138	mobile	iOS	18.5	2
+Chrome	121.0.6167.139	desktop	Linux	5.4.0	2
+Chrome	121.0.6167.139	desktop	Linux	6.8.0	2
+Chrome	121.0.6167.160	desktop	Linux	5.15.0	2
+Chrome	121.0.6167.178	mobile	Android	11.0.0	2
+Chrome	121.0.6167.184	desktop	Macintosh	Intel 13.0	2
+Chrome	121.0.6167.187	desktop	Windows	10	2
+Chrome	121.0.6167.85	desktop	Linux	6.8.0	2
+Chrome	122.0.0.0	desktop	Linux	(not set)	2
+Chrome	122.0.6261.105	mobile	Android	10.0.0	2
+Chrome	122.0.6261.105	mobile	Android	13.0.0	2
+Chrome	122.0.6261.111	desktop	Linux	5.15.0	2
+Chrome	122.0.6261.119	desktop	Linux	(not set)	2
+Chrome	122.0.6261.119	mobile	Android	11.0.0	2
+Chrome	122.0.6261.119	mobile	Android	12.0.0	2
+Chrome	122.0.6261.119	mobile	Android	9.0.0	2
+Chrome	122.0.6261.119	mobile	iOS	13.2	2
+Chrome	122.0.6261.120	mobile	Android	14.0.0	2
+Chrome	122.0.6261.128	desktop	Linux	5.15.0	2
+Chrome	122.0.6261.128	desktop	Macintosh	Intel 14.6	2
+Chrome	122.0.6261.128	desktop	Windows	11	2
+Chrome	122.0.6261.57	desktop	Windows	10	2
+Chrome	122.0.6261.64	mobile	Android	12.0.0	2
+Chrome	122.0.6261.69	desktop	Windows	11	2
+Chrome	122.0.6261.90	mobile	Android	11.0.0	2
+Chrome	122.0.6261.94	desktop	Linux	5.15.0	2
+Chrome	122.0.6261.94	desktop	Linux	6.8.0	2
+Chrome	122.0.6261.94	desktop	Windows	10	2
+Chrome	122.0.6261.96	desktop	Windows	10	2
+Chrome	123.0.0.0	mobile	Android	10	2
+Chrome	123.0.6312.100	mobile	Android	14.0.0	2
+Chrome	123.0.6312.106	desktop	Windows	11	2
+Chrome	123.0.6312.118	desktop	Windows	Server 2003	2
+Chrome	123.0.6312.122	desktop	Linux	5.15.0	2
+Chrome	123.0.6312.52	mobile	iOS	15.8	2
+Chrome	123.0.6312.58	desktop	Linux	5.15.0	2
+Chrome	123.0.6312.80	mobile	Android	12.0.0	2
+Chrome	123.0.6312.80	mobile	Android	14.0.0	2
+Chrome	123.0.6312.80	mobile	Android	8.1.0	2
+Chrome	123.0.6312.86	desktop	Linux	5.4.0	2
+Chrome	123.0.6312.99	mobile	Android	12.0.0	2
+Chrome	124.0.0.0	mobile	Android	11.0.0	2
+Chrome	124.0.0.0	mobile	Android	16	2
+Chrome	124.0.0.0	mobile	Android	9.0.0	2
+Chrome	124.0.6327.1	mobile	Android	11.0.0	2
+Chrome	124.0.6327.1	mobile	Android	12.0.0	2
+Chrome	124.0.6328.0	mobile	Android	11.0.0	2
+Chrome	124.0.6328.0	mobile	Android	9.0.0	2
+Chrome	124.0.6356.6	desktop	Windows	10	2
+Chrome	124.0.6367.111	mobile	iOS	18.5	2
+Chrome	124.0.6367.113	mobile	Android	12.0.0	2
+Chrome	124.0.6367.119	desktop	Macintosh	Intel 15.5	2
+Chrome	124.0.6367.158	desktop	Windows	10	2
+Chrome	124.0.6367.159	mobile	Android	11.0.0	2
+Chrome	124.0.6367.179	mobile	Android	11.0.0	2
+Chrome	124.0.6367.201	desktop	Windows	11	2
+Chrome	124.0.6367.202	desktop	Windows	10	2
+Chrome	124.0.6367.207	desktop	Linux	5.15.0	2
+Chrome	124.0.6367.208	desktop	Macintosh	Intel 14.5	2
+Chrome	124.0.6367.208	desktop	Windows	11	2
+Chrome	124.0.6367.209	desktop	Windows	10	2
+Chrome	124.0.6367.60	desktop	Linux	5.15.0	2
+Chrome	124.0.6367.60	desktop	Windows	11	2
+Chrome	124.0.6367.82	mobile	Android	10.0.0	2
+Chrome	124.0.6367.88	mobile	iOS	15.8	2
+Chrome	124.0.6367.91	desktop	Linux	5.15.0	2
+Chrome	125.0.0.0	mobile	Android	13.0.0	2
+Chrome	125.0.0.0	mobile	Android	15.0.0	2
+Chrome	125.0.6422.112	desktop	Windows	11	2
+Chrome	125.0.6422.142	desktop	Macintosh	Intel 15.4	2
+Chrome	125.0.6422.14231	desktop	Windows	10	2
+Chrome	125.0.6422.146	mobile	Android	12.0.0	2
+Chrome	125.0.6422.165	mobile	Android	11.0.0	2
+Chrome	125.0.6422.176	desktop	Windows	11	2
+Chrome	125.0.6422.186	mobile	Android	13.0.0	2
+Chrome	125.0.6422.53	mobile	Android	10.0.0	2
+Chrome	125.0.6422.71	mobile	Android	12.0.0	2
+Chrome	125.0.6422.72	mobile	Android	10.0.0	2
+Chrome	125.0.6422.72	mobile	Android	9	2
+Chrome	125.0.6422.72	mobile	Android	9.0.0	2
+Chrome	125.0.6422.76	desktop	Linux	5.15.0	2
+Chrome	125.0.6422.76	desktop	Windows	11	2
+Chrome	125.0.6422.77	desktop	Windows	11	2
+Chrome	125.0.6422.80	mobile	iOS	18.5	2
+Chrome	126.0.0.0	desktop	Chrome OS	x86_64 15886.67.19	2
+Chrome	126.0.0.0	desktop	Macintosh	Intel 12.7	2
+Chrome	126.0.0.0	desktop	Macintosh	Intel 14.6	2
+Chrome	126.0.0.0	mobile	Android	15.0.0	2
+Chrome	126.0.0.0	mobile	Android	9.0.0	2
+Chrome	126.0.0.0	mobile	iOS	15.0	2
+Chrome	126.0.6478.108	mobile	iOS	17.6	2
+Chrome	126.0.6478.110	mobile	Android	12.0.0	2
+Chrome	126.0.6478.114	desktop	Windows	10	2
+Chrome	126.0.6478.115	desktop	Windows	10	2
+Chrome	126.0.6478.122	mobile	Android	14	2
+Chrome	126.0.6478.122	mobile	Android	8.1.0	2
+Chrome	126.0.6478.122	mobile	Android	9.0.0	2
+Chrome	126.0.6478.126	desktop	Linux	6.5.0	2
+Chrome	126.0.6478.127	desktop	Macintosh	Intel 13.6	2
+Chrome	126.0.6478.127	desktop	Macintosh	Intel 14.1	2
+Chrome	126.0.6478.127	desktop	Macintosh	Intel 14.7	2
+Chrome	126.0.6478.127	desktop	Macintosh	Intel 15.3	2
+Chrome	126.0.6478.128	desktop	Windows	10	2
+Chrome	126.0.6478.182	desktop	Linux	5.15.184	2
+Chrome	126.0.6478.182	desktop	Linux	5.15.185	2
+Chrome	126.0.6478.183	desktop	Windows	11	2
+Chrome	126.0.6478.222	desktop	Chrome OS	aarch64 15886.74.0	2
+Chrome	126.0.6478.270	desktop	Chrome OS	x86_64 15886.95.0	2
+Chrome	126.0.6478.35	mobile	iOS	18.0	2
+Chrome	126.0.6478.54	tablet	iOS	16.2	2
+Chrome	126.0.6478.55	desktop	Linux	5.15.0	2
+Chrome	126.0.6478.61	desktop	Linux	6.5.0	2
+Chrome	126.0.6478.61	desktop	Windows	10	2
+Chrome	126.0.6478.62	desktop	Macintosh	Intel 15.4	2
+Chrome	126.0.6478.72	mobile	Android	8.1.0	2
+Chrome	127.0.0.0	desktop	Macintosh	Intel 10.15	2
+Chrome	127.0.0.0	desktop	Macintosh	Intel 15.5	2
+Chrome	127.0.0.0	mobile	Android	15.0.0	2
+Chrome	127.0.6533.100	desktop	Macintosh	Intel 13.0	2
+Chrome	127.0.6533.100	desktop	Macintosh	Intel 14.6	2
+Chrome	127.0.6533.100	desktop	Macintosh	Intel 15.5	2
+Chrome	127.0.6533.101	mobile	Android	11	2
+Chrome	127.0.6533.105	mobile	Android	12.0.0	2
+Chrome	127.0.6533.106	mobile	Android	13.0.0	2
+Chrome	127.0.6533.107	mobile	iOS	18.5	2
+Chrome	127.0.6533.120	desktop	Macintosh	Intel 15.5	2
+Chrome	127.0.6533.64	mobile	Android	9.0.0	2
+Chrome	127.0.6533.72	desktop	Linux	6.8.0	2
+Chrome	127.0.6533.84	mobile	Android	10.0.0	2
+Chrome	127.0.6533.84	mobile	Android	14.0.0	2
+Chrome	127.0.6533.84	mobile	Android	9.0.0	2
+Chrome	127.0.6533.85	mobile	Android	14.0.0	2
+Chrome	127.0.6533.88	desktop	Linux	6.11.0	2
+Chrome	127.0.6533.99	desktop	Linux	6.11.0	2
+Chrome	128.0.0.0	desktop	Macintosh	Intel 15.5	2
+Chrome	128.0.6613.100	mobile	Android	10.0.0	2
+Chrome	128.0.6613.100	mobile	Android	13.0.0	2
+Chrome	128.0.6613.113	desktop	Windows	10	2
+Chrome	128.0.6613.114	desktop	Macintosh	Intel 15.5	2
+Chrome	128.0.6613.119	desktop	Linux	5.4.0	2
+Chrome	128.0.6613.120	desktop	Macintosh	Intel 14.2	2
+Chrome	128.0.6613.120	desktop	Macintosh	Intel 14.7	2
+Chrome	128.0.6613.121	desktop	Windows	10	2
+Chrome	128.0.6613.121	desktop	Windows	11	2
+Chrome	128.0.6613.127	mobile	Android	11.0.0	2
+Chrome	128.0.6613.128	mobile	Android	12.0.0	2
+Chrome	128.0.6613.137	desktop	Windows	10	2
+Chrome	128.0.6613.139	desktop	Windows	10	2
+Chrome	128.0.6613.139	desktop	Windows	11	2
+Chrome	128.0.6613.146	mobile	Android	10.0.0	2
+Chrome	128.0.6613.146	mobile	Android	9.0.0	2
+Chrome	128.0.6613.36	desktop	Windows	10	2
+Chrome	128.0.6613.551	mobile	Android	11.0.0	2
+Chrome	128.0.6613.84	desktop	Linux	5.15.0	2
+Chrome	128.0.6613.84	desktop	Windows	11	2
+Chrome	128.0.6613.85	desktop	Macintosh	Intel 13.7	2
+Chrome	128.0.6613.85	desktop	Macintosh	Intel 14.6	2
+Chrome	128.0.6613.85	desktop	Macintosh	Intel 14.7	2
+Chrome	128.0.6613.88	mobile	Android	9.0.0	2
+Chrome	128.0.6613.99	mobile	Android	12.0.0	2
+Chrome	128.0.6613.99	mobile	Android	13.0.0	2
+Chrome	129.0.0.0	desktop	Linux	6.6.20	2
+Chrome	129.0.0.0	desktop	Macintosh	Intel 14.6	2
+Chrome	129.0.0.0	desktop	Macintosh	Intel 15.3	2
+Chrome	129.0.0.0	desktop	Macintosh	Intel 15.4	2
+Chrome	129.0.0.0	mobile	Android	10.0.0	2
+Chrome	129.0.6668.100	desktop	Linux	6.11.0	2
+Chrome	129.0.6668.100	desktop	Windows	11	2
+Chrome	129.0.6668.100	tablet	Android	14.0.0	2
+Chrome	129.0.6668.101	desktop	Macintosh	Intel 14.7	2
+Chrome	129.0.6668.102	mobile	Android	13.0.0	2
+Chrome	129.0.6668.102	mobile	Android	14.0.0	2
+Chrome	129.0.6668.54	mobile	Android	13.0.0	2
+Chrome	129.0.6668.59	desktop	Macintosh	Intel 14.7	2
+Chrome	129.0.6668.59	desktop	Macintosh	Intel 15.5	2
+Chrome	129.0.6668.60	desktop	Macintosh	Intel 15.5	2
+Chrome	129.0.6668.60	desktop	Windows	10	2
+Chrome	129.0.6668.70	mobile	Android	11.0.0	2
+Chrome	129.0.6668.71	desktop	Macintosh	Intel 14.7	2
+Chrome	129.0.6668.81	mobile	Android	10.0.0	2
+Chrome	129.0.6668.81	mobile	Android	11.0.0	2
+Chrome	129.0.6668.81	mobile	Android	15.0.0	2
+Chrome	129.0.6668.81	mobile	Android	8.1.0	2
+Chrome	129.0.6668.90	desktop	Macintosh	Intel 14.7	2
+Chrome	129.0.6668.91	desktop	Macintosh	Intel 14.6	2
+Chrome	130.0.0.0	desktop	Linux	6.15.4	2
+Chrome	130.0.0.0	desktop	Linux	6.8.0	2
+Chrome	130.0.0.0	desktop	Macintosh	Intel 15.4	2
+Chrome	130.0.6723.102	mobile	Android	15.0.0	2
+Chrome	130.0.6723.103	mobile	Android	14.0.0	2
+Chrome	130.0.6723.117	desktop	Macintosh	Intel 13.6	2
+Chrome	130.0.6723.117	desktop	Macintosh	Intel 14.5	2
+Chrome	130.0.6723.117	desktop	Macintosh	Intel 15.4	2
+Chrome	130.0.6723.119	desktop	Windows	10	2
+Chrome	130.0.6723.119	desktop	Windows	11	2
+Chrome	130.0.6723.37	mobile	iOS	18.5	2
+Chrome	130.0.6723.58	desktop	Macintosh	Intel 15.5	2
+Chrome	130.0.6723.59	desktop	Macintosh	Intel 14.6	2
+Chrome	130.0.6723.59	mobile	Android	10.0.0	2
+Chrome	130.0.6723.59	mobile	Android	13.0.0	2
+Chrome	130.0.6723.59	mobile	Android	14.0.0	2
+Chrome	130.0.6723.60	desktop	Windows	11	2
+Chrome	130.0.6723.69	desktop	Linux	6.1.0	2
+Chrome	130.0.6723.69	desktop	Macintosh	Intel 15.5	2
+Chrome	130.0.6723.70	desktop	Macintosh	Intel 13.7	2
+Chrome	130.0.6723.70	desktop	Macintosh	Intel 15.1	2
+Chrome	130.0.6723.7025	desktop	Windows	10	2
+Chrome	130.0.6723.73	mobile	Android	15.0.0	2
+Chrome	130.0.6723.73	mobile	Android	9.0.0	2
+Chrome	130.0.6723.74	mobile	Android	12.0.0	2
+Chrome	130.0.6723.74	mobile	Android	14.0.0	2
+Chrome	130.0.6723.90	mobile	iOS	18.1	2
+Chrome	130.0.6723.90	mobile	iOS	18.5	2
+Chrome	130.0.6723.91	desktop	Linux	5.10.0	2
+Chrome	130.0.6723.91	desktop	Linux	5.15.0	2
+Chrome	130.0.6723.91	desktop	Linux	6.11.0	2
+Chrome	130.0.6723.91	desktop	Windows	10	2
+Chrome	130.0.6723.91	mobile	Android	10.0.0	2
+Chrome	130.0.6723.92	desktop	Macintosh	Intel 13.2	2
+Chrome	130.0.6723.92	desktop	Macintosh	Intel 14.4	2
+Chrome	130.0.6723.92	desktop	Macintosh	Intel 15.3	2
+Chrome	130.0.6723.92	desktop	Macintosh	Intel 15.4	2
+Chrome	130.0.6778.7013	desktop	Windows	10	2
+Chrome	131.0.0.0	desktop	Macintosh	Intel 15.1	2
+Chrome	131.0.0.0	mobile	Android	11.0.0	2
+Chrome	131.0.6778.105	mobile	Android	10.0.0	2
+Chrome	131.0.6778.105	mobile	Android	12.0.0	2
+Chrome	131.0.6778.108	desktop	Linux	6.15.6	2
+Chrome	131.0.6778.109	desktop	Macintosh	Intel 14.5	2
+Chrome	131.0.6778.109	desktop	Macintosh	Intel 15.1	2
+Chrome	131.0.6778.110	desktop	Windows	11	2
+Chrome	131.0.6778.134	mobile	iOS	18.5.0	2
+Chrome	131.0.6778.136	mobile	Android	14.0.0	2
+Chrome	131.0.6778.140	desktop	Macintosh	Intel 14.7	2
+Chrome	131.0.6778.140	desktop	Macintosh	Intel 15.0	2
+Chrome	131.0.6778.140	desktop	Macintosh	Intel 15.4	2
+Chrome	131.0.6778.14011	desktop	Windows	10	2
+Chrome	131.0.6778.154	mobile	iOS	18.2.0	2
+Chrome	131.0.6778.201	mobile	Android	13.0.0	2
+Chrome	131.0.6778.204	desktop	Linux	5.4.0	2
+Chrome	131.0.6778.204	desktop	Linux	5.8.0	2
+Chrome	131.0.6778.204	desktop	Linux	6.2.0	2
+Chrome	131.0.6778.204	desktop	Linux	6.5.0	2
+Chrome	131.0.6778.205	desktop	Macintosh	Intel 12.7	2
+Chrome	131.0.6778.205	desktop	Macintosh	Intel 13.5	2
+Chrome	131.0.6778.205	desktop	Macintosh	Intel 14.2	2
+Chrome	131.0.6778.205	mobile	Windows	10	2
+Chrome	131.0.6778.260	tablet	Android	14.0.0	2
+Chrome	131.0.6778.265	desktop	Macintosh	Intel 13.0	2
+Chrome	131.0.6778.265	desktop	Macintosh	Intel 13.4	2
+Chrome	131.0.6778.265	desktop	Macintosh	Intel 14.5	2
+Chrome	131.0.6778.265	desktop	Macintosh	Intel 14.7	2
+Chrome	131.0.6778.265	desktop	Macintosh	Intel 15.2	2
+Chrome	131.0.6778.265	desktop	Macintosh	Intel 15.3	2
+Chrome	131.0.6778.265	desktop	Macintosh	Intel 15.4	2
+Chrome	131.0.6778.266	desktop	Macintosh	Intel 15.5	2
+Chrome	131.0.6778.39	mobile	Android	11.0.0	2
+Chrome	131.0.6778.39	mobile	Android	13.0.0	2
+Chrome	131.0.6778.70	desktop	Macintosh	Intel 15.5	2
+Chrome	131.0.6778.73	mobile	iOS	16.7.10	2
+Chrome	131.0.6778.73	mobile	iOS	18.5.0	2
+Chrome	131.0.6778.81	mobile	Android	8.1.0	2
+Chrome	131.0.6778.81	mobile	Android	9.0.0	2
+Chrome	131.0.6778.85	desktop	Linux	5.4.0	2
+Chrome	131.0.6778.86	desktop	Macintosh	Intel 15.0	2
+Chrome	131.0.6778.86	desktop	Macintosh	Intel 15.3	2
+Chrome	131.0.6778.96	desktop	Chrome OS	x86_64 16063.45.0	2
+Chrome	132	desktop	Windows	10	2
+Chrome	132.0.0.0	desktop	Chrome OS	x86_64 14541.0.0	2
+Chrome	132.0.0.0	mobile	Android	10.0.0	2
+Chrome	132.0.6834.110	desktop	Linux	6.12.10	2
+Chrome	132.0.6834.111	desktop	Macintosh	Intel 15.4	2
+Chrome	132.0.6834.11129	desktop	Windows	10	2
+Chrome	132.0.6834.122	mobile	Android	9.0.0	2
+Chrome	132.0.6834.123	mobile	Android	13.0.0	2
+Chrome	132.0.6834.160	desktop	Macintosh	Intel 13.5	2
+Chrome	132.0.6834.160	desktop	Macintosh	Intel 14.4	2
+Chrome	132.0.6834.160	desktop	Macintosh	Intel 15.2	2
+Chrome	132.0.6834.160	desktop	Macintosh	Intel 15.5	2
+Chrome	132.0.6834.163	mobile	Android	8.1.0	2
+Chrome	132.0.6834.165	mobile	Android	15.0.0	2
+Chrome	132.0.6834.223	desktop	Chrome OS	x86_64 16093.105.0	2
+Chrome	132.0.6834.226	desktop	Chrome OS	aarch64 16093.108.0	2
+Chrome	132.0.6834.57	desktop	Windows	10	2
+Chrome	132.0.6834.79	mobile	Android	15.0.0	2
+Chrome	132.0.6834.80	mobile	Android	10.0.0	2
+Chrome	132.0.6834.80	mobile	Android	11.0.0	2
+Chrome	132.0.6834.80	mobile	Android	9.0.0	2
+Chrome	132.0.6834.84	desktop	Macintosh	Intel 14.6	2
+Chrome	132.0.6834.84	desktop	Macintosh	Intel 15.2	2
+Chrome	132.0.6834.84	desktop	Macintosh	Intel 15.3	2
+Chrome	133.0.0.0	desktop	Linux	5.15.0	2
+Chrome	133.0.0.0	desktop	Macintosh	Intel 15.4	2
+Chrome	133.0.6847.2	desktop	Windows	11	2
+Chrome	133.0.6943.100	desktop	Macintosh	Intel 13.0	2
+Chrome	133.0.6943.121	mobile	Android	8.1.0	2
+Chrome	133.0.6943.122	mobile	Android	13.0.0	2
+Chrome	133.0.6943.122	mobile	Android	14.0.0	2
+Chrome	133.0.6943.122	mobile	Android	15.0.0	2
+Chrome	133.0.6943.122	mobile	Android	9.0.0	2
+Chrome	133.0.6943.126	desktop	Windows	11	2
+Chrome	133.0.6943.127	desktop	Macintosh	Intel 12.5	2
+Chrome	133.0.6943.127	desktop	Macintosh	Intel 14.4	2
+Chrome	133.0.6943.127	desktop	Macintosh	Intel 14.6	2
+Chrome	133.0.6943.127	desktop	Macintosh	Intel 14.7	2
+Chrome	133.0.6943.127	desktop	Macintosh	Intel 15.4	2
+Chrome	133.0.6943.138	mobile	Android	12.0.0	2
+Chrome	133.0.6943.138	mobile	Android	13.0.0	2
+Chrome	133.0.6943.141	desktop	Linux	6.12.10	2
+Chrome	133.0.6943.142	desktop	Macintosh	Intel 14.4	2
+Chrome	133.0.6943.142	desktop	Macintosh	Intel 14.5	2
+Chrome	133.0.6943.143	desktop	Windows	10	2
+Chrome	133.0.6943.146	desktop	Chrome OS	x86_64 16151.53.0	2
+Chrome	133.0.6943.33	mobile	iOS	18.5.0	2
+Chrome	133.0.6943.49	mobile	Android	12.0.0	2
+Chrome	133.0.6943.50	mobile	Android	13.0.0	2
+Chrome	133.0.6943.50	mobile	Android	14.0.0	2
+Chrome	133.0.6943.50	mobile	Android	8.1.0	2
+Chrome	133.0.6943.51	mobile	Android	11.0.0	2
+Chrome	133.0.6943.53	desktop	Linux	5.4.0	2
+Chrome	133.0.6943.53	desktop	Linux	6.9.3	2
+Chrome	133.0.6943.54	desktop	Macintosh	Intel 14.7	2
+Chrome	133.0.6943.54	desktop	Macintosh	Intel 15.2	2
+Chrome	133.0.6943.55	desktop	Macintosh	Intel 14.6	2
+Chrome	133.0.6943.89	mobile	Android	14.0.0	2
+Chrome	133.0.6943.98	desktop	Linux	5.3.18	2
+Chrome	133.0.6943.98	desktop	Linux	5.4.0	2
+Chrome	133.0.6943.98	desktop	Linux	6.5.0	2
+Chrome	133.0.6943.98	desktop	Macintosh	Intel 14.5	2
+Chrome	133.0.6943.98	desktop	Macintosh	Intel 14.6	2
+Chrome	133.0.6943.99	desktop	Macintosh	Intel 14.6	2
+Chrome	134.0.0.0	desktop	Macintosh	Intel 13.0	2
+Chrome	134.0.0.0	desktop	Macintosh	Intel 15.1	2
+Chrome	134.0.0.0	desktop	Macintosh	Intel 15.2	2
+Chrome	134.0.0.0	mobile	Android	10	2
+Chrome	134.0.6998.109	mobile	Android	12.0.0	2
+Chrome	134.0.6998.109	mobile	Android	13.0.0	2
+Chrome	134.0.6998.109	mobile	Android	15.0.0	2
+Chrome	134.0.6998.117	desktop	Linux	5.15.0	2
+Chrome	134.0.6998.118	desktop	Macintosh	Intel 13.5	2
+Chrome	134.0.6998.118	desktop	Macintosh	Intel 14.6	2
+Chrome	134.0.6998.118	desktop	Macintosh	Intel 15.2	2
+Chrome	134.0.6998.135	mobile	Android	8.0.0	2
+Chrome	134.0.6998.165	desktop	Macintosh	Intel 15.1	2
+Chrome	134.0.6998.165	desktop	Windows	11	2
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 11.5	2
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 12.5	2
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 12.7	2
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 13.6	2
+Chrome	134.0.6998.167	desktop	Macintosh	Intel 12.7	2
+Chrome	134.0.6998.167	desktop	Macintosh	Intel 13.2	2
+Chrome	134.0.6998.167	desktop	Macintosh	Intel 14.6	2
+Chrome	134.0.6998.167	desktop	Macintosh	Intel 15.3	2
+Chrome	134.0.6998.205	desktop	Linux	6.11.0	2
+Chrome	134.0.6998.205	desktop	Linux	6.15.6	2
+Chrome	134.0.6998.205	desktop	Macintosh	Intel 14.5	2
+Chrome	134.0.6998.207	tablet	Android	9	2
+Chrome	134.0.6998.35	desktop	Linux	5.4.0	2
+Chrome	134.0.6998.36	desktop	Macintosh	Intel 13.0	2
+Chrome	134.0.6998.39	mobile	Android	11.0.0	2
+Chrome	134.0.6998.44	desktop	Macintosh	Intel 15.3	2
+Chrome	134.0.6998.44	desktop	Macintosh	Intel 15.4	2
+Chrome	134.0.6998.45	desktop	Macintosh	Intel 14.5	2
+Chrome	134.0.6998.45	desktop	Macintosh	Intel 15.1	2
+Chrome	134.0.6998.88	desktop	Linux	5.4.0	2
+Chrome	134.0.6998.88	desktop	Windows	11	2
+Chrome	134.0.6998.89	desktop	Macintosh	Intel 13.6	2
+Chrome	134.0.6998.89	desktop	Macintosh	Intel 15.2	2
+Chrome	134.0.6998.895	mobile	Android	12.0.0	2
+Chrome	134.0.6998.895	mobile	Android	14.0.0	2
+Chrome	134.0.6998.90	desktop	Windows	10	2
+Chrome	134.0.6998.903	mobile	Android	10	2
+Chrome	134.0.6998.95	mobile	Android	9.0.0	2
+Chrome	134.0.6998.99	mobile	iOS	16.7.11	2
+Chrome	134.0.6998.99	mobile	iOS	18.3.2	2
+Chrome	134.0.6998.99	mobile	iOS	18.4.1	2
+Chrome	134.0.6998.99	mobile	iOS	18.6.0	2
+Chrome	135.0.0.0	desktop	Linux	5.15.0	2
+Chrome	135.0.0.0	desktop	Linux	6.1.0	2
+Chrome	135.0.0.0	desktop	Linux	6.14.2	2
+Chrome	135.0.0.0	desktop	Linux	6.14.4	2
+Chrome	135.0.0.0	desktop	Macintosh	Intel 13.0	2
+Chrome	135.0.0.0	desktop	Macintosh	Intel 14.4	2
+Chrome	135.0.0.0	desktop	Macintosh	Intel 15.0	2
+Chrome	135.0.0.0	desktop	Macintosh	Intel 15.3	2
+Chrome	135.0.7049.100	mobile	Android	8.0.0	2
+Chrome	135.0.7049.101	mobile	Android	15.0.0	2
+Chrome	135.0.7049.111	mobile	Android	15	2
+Chrome	135.0.7049.113	mobile	Android	10.0.0	2
+Chrome	135.0.7049.114	desktop	Linux	6.14.0	2
+Chrome	135.0.7049.114	desktop	Linux	6.14.4	2
+Chrome	135.0.7049.114	desktop	Linux	6.2.0	2
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 11.7	2
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 12.4	2
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 13.1	2
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 13.3	2
+Chrome	135.0.7049.116	desktop	Macintosh	Intel 12.5	2
+Chrome	135.0.7049.116	desktop	Macintosh	Intel 12.7	2
+Chrome	135.0.7049.116	desktop	Macintosh	Intel 13.4	2
+Chrome	135.0.7049.116	desktop	Macintosh	Intel 13.6	2
+Chrome	135.0.7049.116	desktop	Macintosh	Intel 14.0	2
+Chrome	135.0.7049.116	desktop	Macintosh	Intel 15.1	2
+Chrome	135.0.7049.128	desktop	Chrome OS	aarch64 16209.67.0	2
+Chrome	135.0.7049.236	mobile	Android	13.0.0	2
+Chrome	135.0.7049.264	mobile	Android	11.0.0	2
+Chrome	135.0.7049.264	mobile	Android	15.0.0	2
+Chrome	135.0.7049.38	mobile	Android	8.1.0	2
+Chrome	135.0.7049.38	tablet	Android	14.0.0	2
+Chrome	135.0.7049.39	mobile	Android	11.0.0	2
+Chrome	135.0.7049.39	mobile	Android	13.0.0	2
+Chrome	135.0.7049.39	mobile	Android	15.0.0	2
+Chrome	135.0.7049.41	desktop	Macintosh	Intel 12.5	2
+Chrome	135.0.7049.42	desktop	Macintosh	Intel 12.5	2
+Chrome	135.0.7049.42	desktop	Macintosh	Intel 13.7	2
+Chrome	135.0.7049.42	desktop	Macintosh	Intel 14.1	2
+Chrome	135.0.7049.43	desktop	Macintosh	Intel 15.0	2
+Chrome	135.0.7049.43	desktop	Macintosh	Intel 15.3	2
+Chrome	135.0.7049.43	desktop	Windows	11	2
+Chrome	135.0.7049.52	desktop	Linux	5.4.0	2
+Chrome	135.0.7049.52	desktop	Linux	6.12.9	2
+Chrome	135.0.7049.52	desktop	Linux	6.5.0	2
+Chrome	135.0.7049.83	mobile	iOS	16.7.11	2
+Chrome	135.0.7049.83	mobile	iOS	18.2.1	2
+Chrome	135.0.7049.83	mobile	iOS	18.3.2	2
+Chrome	135.0.7049.83	mobile	iOS	18.4.1	2
+Chrome	135.0.7049.84	desktop	Linux	6.14.0	2
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 12.7	2
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 13.2	2
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 13.3	2
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 13.4	2
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 13.5	2
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 13.7	2
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 14.1	2
+Chrome	135.0.7049.86	desktop	Macintosh	Intel 15.3	2
+Chrome	135.0.7049.86	desktop	Windows	10	2
+Chrome	135.0.7049.95	desktop	Linux	6.12.10	2
+Chrome	135.0.7049.95	desktop	Linux	6.12.20	2
+Chrome	135.0.7049.95	desktop	Linux	6.5.0	2
+Chrome	135.0.7049.95	desktop	Macintosh	Intel 12.5	2
+Chrome	135.0.7049.95	desktop	Macintosh	Intel 15.3	2
+Chrome	135.0.7049.95	desktop	Macintosh	Intel 15.4	2
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 11.7	2
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 13.0	2
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 13.2	2
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 13.4	2
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 13.5	2
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 14.0	2
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 14.1	2
+Chrome	135.0.7049.97	desktop	Macintosh	Intel 14.4	2
+Chrome	135.0.7049.97	desktop	Macintosh	Intel 14.5	2
+Chrome	135.0.7049.97	desktop	Macintosh	Intel 15.0	2
+Chrome	135.0.7049.97	desktop	Windows	10	2
+Chrome	136.0.0.0	desktop	Linux	6.12.25	2
+Chrome	136.0.0.0	desktop	Linux	6.12.28	2
+Chrome	136.0.0.0	desktop	Linux	6.14.5	2
+Chrome	136.0.0.0	desktop	Macintosh	Intel 14.7	2
+Chrome	136.0.0.0	desktop	Macintosh	Intel 15.2	2
+Chrome	136.0.0.0	desktop	Macintosh	Intel 15.4	2
+Chrome	136.0.0.0	desktop	Windows	7	2
+Chrome	136.0.0.0	mobile	Android	6.0	2
+Chrome	136.0.0.0	mobile	Macintosh	 10.15	2
+Chrome	136.0.7049.38	mobile	Android	14.0.0	2
+Chrome	136.0.7103.113	desktop	Linux	4.18.0	2
+Chrome	136.0.7103.113	desktop	Linux	6.12.13	2
+Chrome	136.0.7103.113	desktop	Linux	6.12.28	2
+Chrome	136.0.7103.113	desktop	Linux	6.12.30	2
+Chrome	136.0.7103.113	desktop	Linux	6.14.5	2
+Chrome	136.0.7103.113	desktop	Linux	6.15.1	2
+Chrome	136.0.7103.113	desktop	Linux	6.15.2	2
+Chrome	136.0.7103.113	desktop	Linux	6.15.4	2
+Chrome	136.0.7103.113	desktop	Linux	6.8.11	2
+Chrome	136.0.7103.113	desktop	Macintosh	Intel 15.0	2
+Chrome	136.0.7103.113	desktop	Macintosh	Intel 15.5	2
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 11.3	2
+Chrome	136.0.7103.114	mobile	Macintosh	 15.5	2
+Chrome	136.0.7103.115	desktop	Macintosh	Intel 14.5	2
+Chrome	136.0.7103.115	desktop	Macintosh	Intel 14.6	2
+Chrome	136.0.7103.115	desktop	Windows	10	2
+Chrome	136.0.7103.115	desktop	Windows	11	2
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 11.6	2
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 12.7	2
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 13.2	2
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 13.4	2
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 13.7	2
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 14.0	2
+Chrome	136.0.7103.125	mobile	Android	10	2
+Chrome	136.0.7103.125	mobile	Android	16.0.0	2
+Chrome	136.0.7103.125	mobile	Android	9	2
+Chrome	136.0.7103.128	mobile	Android	14.0.0	2
+Chrome	136.0.7103.162	desktop	Linux	6.12.10	2
+Chrome	136.0.7103.170	desktop	Macintosh	Intel 15.5	2
+Chrome	136.0.7103.177	desktop	Macintosh	Intel 14.3	2
+Chrome	136.0.7103.177	desktop	Macintosh	Intel 15.4	2
+Chrome	136.0.7103.179	desktop	Linux	6.11.0	2
+Chrome	136.0.7103.179	desktop	Linux	6.15.4	2
+Chrome	136.0.7103.311	mobile	Android	15.0.0	2
+Chrome	136.0.7103.33	desktop	Linux	5.15.0	2
+Chrome	136.0.7103.42	mobile	iOS	18.3.2	2
+Chrome	136.0.7103.44	mobile	Android	14.0.0	2
+Chrome	136.0.7103.48	desktop	Macintosh	Intel 13.3	2
+Chrome	136.0.7103.48	desktop	Macintosh	Intel 13.5	2
+Chrome	136.0.7103.48	desktop	Macintosh	Intel 13.7	2
+Chrome	136.0.7103.48	desktop	Macintosh	Intel 14.4	2
+Chrome	136.0.7103.48	desktop	Macintosh	Intel 14.6	2
+Chrome	136.0.7103.48	desktop	Macintosh	Intel 14.7	2
+Chrome	136.0.7103.48	desktop	Macintosh	Intel 15.1	2
+Chrome	136.0.7103.48	desktop	Macintosh	Intel 15.2	2
+Chrome	136.0.7103.49	desktop	Macintosh	Intel 15.2	2
+Chrome	136.0.7103.49	desktop	Macintosh	Intel 15.3	2
+Chrome	136.0.7103.59	desktop	Linux	6.1.0	2
+Chrome	136.0.7103.59	desktop	Linux	6.5.13	2
+Chrome	136.0.7103.59	desktop	Linux	6.9.3	2
+Chrome	136.0.7103.60	mobile	Android	11	2
+Chrome	136.0.7103.60	mobile	Android	9.0.0	2
+Chrome	136.0.7103.61	mobile	Android	10.0.0	2
+Chrome	136.0.7103.61	mobile	Android	12.0.0	2
+Chrome	136.0.7103.87	tablet	Android	11.0.0	2
+Chrome	136.0.7103.88	mobile	Android	10.0.0	2
+Chrome	136.0.7103.896	mobile	Android	14.0.0	2
+Chrome	136.0.7103.896	mobile	Android	15.0.0	2
+Chrome	136.0.7103.91	mobile	iOS	17.6.1	2
+Chrome	136.0.7103.91	mobile	iOS	18.0.1	2
+Chrome	136.0.7103.91	mobile	iOS	18.2.0	2
+Chrome	136.0.7103.91	mobile	iOS	18.3.2	2
+Chrome	136.0.7103.91	tablet	iOS	18.4.1	2
+Chrome	136.0.7103.92	desktop	Linux	6.1.0	2
+Chrome	136.0.7103.92	desktop	Linux	6.12.10	2
+Chrome	136.0.7103.92	desktop	Linux	6.14.6	2
+Chrome	136.0.7103.92	desktop	Linux	6.2.0	2
+Chrome	136.0.7103.92	desktop	Windows	11	2
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 11.7	2
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 12.0	2
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 12.4	2
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 12.5	2
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 13.1	2
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 14.0	2
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 15.2	2
+Chrome	136.0.7103.94	desktop	Macintosh	Intel 14.6	2
+Chrome	136.0.7103.94	desktop	Macintosh	Intel 14.7	2
+Chrome	136.0.7103.94	desktop	Macintosh	Intel 15.3	2
+Chrome	136.0.7103.94	desktop	Macintosh	Intel 15.4	2
+Chrome	136.0.7103.961	mobile	Android	15.0.0	2
+Chrome	137.0.0.0	desktop	Linux	6.12.10	2
+Chrome	137.0.0.0	desktop	Linux	6.12.31	2
+Chrome	137.0.0.0	desktop	Linux	6.12.35	2
+Chrome	137.0.0.0	desktop	Linux	6.14.6	2
+Chrome	137.0.0.0	desktop	Linux	6.14.7	2
+Chrome	137.0.0.0	desktop	Linux	6.2.0	2
+Chrome	137.0.0.0	desktop	Linux	6.5.0	2
+Chrome	137.0.0.0	desktop	Linux	6.6.90	2
+Chrome	137.0.0.0	desktop	Macintosh	Intel 13.3	2
+Chrome	137.0.0.0	desktop	Macintosh	Intel 13.5	2
+Chrome	137.0.3296.92	mobile	iOS	18.5.0	2
+Chrome	137.0.7141.3	desktop	Windows	10	2
+Chrome	137.0.7151.100	mobile	Android	15.0.0	2
+Chrome	137.0.7151.103	desktop	Linux	6.12.25	2
+Chrome	137.0.7151.103	desktop	Linux	6.14.11	2
+Chrome	137.0.7151.103	desktop	Linux	6.14.5	2
+Chrome	137.0.7151.103	desktop	Macintosh	Intel 11.7	2
+Chrome	137.0.7151.103	desktop	Macintosh	Intel 12.7	2
+Chrome	137.0.7151.103	desktop	Macintosh	Intel 14.0	2
+Chrome	137.0.7151.103	desktop	Macintosh	Intel 14.1	2
+Chrome	137.0.7151.103	desktop	Macintosh	Intel 14.3	2
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 11.1	2
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 11.6	2
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 12.1	2
+Chrome	137.0.7151.104	mobile	Macintosh	 15.5	2
+Chrome	137.0.7151.104	mobile	Windows	10	2
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 12.1	2
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 13.4	2
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 13.6	2
+Chrome	137.0.7151.107	mobile	iOS	16.0.0	2
+Chrome	137.0.7151.107	mobile	iOS	16.2.0	2
+Chrome	137.0.7151.107	mobile	iOS	16.3.0	2
+Chrome	137.0.7151.107	mobile	iOS	16.4.1	2
+Chrome	137.0.7151.107	mobile	iOS	17.1.2	2
+Chrome	137.0.7151.107	mobile	iOS	17.3.1	2
+Chrome	137.0.7151.107	mobile	iOS	17.7.0	2
+Chrome	137.0.7151.116	mobile	Android	13.0.0	2
+Chrome	137.0.7151.117	tablet	Android	10.0.0	2
+Chrome	137.0.7151.118	mobile	Android	8.1.0	2
+Chrome	137.0.7151.119	desktop	Linux	5.14.0	2
+Chrome	137.0.7151.119	desktop	Linux	6.12.27	2
+Chrome	137.0.7151.119	desktop	Linux	6.12.28	2
+Chrome	137.0.7151.119	desktop	Linux	6.12.33	2
+Chrome	137.0.7151.119	desktop	Linux	6.13.12	2
+Chrome	137.0.7151.119	desktop	Linux	6.13.5	2
+Chrome	137.0.7151.119	desktop	Linux	6.14.8	2
+Chrome	137.0.7151.119	desktop	Linux	6.15.6	2
+Chrome	137.0.7151.119	desktop	Linux	6.9.3	2
+Chrome	137.0.7151.119	desktop	Macintosh	 10.15	2
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 13.2	2
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 13.3	2
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 13.4	2
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 13.6	2
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 14.0	2
+Chrome	137.0.7151.119	mobile	Android	11.0	2
+Chrome	137.0.7151.120	mobile	Android	13	2
+Chrome	137.0.7151.120	mobile	Android	13.0.0	2
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 11.7	2
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 14.1	2
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 14.2	2
+Chrome	137.0.7151.123	mobile	Android	11.0	2
+Chrome	137.0.7151.123	mobile	Chrome OS	x86_64 16267.51.0	2
+Chrome	137.0.7151.132	mobile	Chrome OS	x86_64 16267.60.0	2
+Chrome	137.0.7151.137	mobile	Chrome OS	x86_64 16267.66.0	2
+Chrome	137.0.7151.14	mobile	Android	13.0.0	2
+Chrome	137.0.7151.17	desktop	Chrome OS	x86_64 16267.11.0	2
+Chrome	137.0.7151.41	desktop	Macintosh	Intel 14.5	2
+Chrome	137.0.7151.41	desktop	Macintosh	Intel 14.6	2
+Chrome	137.0.7151.51	mobile	iOS	16.3.1	2
+Chrome	137.0.7151.51	mobile	iOS	18.1.1	2
+Chrome	137.0.7151.51	mobile	iOS	18.3.1	2
+Chrome	137.0.7151.51	mobile	iOS	18.4.0	2
+Chrome	137.0.7151.51	tablet	iOS	16.7.11	2
+Chrome	137.0.7151.55	desktop	Linux	5.14.0	2
+Chrome	137.0.7151.55	desktop	Linux	6.11.9	2
+Chrome	137.0.7151.55	desktop	Linux	6.12.13	2
+Chrome	137.0.7151.55	desktop	Linux	6.2.0	2
+Chrome	137.0.7151.55	desktop	Macintosh	 10.15	2
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 10.15	2
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 13.6	2
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 14.1	2
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 14.2	2
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 13.0	2
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 13.1	2
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 13.4	2
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 13.6	2
+Chrome	137.0.7151.57	desktop	Macintosh	Intel 12.7	2
+Chrome	137.0.7151.61	mobile	Android	10.0.0	2
+Chrome	137.0.7151.61	mobile	Android	12.0.0	2
+Chrome	137.0.7151.61	mobile	Android	13	2
+Chrome	137.0.7151.68	desktop	Linux	5.19.0	2
+Chrome	137.0.7151.68	desktop	Linux	6.11.2	2
+Chrome	137.0.7151.68	desktop	Linux	6.12.32	2
+Chrome	137.0.7151.68	desktop	Linux	6.12.34	2
+Chrome	137.0.7151.68	desktop	Linux	6.13.7	2
+Chrome	137.0.7151.68	desktop	Linux	6.14.6	2
+Chrome	137.0.7151.68	desktop	Linux	6.15.2	2
+Chrome	137.0.7151.68	desktop	Linux	6.15.3	2
+Chrome	137.0.7151.68	desktop	Linux	6.7.10	2
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 11.7	2
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 12.7	2
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 15.0	2
+Chrome	137.0.7151.68	mobile	Android	6.0.1	2
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 11.5	2
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 12.1	2
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 14.3	2
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 15.2	2
+Chrome	137.0.7151.72	mobile	Android	15	2
+Chrome	137.0.7151.79	mobile	iOS	18.2.1	2
+Chrome	137.0.7151.79	mobile	iOS	18.4.1	2
+Chrome	137.0.7151.79	mobile	iOS	18.6.0	2
+Chrome	137.0.7151.79	mobile	iOS	19.0.0	2
+Chrome	137.0.7151.79	tablet	iOS	16.7.11	2
+Chrome	137.0.7151.89	desktop	Windows	(not set)	2
+Chrome	137.0.7151.89	tablet	Android	12.0.0	2
+Chrome	137.0.7151.89	tablet	Android	13.0.0	2
+Chrome	138.0.0.0	desktop	Linux	5.4.0	2
+Chrome	138.0.0.0	desktop	Linux	6.14.11	2
+Chrome	138.0.0.0	desktop	Linux	6.14.8	2
+Chrome	138.0.0.0	desktop	Linux	6.15.7	2
+Chrome	138.0.0.0	desktop	Linux	6.6.94	2
+Chrome	138.0.0.0	desktop	Macintosh	Intel 13.2	2
+Chrome	138.0.0.0	desktop	Macintosh	Intel 14.0	2
+Chrome	138.0.7166.3	desktop	Windows	11	2
+Chrome	138.0.7188.0	desktop	Chrome OS	x86_64 16290.0.0	2
+Chrome	138.0.7204.100	desktop	Linux	4.18.0	2
+Chrome	138.0.7204.100	desktop	Linux	5.14.0	2
+Chrome	138.0.7204.100	desktop	Linux	5.19.0	2
+Chrome	138.0.7204.100	desktop	Linux	6.12.20	2
+Chrome	138.0.7204.100	desktop	Linux	6.12.32	2
+Chrome	138.0.7204.100	desktop	Linux	6.12.34	2
+Chrome	138.0.7204.100	desktop	Linux	6.14.11	2
+Chrome	138.0.7204.100	desktop	Linux	6.9.0	2
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 12.0	2
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 12.1	2
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 12.2	2
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 12.6	2
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 26.0	2
+Chrome	138.0.7204.100	mobile	Android	11.0	2
+Chrome	138.0.7204.100	mobile	Android	6.0	2
+Chrome	138.0.7204.100	mobile	Windows	11	2
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 11.0	2
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 11.4	2
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 11.5	2
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 12.1	2
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 12.2	2
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 12.5	2
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 16.0	2
+Chrome	138.0.7204.102	mobile	Windows	10	2
+Chrome	138.0.7204.119	mobile	iOS	17.0.2	2
+Chrome	138.0.7204.119	mobile	iOS	17.3.1	2
+Chrome	138.0.7204.119	tablet	iOS	17.7.0	2
+Chrome	138.0.7204.119	tablet	iOS	18.3.2	2
+Chrome	138.0.7204.139	mobile	Android	14	2
+Chrome	138.0.7204.14	mobile	Android	14.0.0	2
+Chrome	138.0.7204.143	desktop	Linux	6.12.34	2
+Chrome	138.0.7204.143	desktop	Linux	6.15.5	2
+Chrome	138.0.7204.143	desktop	Linux	6.8.0	2
+Chrome	138.0.7204.156	mobile	iOS	17.1.0	2
+Chrome	138.0.7204.156	mobile	iOS	17.4.1	2
+Chrome	138.0.7204.156	mobile	iOS	17.5.1	2
+Chrome	138.0.7204.156	mobile	iOS	18.2.1	2
+Chrome	138.0.7204.156	mobile	iOS	18.4.0	2
+Chrome	138.0.7204.156	mobile	iOS	18.4.1	2
+Chrome	138.0.7204.156	tablet	iOS	18.4.1	2
+Chrome	138.0.7204.157	desktop	Linux	4.18.0	2
+Chrome	138.0.7204.157	desktop	Linux	6.12.32	2
+Chrome	138.0.7204.157	desktop	Linux	6.12.33	2
+Chrome	138.0.7204.157	desktop	Linux	6.15.5	2
+Chrome	138.0.7204.157	desktop	Linux	6.2.0	2
+Chrome	138.0.7204.157	desktop	Linux	6.5.0	2
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 12.0	2
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 12.4	2
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 13.6	2
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 14.0	2
+Chrome	138.0.7204.157	mobile	Android	9	2
+Chrome	138.0.7204.158	desktop	Macintosh	 10.15	2
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 10.15	2
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 11.2	2
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 11.5	2
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 11.6	2
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 12.1	2
+Chrome	138.0.7204.158	mobile	Macintosh	 15.5	2
+Chrome	138.0.7204.22	desktop	Chrome OS	x86_64 16295.17.0	2
+Chrome	138.0.7204.23	desktop	Windows	11	2
+Chrome	138.0.7204.3	mobile	Android	15.0.0	2
+Chrome	138.0.7204.32	mobile	Android	15.0.0	2
+Chrome	138.0.7204.35	desktop	Macintosh	Intel 13.7	2
+Chrome	138.0.7204.35	desktop	Macintosh	Intel 14.5	2
+Chrome	138.0.7204.35	desktop	Macintosh	Intel 15.0	2
+Chrome	138.0.7204.35	desktop	Macintosh	Intel 15.1	2
+Chrome	138.0.7204.35	desktop	Macintosh	Intel 15.4	2
+Chrome	138.0.7204.35	mobile	Android	9.0.0	2
+Chrome	138.0.7204.45	desktop	Linux	(not set)	2
+Chrome	138.0.7204.45	mobile	Android	8.0.0	2
+Chrome	138.0.7204.45	tablet	Android	10.0.0	2
+Chrome	138.0.7204.45	tablet	Android	9.0.0	2
+Chrome	138.0.7204.49	desktop	Linux	6.12.12	2
+Chrome	138.0.7204.49	desktop	Linux	6.12.30	2
+Chrome	138.0.7204.49	desktop	Linux	6.12.9	2
+Chrome	138.0.7204.49	desktop	Linux	6.14.9	2
+Chrome	138.0.7204.49	desktop	Macintosh	 10.15	2
+Chrome	138.0.7204.49	mobile	Windows	10	2
+Chrome	138.0.7204.50	desktop	Linux	5.15.0	2
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 12.5	2
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 13.3	2
+Chrome	138.0.7204.50	mobile	Android	11.0	2
+Chrome	138.0.7204.50	mobile	Macintosh	 15.5	2
+Chrome	138.0.7204.50	mobile	Windows	11	2
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 10.15	2
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 11.5	2
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 12.0	2
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 12.3	2
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 13.0	2
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 26.0	2
+Chrome	138.0.7204.53	mobile	iOS	18.2.0	2
+Chrome	138.0.7204.56	mobile	iOS	17.7.0	2
+Chrome	138.0.7204.56	mobile	iOS	18.1.0	2
+Chrome	138.0.7204.56	mobile	iOS	18.3.0	2
+Chrome	138.0.7204.56	tablet	iOS	19.0.0	2
+Chrome	138.0.7204.63	tablet	Android	16.0.0	2
+Chrome	138.0.7204.64	mobile	Android	8.0.0	2
+Chrome	138.0.7204.67	desktop	Linux	(not set)	2
+Chrome	138.0.7204.68	mobile	Android	10	2
+Chrome	138.0.7204.92	desktop	Linux	4.18.0	2
+Chrome	138.0.7204.92	desktop	Linux	5.14.18	2
+Chrome	138.0.7204.92	desktop	Linux	6.12.12	2
+Chrome	138.0.7204.92	desktop	Linux	6.12.32	2
+Chrome	138.0.7204.92	desktop	Linux	6.12.37	2
+Chrome	138.0.7204.92	desktop	Linux	6.14.6	2
+Chrome	138.0.7204.92	desktop	Linux	6.6.94	2
+Chrome	138.0.7204.92	desktop	Linux	6.9.0	2
+Chrome	138.0.7204.92	desktop	Linux	6.9.3	2
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 12.3	2
+Chrome	138.0.7204.93	desktop	Macintosh	Intel 11.0	2
+Chrome	138.0.7204.93	mobile	Android	11.0	2
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 12.4	2
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 13.0	2
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 16.0	2
+Chrome	138.0.7204.94	mobile	Android	6.0	2
+Chrome	138.0.7204.96	desktop	Macintosh	 10.15	2
+Chrome	138.0.7204.96	desktop	Macintosh	Intel 10.15	2
+Chrome	138.0.7204.96	mobile	Windows	11	2
+Chrome	138.0.7204.97	desktop	Linux	5.15.0	2
+Chrome	138.0.7204.97	desktop	Macintosh	Intel 15.5	2
+Chrome	138.0.7204.97	smart tv	Windows	10	2
+Chrome	139	mobile	iOS	(not set)	2
+Chrome	139.0.0.0	desktop	Macintosh	Intel 15.4	2
+Chrome	139.0.0.0	mobile	Android	12.0.0	2
+Chrome	139.0.0.0	mobile	Android	8.1.0	2
+Chrome	139.0.7246.0	mobile	Android	12.0.0	2
+Chrome	139.0.7246.0	tablet	Android	10.0.0	2
+Chrome	139.0.7246.2	desktop	Macintosh	Intel 15.4	2
+Chrome	139.0.7246.2	desktop	Macintosh	Intel 15.6	2
+Chrome	139.0.7247.0	desktop	Chrome OS	x86_64 16324.0.0	2
+Chrome	139.0.7258.0	desktop	Windows	11	2
+Chrome	139.0.7258.2	desktop	Macintosh	Intel 15.5	2
+Chrome	139.0.7258.2	desktop	Windows	11	2
+Chrome	139.0.7258.3	mobile	Android	12	2
+Chrome	139.0.7258.3	tablet	Android	11.0.0	2
+Chrome	139.0.7258.3	tablet	Android	15.0.0	2
+Chrome	139.0.7258.32	tablet	Android	11.0.0	2
+Chrome	139.0.7258.41	mobile	Android	10.0.0	2
+Chrome	139.0.7258.5	desktop	Linux	5.15.0	2
+Chrome	139.0.7258.5	desktop	Macintosh	Intel 14.7	2
+Chrome	139.0.7258.5	desktop	Macintosh	Intel 15.1	2
+Chrome	139.0.7258.5	desktop	Macintosh	Intel 15.6	2
+Chrome	139.0.7258.5	desktop	Macintosh	Intel 16.0	2
+Chrome	139.0.7258.7	mobile	iOS	19.0.0	2
+Chrome	140.0.7259.0	desktop	Macintosh	Intel 15.5	2
+Chrome	140.0.7259.2	desktop	Macintosh	Intel 14.5	2
+Chrome	140.0.7259.2	desktop	Macintosh	Intel 15.6	2
+Chrome	140.0.7259.2	desktop	Macintosh	Intel 16.0	2
+Chrome	140.0.7259.2	desktop	Macintosh	Intel 26.0	2
+Chrome	140.0.7261.0	desktop	Macintosh	Intel 15.3	2
+Chrome	140.0.7262.0	desktop	Macintosh	Intel 15.5	2
+Chrome	140.0.7262.0	desktop	Windows	11	2
+Chrome	140.0.7263.0	desktop	Macintosh	Intel 15.5	2
+Chrome	140.0.7267.0	desktop	Windows	10	2
+Chrome	140.0.7267.0	desktop	Windows	11	2
+Chrome	140.0.7268.0	desktop	Windows	10	2
+Chrome	140.0.7269.0	desktop	Macintosh	Intel 15.5	2
+Chrome	140.0.7270.0	desktop	Windows	11	2
+Chrome	140.0.7273.0	desktop	Windows	11	2
+Chrome	140.0.7274.0	desktop	Macintosh	Intel 15.5	2
+Chrome	140.0.7275.0	desktop	Macintosh	Intel 14.3	2
+Chrome	140.0.7276.0	desktop	Windows	11	2
+Chrome	140.0.7285.0	desktop	Windows	11	2
+Chrome	140.0.7286.0	desktop	Macintosh	Intel 15.5	2
+Chrome	140.0.7286.0	desktop	Windows	10	2
+Chrome	140.0.7288.0	desktop	Macintosh	Intel 15.4	2
+Chrome	140.0.7292.0	desktop	Macintosh	Intel 15.5	2
+Chrome	140.0.7293.0	desktop	Macintosh	Intel 15.5	2
+Chrome	140.0.7293.0	desktop	Windows	11	2
+Chrome	140.0.7294.0	desktop	Macintosh	Intel 15.5	2
+Chrome	140.0.7294.0	desktop	Windows	10	2
+Chrome	140.0.7294.0	desktop	Windows	11	2
+Chrome	140.0.7295.0	desktop	Windows	10	2
+Chrome	140.0.7295.0	desktop	Windows	11	2
+Chrome	140.0.7296.0	desktop	Windows	10	2
+Chrome	140.0.7296.0	mobile	Android	12.0.0	2
+Chrome	140.0.7297.0	desktop	Macintosh	Intel 14.6	2
+Chrome	140.0.7299.0	mobile	Android	11.0.0	2
+Chrome	140.0.7299.0	mobile	Android	12.0.0	2
+Chrome	140.0.7301.0	desktop	Macintosh	Intel 15.5	2
+Chrome	140.0.7303.0	desktop	Macintosh	Intel 15.5	2
+Chrome	140.0.7307.0	desktop	Windows	11	2
+Chrome	140.0.7308.0	desktop	Windows	11	2
+Chrome	38.0.2125.102	mobile	Android	5.0	2
+Chrome	41.0.2224.3	desktop	Windows	XP	2
+Chrome	52.0.2743.33	mobile	Android	6.0.1	2
+Chrome	58.0.3029.83	mobile	Android	6.0.1	2
+Chrome	59.0.3071.92	mobile	Android	7.1	2
+Chrome	61.0.3163.128	desktop	Linux	(not set)	2
+Chrome	62.0.3202.84	desktop	Windows	Server 2003	2
+Chrome	63.0.3239.132	desktop	Windows	10	2
+Chrome	64.0.3282.123	mobile	Android	5.0.2	2
+Chrome	65.0.3325.109	mobile	Android	8.0.0	2
+Chrome	65.0.3325.181	desktop	Linux	(not set)	2
+Chrome	65.0.3325.209	desktop	Chrome OS	x86_64 10323.67.9	2
+Chrome	67.0.3396.87	mobile	Android	8.0.0	2
+Chrome	67.0.3396.87	mobile	Android	8.1.0	2
+Chrome	67.0.3396.99	desktop	Windows	7	2
+Chrome	68.0.3440.106	desktop	Linux	(not set)	2
+Chrome	69.0.3497.100	mobile	Android	8.0.0	2
+Chrome	70.0.3538.110	mobile	Android	10	2
+Chrome	70.0.3538.110	tablet	Android	8.0.0	2
+Chrome	71.0.3578.141	desktop	Linux	(not set)	2
+Chrome	71.0.3578.99	tablet	Android	4.2.2	2
+Chrome	72.0.3626.81	desktop	Windows	10	2
+Chrome	74.0.3729.108	smart tv	Linux	(not set)	2
+Chrome	74.0.3729.136	desktop	Linux	(not set)	2
+Chrome	74.0.3729.136	mobile	Android	10	2
+Chrome	76.0.3809.102	desktop	Chrome OS	x86_64 12239.67.0	2
+Chrome	77.0.3865.92	mobile	Android	10	2
+Chrome	78.0.3904.96	mobile	Android	9	2
+Chrome	80.0.3987.149	desktop	Windows	10	2
+Chrome	80.0.3987.87	desktop	Windows	10	2
+Chrome	81.0.4044.138	desktop	Linux	(not set)	2
+Chrome	81.0.4044.138	mobile	Android	5.0.2	2
+Chrome	81.0.4044.138	tablet	Android	5.0.1	2
+Chrome	83.0.4103.101	desktop	Linux	(not set)	2
+Chrome	85.0.4178.0	mobile	Android	11	2
+Chrome	86.0.4240.185	mobile	Android	11	2
+Chrome	86.0.4240.198	desktop	Windows	7	2
+Chrome	86.0.4240.198	mobile	Android	12	2
+Chrome	87.0.4280.141	desktop	Windows	10	2
+Chrome	87.0.4280.141	mobile	Android	13	2
+Chrome	87.0.4280.141	mobile	Android	6.0.1	2
+Chrome	87.0.4280.141	mobile	Android	8.1	2
+Chrome	87.0.4280.141	tablet	Android	11	2
+Chrome	87.0.4280.66	mobile	Android	10	2
+Chrome	88.0.4324.146	desktop	Windows	10	2
+Chrome	88.0.4324.181	tablet	Android	10	2
+Chrome	88.0.4324.93	mobile	Android	11	2
+Chrome	89.0.4389.116	mobile	Android	8.1.0	2
+Chrome	90.0.4430.72	desktop	Windows	8	2
+Chrome	90.0.4430.82	mobile	Android	10	2
+Chrome	91.0.4472.147	desktop	Chrome OS	x86_64 13904.77.0	2
+Chrome	94.0.4606.71	desktop	Windows	10	2
+Chrome	95.0.4638.54	desktop	Macintosh	Intel 10.15	2
+Chrome	95.0.4638.69	desktop	Windows	10	2
+Chrome	95.0.4638.74	mobile	Android	11	2
+Chrome	95.0.4638.74	tablet	Android	5.1	2
+Chrome	96.0.4664.104	mobile	Android	11	2
+Chrome	96.0.4664.110	desktop	Windows	10	2
+Chrome	96.0.4664.45	desktop	Windows	10	2
+Chrome	96.0.4664.45	desktop	Windows	7	2
+Chrome	97.0.4692.71	mobile	Android	6.0	2
+Chrome	97.0.4692.98	mobile	Android	10	2
+Chrome	97.0.4692.98	mobile	Android	15	2
+Chrome	98.0.4758.102	desktop	Windows	10	2
+Chrome	98.0.4758.9	desktop	Windows	10	2
+Chrome	99.0.4844.59	mobile	iOS	15.8	2
+Coc Coc	90.0.146	desktop	Windows	10	2
+DuckDuckGo Browser	5	mobile	Android	11	2
+Edge	109.0.1518.78	desktop	Windows	10	2
+Edge	116.0.1938.76	desktop	Windows	10	2
+Edge	120.0.2210.61	desktop	Windows	11	2
+Edge	121.0.2277.98	desktop	Windows	10	2
+Edge	123.0.2420.81	desktop	Windows	10	2
+Edge	123.0.2420.97	desktop	Windows	10	2
+Edge	126.0.2592.87	desktop	Windows	10	2
+Edge	126.0.2592.87	desktop	Windows	11	2
+Edge	127.0.2651.86	desktop	Windows	11	2
+Edge	127.0.2651.98	desktop	Windows	11	2
+Edge	128.0.0.0	desktop	Windows	10	2
+Edge	128.0.2739.42	desktop	Windows	11	2
+Edge	128.0.2739.67	desktop	Linux	6.8.0	2
+Edge	129.0.2792.65	desktop	Windows	10	2
+Edge	130.0.2849.56	desktop	Windows	10	2
+Edge	130.0.2849.68	desktop	Linux	6.8.0	2
+Edge	131.0.0.0	desktop	Windows	10	2
+Edge	131.0.2903.63	desktop	Macintosh	Intel 15.5	2
+Edge	131.0.2903.70	desktop	Windows	10	2
+Edge	131.0.2903.99	desktop	Windows	11	2
+Edge	132.0.2957.127	desktop	Macintosh	Intel 15.5	2
+Edge	132.0.2957.140	desktop	Macintosh	Intel 15.5	2
+Edge	133.0.3065.69	desktop	Linux	6.8.0	2
+Edge	133.0.3065.82	desktop	Macintosh	Intel 15.3	2
+Edge	134.0.3124.68	desktop	Macintosh	Intel 15.5	2
+Edge	134.0.3124.85	desktop	Macintosh	Intel 14.7	2
+Edge	134.0.3124.85	desktop	Macintosh	Intel 15.5	2
+Edge	134.0.3124.85	desktop	Windows	10	2
+Edge	135.0.3179.66	desktop	Windows	10	2
+Edge	135.0.3179.85	mobile	Android	12.0.0	2
+Edge	136.0.3240.50	desktop	Macintosh	Intel 14.7	2
+Edge	136.0.3240.50	desktop	Macintosh	Intel 15.4	2
+Edge	136.0.3240.50	desktop	Macintosh	Intel 15.5	2
+Edge	136.0.3240.76	desktop	Linux	6.11.0	2
+Edge	136.0.3240.76	desktop	Linux	6.14.0	2
+Edge	136.0.3240.76	desktop	Macintosh	Intel 14.4	2
+Edge	136.0.3240.92	desktop	Linux	6.12.10	2
+Edge	136.0.3240.92	desktop	Linux	6.8.0	2
+Edge	136.0.3240.92	desktop	Macintosh	Intel 14.7	2
+Edge	137.0.0.0	mobile	iOS	16.6	2
+Edge	137.0.3296.104	desktop	Windows	11	2
+Edge	137.0.3296.58	desktop	Windows	11	2
+Edge	137.0.3296.62	desktop	Linux	6.11.0	2
+Edge	137.0.3296.65	desktop	Linux	(not set)	2
+Edge	137.0.3296.65	mobile	Android	13.0.0	2
+Edge	137.0.3296.68	desktop	Macintosh	Intel 14.6	2
+Edge	137.0.3296.68	desktop	Macintosh	Intel 14.7	2
+Edge	137.0.3296.68	desktop	Macintosh	Intel 15.4	2
+Edge	137.0.3296.83	desktop	Linux	6.11.0	2
+Edge	137.0.3296.83	desktop	Macintosh	Intel 15.1	2
+Edge	137.0.3296.83	desktop	Macintosh	Intel 15.2	2
+Edge	137.0.3296.83	mobile	Windows	11	2
+Edge	137.0.3296.92	mobile	Android	9.0.0	2
+Edge	137.0.3296.93	desktop	Linux	6.12.10	2
+Edge	137.0.3296.93	desktop	Macintosh	 10.15	2
+Edge	137.0.3296.93	desktop	Macintosh	Intel 10.15	2
+Edge	137.0.3296.93	desktop	Macintosh	Intel 12.7	2
+Edge	137.0.3296.93	desktop	Macintosh	Intel 14.2	2
+Edge	137.0.3296.93	desktop	Macintosh	Intel 15.0	2
+Edge	137.0.3296.93	desktop	Macintosh	Intel 16.0	2
+Edge	137.0.3296.93	mobile	Windows	10	2
+Edge	138.0.3351.35	mobile	Android	15.0.0	2
+Edge	138.0.3351.47	mobile	Android	15.0.0	2
+Edge	138.0.3351.55	desktop	Linux	5.15.0	2
+Edge	138.0.3351.55	desktop	Linux	6.11.0	2
+Edge	138.0.3351.55	desktop	Linux	6.15.3	2
+Edge	138.0.3351.55	desktop	Macintosh	Intel 11.7	2
+Edge	138.0.3351.55	desktop	Macintosh	Intel 13.6	2
+Edge	138.0.3351.55	desktop	Macintosh	Intel 14.4	2
+Edge	138.0.3351.55	desktop	Macintosh	Intel 15.0	2
+Edge	138.0.3351.55	mobile	Android	14.0.0	2
+Edge	138.0.3351.59	desktop	Windows	11	2
+Edge	138.0.3351.65	desktop	Linux	5.15.0	2
+Edge	138.0.3351.65	desktop	Linux	6.12.25	2
+Edge	138.0.3351.65	desktop	Linux	6.15.5	2
+Edge	138.0.3351.65	desktop	Macintosh	Intel 14.1	2
+Edge	138.0.3351.65	desktop	Macintosh	Intel 14.2	2
+Edge	138.0.3351.65	desktop	Macintosh	Intel 14.4	2
+Edge	138.0.3351.65	desktop	Macintosh	Intel 14.5	2
+Edge	138.0.3351.65	desktop	Macintosh	Intel 15.0	2
+Edge	138.0.3351.65	desktop	Macintosh	Intel 15.1	2
+Edge	138.0.3351.65	desktop	Macintosh	Intel 15.6	2
+Edge	138.0.3351.65	desktop	Macintosh	Intel 16.0	2
+Edge	138.0.3351.65	mobile	Windows	11	2
+Edge	138.0.3351.66	mobile	Android	10.0.0	2
+Edge	138.0.3351.69	desktop	Windows	11	2
+Edge	138.0.3351.73	desktop	Windows	11	2
+Edge	138.0.3351.77	desktop	Linux	6.15.4	2
+Edge	138.0.3351.77	desktop	Macintosh	Intel 14.3	2
+Edge	138.0.3351.77	mobile	Android	10.0.0	2
+Edge	138.0.3351.79	desktop	Windows	11	2
+Edge	138.0.3351.83	desktop	Linux	6.11.0	2
+Edge	138.0.3351.83	desktop	Macintosh	Intel 12.7	2
+Edge	138.0.3351.83	desktop	Macintosh	Intel 14.1	2
+Edge	138.0.3351.83	desktop	Macintosh	Intel 14.2	2
+Edge	138.0.3351.83	desktop	Macintosh	Intel 14.4	2
+Edge	138.0.3351.83	desktop	Macintosh	Intel 15.6	2
+Edge	138.0.3351.83	desktop	Macintosh	Intel 26.0	2
+Edge	138.0.3351.83	mobile	Android	10.0.0	2
+Edge	138.0.3351.83	mobile	Android	6.0	2
+Edge	138.0.3351.83	mobile	Windows	10	2
+Edge	138.0.3351.83	mobile	Windows	11	2
+Edge	138.0.3351.93	desktop	Windows	11	2
+Edge	138.0.3351.94	desktop	Windows	11	2
+Edge	138.0.3351.95	desktop	Macintosh	Intel 15.2	2
+Edge	138.0.3351.95	desktop	Macintosh	Intel 16.0	2
+Edge	138.0.3351.95	desktop	Macintosh	Intel 26.0	2
+Edge	138.0.3351.95	mobile	Windows	10	2
+Edge	139.0.3380.1	desktop	Windows	11	2
+Edge	139.0.3394.0	desktop	Windows	11	2
+Edge	139.0.3399.0	desktop	Windows	11	2
+Edge	139.0.3403.0	desktop	Windows	11	2
+Edge	139.0.3405.19	desktop	Windows	11	2
+Edge	139.0.3405.22	desktop	Windows	11	2
+Edge	139.0.3405.24	desktop	Windows	11	2
+Edge	139.0.3405.35	desktop	Windows	11	2
+Edge	139.0.3405.38	desktop	Windows	11	2
+Edge	139.0.3405.44	desktop	Windows	11	2
+Edge	139.0.3405.49	desktop	Windows	11	2
+Edge	140.0.0.0	mobile	Android	6.0	2
+Edge	140.0.3407.0	desktop	Windows	11	2
+Edge	140.0.3438.0	desktop	Windows	11	2
+Edge	140.0.3449.0	desktop	Windows	11	2
+Edge	140.0.3450.0	desktop	Windows	11	2
+Firefox	105.0	desktop	Windows	10	2
+Firefox	108.0	desktop	Linux	(not set)	2
+Firefox	110.0	desktop	Linux	(not set)	2
+Firefox	116.0	desktop	Windows	10	2
+Firefox	117.0	mobile	Android	15	2
+Firefox	120.0	desktop	Linux	(not set)	2
+Firefox	121.0	desktop	Linux	(not set)	2
+Firefox	123.0	desktop	Linux	(not set)	2
+Firefox	124.0	desktop	Linux	(not set)	2
+Firefox	125.0	desktop	Windows	10	2
+Firefox	126.0	desktop	Linux	(not set)	2
+Firefox	126.0	desktop	Macintosh	Intel 10.15	2
+Firefox	126.0	desktop	Windows	10	2
+Firefox	129.0	desktop	Windows	10	2
+Firefox	136.0	mobile	Android	14	2
+Firefox	137.0	mobile	Android	11	2
+Firefox	137.0	mobile	Android	14	2
+Firefox	138.0	mobile	Android	10	2
+Firefox	138.0	mobile	Android	15	2
+Firefox	139.0	mobile	Android	11	2
+Firefox	141.0	mobile	Android	10	2
+Firefox	141.0	mobile	Android	16	2
+Firefox	142.0	mobile	Android	13	2
+Firefox	142.0	mobile	Android	16	2
+Firefox	4.0	desktop	Linux	(not set)	2
+Firefox	40.0	desktop	UNIX	(not set)	2
+Firefox	72.0	desktop	Windows	10	2
+Firefox	78.0	desktop	Macintosh	Intel 10.11	2
+Firefox	84.0	mobile	Firefox OS	(not set)	2
+Internet Explorer	11.0	desktop	Windows	10	2
+Opera	102.0.0.0	desktop	Macintosh	Intel 10.15	2
+Opera	113.0.0.0	desktop	Linux	(not set)	2
+Opera	114.0.0.0	desktop	Windows	10	2
+Opera	114.0.5282.21	desktop	Linux	(not set)	2
+Opera	117.0.5408.197	desktop	Linux	(not set)	2
+Opera	44.12.2246.133431	desktop	Linux	(not set)	2
+Opera	44.12.2246.133431	mobile	Android	6.0	2
+Opera	79.0.4143.22	desktop	Windows	10	2
+Opera	79.0.4143.22	desktop	Windows	7	2
+Opera	85.0.4341.47	desktop	Windows	7	2
+Opera	87.0.0.0	mobile	Android	10	2
+Opera	91.0.2254.77465	mobile	Android	12	2
+Opera	91.0.2254.77465	mobile	Android	13	2
+Opera	92.0.2254.77856	mobile	Android	10	2
+Opera	92.0.2254.77856	mobile	Android	15	2
+Opera	92.0.2254.77878	mobile	Android	8.0.0	2
+Opera	92.0.2254.77878	mobile	Android	9	2
+Opera	95.0.0.0	desktop	Windows	10	2
+Puffin	128.6.9.76768FP,gzip(gfe)	desktop	(not set)	(not set)	2
+Safari	12.1.1	mobile	iOS	12.3.1	2
+Safari	13.1.1	mobile	iOS	13.5.1	2
+Safari	13.1.2	desktop	Macintosh	Intel 10.13	2
+Safari	14.0.3	desktop	Macintosh	Intel 10.15	2
+Safari	14.1.2	desktop	Macintosh	Intel 10.15	2
+Safari	14.1.2	mobile	iOS	14.8.1	2
+Safari	15.1	desktop	Macintosh	Intel 10.15	2
+Safari	15.2	desktop	Macintosh	Intel 10.15	2
+Safari	15.4	desktop	Macintosh	Intel 10.15	2
+Safari	15.4	mobile	iOS	14.4	2
+Safari	15.6.4	mobile	iOS	15.7.2	2
+Safari	15.6.4	mobile	iOS	15.7.6	2
+Safari	15.6.6	desktop	Macintosh	Intel 10.15	2
+Safari	16.0	mobile	iOS	16.0.1	2
+Safari	16.0	mobile	iOS	16.7.11	2
+Safari	16.1	tablet	iOS	16.1.1	2
+Safari	16.4.1	desktop	Macintosh	Intel 10.15	2
+Safari	16.6	mobile	iOS	16.7.2	2
+Safari	16.6	mobile	iOS	16.7.4	2
+Safari	16.6	mobile	iOS	16.7.5	2
+Safari	17.0	mobile	iOS	17.0.1	2
+Safari	17.0	tablet	iOS	17.0	2
+Safari	17.5	tablet	iOS	17.5.1	2
+Safari	18.0	mobile	iOS	18.3.1	2
+Safari	18.0	mobile	iOS	18.4.0	2
+Safari	5.0.2	mobile	iOS	4.3.2	2
+Safari	5.1	tablet	iOS	5.1	2
+Safari	604.1	mobile	iOS	12.5	2
+Safari	604.1	mobile	iOS	15.6.0	2
+Safari	604.1	mobile	iOS	15.6.1	2
+Safari	604.1	mobile	iOS	15.8.0	2
+Safari	604.1	mobile	iOS	16.0	2
+Safari	604.1	mobile	iOS	16.0.3	2
+Safari	604.1	mobile	iOS	16.1.2	2
+Safari	604.1	mobile	iOS	16.2.0	2
+Safari	604.1	mobile	iOS	16.5.1	2
+Safari	604.1	mobile	iOS	16.6.0	2
+Safari	604.1	mobile	iOS	16.7.6	2
+Safari	604.1	mobile	iOS	17.4	2
+Safari	604.1	mobile	iOS	18.0	2
+Safari	604.1	mobile	iOS	18.2	2
+Safari	604.1	mobile	iOS	18.3	2
+Safari	604.1	mobile	iOS	18.6	2
+Safari	604.1	tablet	iOS	16.6.0	2
+Safari	604.1	tablet	iOS	16.7.11	2
+Safari	604.1	tablet	iOS	17.7.2	2
+Safari	604.1	tablet	iOS	18.2.1	2
+Safari	7.0	tablet	iOS	7.0.4	2
+Safari (in-app)	(not set)	mobile	iOS	15.5	2
+Safari (in-app)	(not set)	mobile	iOS	17.1.1	2
+Safari (in-app)	(not set)	tablet	iOS	17.4.1	2
+Safari (in-app)	(not set)	tablet	iOS	18.3.1	2
+Safari (in-app)	15.0	mobile	iOS	18.5	2
+Samsung Internet	13.2	mobile	Android	12	2
+Samsung Internet	19.0	mobile	Android	11	2
+Samsung Internet	19.0	mobile	Android	13	2
+Samsung Internet	19.0	mobile	Android	14	2
+Samsung Internet	19.0	mobile	Android	15	2
+Samsung Internet	21.0	desktop	Linux	(not set)	2
+Samsung Internet	21.0	mobile	Android	7.0	2
+Samsung Internet	22.0	mobile	Android	12	2
+Samsung Internet	22.0	mobile	Android	13	2
+Samsung Internet	23.0	mobile	Android	8.0.0	2
+Samsung Internet	4.0	mobile	Tizen	6.0	2
+Samsung Internet	7.0	mobile	Tizen	8.0	2
+Samsung Internet	8.0	mobile	Android	8.1.0	2
+Samsung Internet	9.2	mobile	Android	9	2
+Seznam	11.3.1	mobile	Android	14	2
+UC Browser	11.6.4.950	mobile	Android	13	2
+UC Browser	11.6.4.950	mobile	Android	14	2
+UC Browser	12.12.10.1228	mobile	Android	13	2
+UC Browser	12.12.10.1228	mobile	Android	15	2
+Whale Browser	1.0.0.0	mobile	Android	15	2
+Whale Browser	4.32.315.22	desktop	Macintosh	Intel 10.15	2
+YaBrowser	18.0	mobile	iOS	18.3.1	2
+YaBrowser	23.11.1.126.00	mobile	Android	14	2
+YaBrowser	23.5.3.918	desktop	Windows	10	2
+YaBrowser	23.9.0.2325	desktop	Macintosh	Intel 10.13	2
+YaBrowser	24.10.4.644	desktop	Windows	7	2
+YaBrowser	24.12.0.0	desktop	Windows	10	2
+YaBrowser	24.6.0.0	desktop	Windows	10	2
+YaBrowser	24.7.0.0	desktop	Macintosh	Intel 10.15	2
+YaBrowser	25.2.4.112.00	mobile	Android	11	2
+YaBrowser	25.2.7.95.00	mobile	Android	13	2
+YaBrowser	25.2.8.97.00	mobile	Android	15	2
+YaBrowser	25.2.9.55.00	mobile	Android	14	2
+YaBrowser	25.3.0.33.00	mobile	Android	14	2
+YaBrowser	25.3.0.33.00	mobile	Android	15	2
+YaBrowser	25.4.2.107.00	mobile	Android	14	2
+YaBrowser	25.4.3.182.00	mobile	Android	10	2
+YaBrowser	25.4.4.111.00	mobile	Android	15	2
+YaBrowser	25.4.6.55.00	mobile	Android	14	2
+YaBrowser	25.4.6.64.00	mobile	Android	13	2
+YaBrowser	25.6.1.101.00	mobile	Android	13	2
+YaBrowser	25.6.1.95.01	tablet	Android	13	2
+YaBrowser	25.6.2.108.00	mobile	Android	11	2
+YaBrowser	25.6.2.109.00	mobile	Android	11	2
+YaBrowser	25.6.2.117.00	mobile	Android	15	2
+YaBrowser	25.6.2.120.00	mobile	Android	15	2
+YaBrowser	25.6.4.107.00	mobile	Android	10	2
+YaBrowser	25.6.4.107.00	mobile	Android	13	2
+YaBrowser	25.7.0.66.10	mobile	iOS	18.5	2
+YaBrowser	25.7.2.430.10	mobile	iOS	18.5	2
+YaBrowser	25.7.3.812.10	mobile	iOS	18.5	2
+(not set)	(not set)	mobile	Android	(not set)	1
+Aloha Browser	4.2.0.0	desktop	Windows	10	1
+Aloha Browser	4.6.0.0	desktop	Windows	10	1
+Aloha Browser	7.4.3	mobile	Android	10	1
+Amazon Silk	108.2.18	tablet	Android	11	1
+Amazon Silk	110.4.3	tablet	Android	11	1
+Amazon Silk	120.4.5	tablet	Android	9	1
+Amazon Silk	130.5.9	tablet	Android	11	1
+Amazon Silk	136.3.2401	mobile	Android	7.1.2	1
+Amazon Silk	136.7.3	mobile	Android	(not set)	1
+Amazon Silk	138.2.3	tablet	Android	9	1
+Amazon Silk	73.7.5	tablet	Android	4.0.3	1
+Android Browser	4.0	mobile	Android	4.2.3	1
+Android Browser	4.0	mobile	Android	5.1.1	1
+Android Runtime	2.1.0	mobile	Android	11	1
+Android Runtime	2.1.0	mobile	Android	15	1
+Android Runtime	2.1.0	mobile	Android	6.0	1
+Android Webview	100.0.4896.60	mobile	Android	10	1
+Android Webview	100.0.4896.60	mobile	Android	12	1
+Android Webview	100.0.4896.79	mobile	Android	10.0	1
+Android Webview	101.0.4951.41	mobile	Android	13	1
+Android Webview	101.0.4951.61	mobile	Android	10	1
+Android Webview	101.0.4951.61	mobile	Android	7.0	1
+Android Webview	102.0.5005.125	mobile	Android	9	1
+Android Webview	103.0.5060.129	mobile	Android	13	1
+Android Webview	103.0.5060.70	mobile	Android	6.0.1	1
+Android Webview	104.0.5112.69	mobile	Android	9	1
+Android Webview	104.0.5112.97	mobile	Android	12	1
+Android Webview	105.0.5195.124	mobile	Android	10.0	1
+Android Webview	105.0.5195.136	mobile	Android	11	1
+Android Webview	105.0.5195.136	mobile	Android	11.0	1
+Android Webview	105.0.5195.79	mobile	Android	11.0	1
+Android Webview	106.0.5249.126	tablet	Android	13	1
+Android Webview	106.0.5249.79	mobile	Android	9	1
+Android Webview	108.0.5359.128	mobile	Android	9	1
+Android Webview	109.0.5414.86	mobile	Android	13	1
+Android Webview	109.0.5414.86	mobile	Android	14	1
+Android Webview	109.0.5414.86	tablet	Android	14	1
+Android Webview	112.0.5615.135	mobile	Android	9	1
+Android Webview	113.0.5672.77	mobile	Android	9	1
+Android Webview	114.0.5735.196	mobile	Android	9	1
+Android Webview	114.0.5735.196	smart tv	Android	11	1
+Android Webview	115.0.5790.138	mobile	Android	13	1
+Android Webview	115.0.5790.166	mobile	Android	9	1
+Android Webview	117.0.0.0	mobile	Android	9	1
+Android Webview	118.0.0.0	mobile	Android	8.1.0	1
+Android Webview	119.0.6045.163	mobile	Android	10	1
+Android Webview	119.0.6045.163	mobile	Android	11	1
+Android Webview	119.0.6045.163	mobile	Android	7.0	1
+Android Webview	119.0.6045.193	mobile	Android	12.0	1
+Android Webview	119.0.6045.194	mobile	Android	7.1.2	1
+Android Webview	120.0.6099.115	mobile	Android	9	1
+Android Webview	120.0.6099.144	mobile	Android	13	1
+Android Webview	120.0.6099.144	mobile	Android	14	1
+Android Webview	120.0.6099.193	mobile	Android	12	1
+Android Webview	120.0.6099.43	mobile	Android	10	1
+Android Webview	120.0.6099.43	mobile	Android	8.1.0	1
+Android Webview	120.0.6099.43	mobile	Android	9	1
+Android Webview	121.0.6167.101	mobile	Android	14	1
+Android Webview	121.0.6167.164	mobile	Android	13	1
+Android Webview	121.0.6167.178	mobile	Android	12	1
+Android Webview	121.0.6167.180	mobile	Android	13	1
+Android Webview	121.0.6167.180	mobile	Android	9	1
+Android Webview	121.0.6167.71	mobile	Android	13	1
+Android Webview	121.0.6167.71	mobile	Android	14	1
+Android Webview	122.0.6261.105	mobile	Android	13	1
+Android Webview	122.0.6261.105	mobile	Android	14	1
+Android Webview	122.0.6261.119	mobile	Android	12	1
+Android Webview	122.0.6261.119	mobile	Android	13	1
+Android Webview	122.0.6261.64	mobile	Android	12	1
+Android Webview	123.0.6312.42	mobile	Android	14	1
+Android Webview	123.0.6312.80	mobile	Android	9	1
+Android Webview	123.0.6312.99	mobile	Android	9	1
+Android Webview	124.0.0.0	mobile	Android	12	1
+Android Webview	124.0.0.0	mobile	Android	13	1
+Android Webview	124.0.6367.113	mobile	Android	9	1
+Android Webview	124.0.6367.123	mobile	Android	11	1
+Android Webview	124.0.6367.172	mobile	Android	14	1
+Android Webview	124.0.6367.180	mobile	Android	13	1
+Android Webview	125.0.6422.113	mobile	Android	9	1
+Android Webview	125.0.6422.147	mobile	Android	9	1
+Android Webview	125.0.6422.72	mobile	Android	11	1
+Android Webview	125.0.6422.72	mobile	Android	12	1
+Android Webview	125.0.6422.72	mobile	Android	15	1
+Android Webview	125.0.6422.72	mobile	Android	8.1.0	1
+Android Webview	125.0.6422.82	mobile	Android	10	1
+Android Webview	126.0.6478.122	mobile	Android	8.1.0	1
+Android Webview	126.0.6478.134	mobile	Android	13	1
+Android Webview	126.0.6478.135	mobile	Android	12	1
+Android Webview	126.0.6478.135	mobile	Android	13	1
+Android Webview	126.0.6478.186	mobile	Android	11	1
+Android Webview	126.0.6478.186	mobile	Android	13	1
+Android Webview	126.0.6478.186	mobile	Android	14	1
+Android Webview	126.0.6478.186	mobile	Android	9	1
+Android Webview	126.0.6478.188	mobile	Android	14	1
+Android Webview	126.0.6478.188	mobile	Android	15	1
+Android Webview	127.0.6533.103	mobile	Android	11	1
+Android Webview	127.0.6533.103	mobile	Android	12	1
+Android Webview	127.0.6533.105	mobile	Android	9	1
+Android Webview	127.0.6533.106	mobile	Android	9	1
+Android Webview	127.0.6533.51	mobile	Android	13	1
+Android Webview	127.0.6533.64	mobile	Android	11	1
+Android Webview	127.0.6533.84	mobile	Android	9	1
+Android Webview	127.0.6533.85	tablet	Android	8.0.0	1
+Android Webview	127.0.6533.9	tablet	Android	10	1
+Android Webview	128.0.6613.146	mobile	Android	12	1
+Android Webview	128.0.6613.146	mobile	Android	14	1
+Android Webview	128.0.6613.146	mobile	Android	9	1
+Android Webview	128.0.6613.148	mobile	Android	12	1
+Android Webview	128.0.6613.88	mobile	Android	14	1
+Android Webview	128.0.6613.99	mobile	Android	9	1
+Android Webview	129.0.6668.100	mobile	Android	11	1
+Android Webview	129.0.6668.100	mobile	Android	13	1
+Android Webview	129.0.6668.70	mobile	Android	13	1
+Android Webview	129.0.6668.70	mobile	Android	15	1
+Android Webview	129.0.6668.81	mobile	Android	13	1
+Android Webview	129.0.6668.82	mobile	Android	11	1
+Android Webview	130.0.6723.103	mobile	Android	8.1.0	1
+Android Webview	130.0.6723.107	mobile	Android	12	1
+Android Webview	130.0.6723.107	mobile	Android	14	1
+Android Webview	130.0.6723.108	mobile	Android	12	1
+Android Webview	130.0.6723.58	mobile	Android	11	1
+Android Webview	130.0.6723.73	mobile	Android	8.1.0	1
+Android Webview	130.0.6723.86	mobile	Android	10	1
+Android Webview	130.0.6723.86	mobile	Android	11	1
+Android Webview	131.0.6778.104	mobile	Android	11	1
+Android Webview	131.0.6778.104	mobile	Android	12	1
+Android Webview	131.0.6778.104	mobile	Android	8.1.0	1
+Android Webview	131.0.6778.104	mobile	Android	9	1
+Android Webview	131.0.6778.105	mobile	Android	11	1
+Android Webview	131.0.6778.131	mobile	Android	10	1
+Android Webview	131.0.6778.131	mobile	Android	12	1
+Android Webview	131.0.6778.135	mobile	Android	11	1
+Android Webview	131.0.6778.135	mobile	Android	15	1
+Android Webview	131.0.6778.135	mobile	Android	9	1
+Android Webview	131.0.6778.135	tablet	Android	14	1
+Android Webview	131.0.6778.136	mobile	Android	13	1
+Android Webview	131.0.6778.200	mobile	Android	11	1
+Android Webview	131.0.6778.200	mobile	Android	13	1
+Android Webview	131.0.6778.200	mobile	Android	15	1
+Android Webview	131.0.6778.200	mobile	Android	8.1.0	1
+Android Webview	131.0.6778.201	mobile	Android	11	1
+Android Webview	131.0.6778.201	mobile	Android	13	1
+Android Webview	131.0.6778.260	mobile	Android	11	1
+Android Webview	131.0.6778.260	mobile	Android	8.1.0	1
+Android Webview	131.0.6778.260	smart tv	Android	11	1
+Android Webview	131.0.6778.260	tablet	Android	15	1
+Android Webview	131.0.6778.261	mobile	Android	14	1
+Android Webview	131.0.6778.262	mobile	Android	11	1
+Android Webview	131.0.6778.39	mobile	Android	11	1
+Android Webview	131.0.6778.39	mobile	Android	12	1
+Android Webview	131.0.6778.41	mobile	Android	10	1
+Android Webview	131.0.6778.41	mobile	Android	13	1
+Android Webview	132.0.0.0	mobile	Android	12	1
+Android Webview	132.0.6834.122	mobile	Android	13	1
+Android Webview	132.0.6834.122	mobile	Android	14	1
+Android Webview	132.0.6834.123	mobile	Android	12	1
+Android Webview	132.0.6834.123	mobile	Android	15	1
+Android Webview	132.0.6834.163	mobile	Android	11	1
+Android Webview	132.0.6834.163	mobile	Android	15	1
+Android Webview	132.0.6834.164	mobile	Android	8.1.0	1
+Android Webview	132.0.6834.165	mobile	Android	9	1
+Android Webview	132.0.6834.166	mobile	Android	11	1
+Android Webview	132.0.6834.166	mobile	Android	12	1
+Android Webview	132.0.6834.166	mobile	Android	13	1
+Android Webview	132.0.6834.166	mobile	Android	14	1
+Android Webview	132.0.6834.209	tablet	Android	11	1
+Android Webview	132.0.6834.79	mobile	Android	10	1
+Android Webview	132.0.6834.79	mobile	Android	11	1
+Android Webview	132.0.6834.79	mobile	Android	8.1.0	1
+Android Webview	133.0.6943.121	mobile	Android	10	1
+Android Webview	133.0.6943.121	mobile	Android	12	1
+Android Webview	133.0.6943.121	mobile	Android	13	1
+Android Webview	133.0.6943.121	mobile	Android	8.1.0	1
+Android Webview	133.0.6943.137	mobile	Android	12	1
+Android Webview	133.0.6943.137	mobile	Android	16	1
+Android Webview	133.0.6943.137	mobile	Android	8.1.0	1
+Android Webview	133.0.6943.137	tablet	Android	14	1
+Android Webview	133.0.6943.138	mobile	Android	12	1
+Android Webview	133.0.6943.138	mobile	Android	15	1
+Android Webview	133.0.6943.138	tablet	Android	14	1
+Android Webview	133.0.6943.49	mobile	Android	9	1
+Android Webview	133.0.6943.50	mobile	Android	9	1
+Android Webview	133.0.6943.89	mobile	Android	9	1
+Android Webview	134.0.6998.108	mobile	Android	13	1
+Android Webview	134.0.6998.108	mobile	Android	14	1
+Android Webview	134.0.6998.108	mobile	Android	8.1.0	1
+Android Webview	134.0.6998.109	mobile	Android	14	1
+Android Webview	134.0.6998.135	mobile	Android	8.1.0	1
+Android Webview	134.0.6998.39	mobile	Android	15	1
+Android Webview	134.0.6998.39	mobile	Android	8.1.0	1
+Android Webview	134.0.6998.40	mobile	Android	12	1
+Android Webview	134.0.6998.40	mobile	Android	14	1
+Android Webview	134.0.6998.50	mobile	Android	15	1
+Android Webview	134.0.6998.92	mobile	Android	14	1
+Android Webview	134.0.6998.96	mobile	Android	9	1
+Android Webview	135.0.7049.100	mobile	Android	8.1.0	1
+Android Webview	135.0.7049.105	mobile	Android	14	1
+Android Webview	135.0.7049.110	mobile	Android	12	1
+Android Webview	135.0.7049.110	mobile	Android	14	1
+Android Webview	135.0.7049.110	mobile	Android	15	1
+Android Webview	135.0.7049.111	tablet	Android	14	1
+Android Webview	135.0.7049.113	mobile	Android	12	1
+Android Webview	135.0.7049.37	mobile	Android	10	1
+Android Webview	135.0.7049.37	mobile	Android	11	1
+Android Webview	135.0.7049.37	mobile	Android	13	1
+Android Webview	135.0.7049.38	mobile	Android	10	1
+Android Webview	135.0.7049.38	mobile	Android	15	1
+Android Webview	135.0.7049.76	mobile	Android	14	1
+Android Webview	135.0.7049.80	mobile	Android	9	1
+Android Webview	135.0.7049.92	mobile	Android	12	1
+Android Webview	135.0.7049.92	mobile	Android	15	1
+Android Webview	135.0.7049.92	mobile	Android	8.1.0	1
+Android Webview	135.0.7049.99	mobile	Android	14	1
+Android Webview	136.0.7049.38	mobile	Android	13	1
+Android Webview	136.0.7103.112	mobile	Android	10	1
+Android Webview	136.0.7103.112	mobile	Android	12	1
+Android Webview	136.0.7103.112	mobile	Android	13	1
+Android Webview	136.0.7103.125	tablet	Android	13	1
+Android Webview	136.0.7103.126	mobile	Android	13	1
+Android Webview	136.0.7103.127	smart tv	Android	11	1
+Android Webview	136.0.7103.140	mobile	Android	11	1
+Android Webview	136.0.7103.140	mobile	Android	14	1
+Android Webview	136.0.7103.140	mobile	Android	9	1
+Android Webview	136.0.7103.44	mobile	Android	14	1
+Android Webview	136.0.7103.60	tablet	Android	10	1
+Android Webview	136.0.7103.60	tablet	Android	13	1
+Android Webview	136.0.7103.61	mobile	Android	10	1
+Android Webview	136.0.7103.84	mobile	Android	11	1
+Android Webview	136.0.7103.84	mobile	Android	13	1
+Android Webview	136.0.7103.87	mobile	Android	8.1.0	1
+Android Webview	137.0.0.0	mobile	Android	14	1
+Android Webview	137.0.7151.109	mobile	Android	11	1
+Android Webview	137.0.7151.109	mobile	Android	13	1
+Android Webview	137.0.7151.112	mobile	Android	8.1.0	1
+Android Webview	137.0.7151.115	mobile	Android	(not set)	1
+Android Webview	137.0.7151.115	mobile	Android	8.0.0	1
+Android Webview	137.0.7151.115	smart tv	Android	10	1
+Android Webview	137.0.7151.115	smart tv	Android	14	1
+Android Webview	137.0.7151.115	tablet	Android	10	1
+Android Webview	137.0.7151.116	mobile	Android	16	1
+Android Webview	137.0.7151.116	mobile	Android	8.1.0	1
+Android Webview	137.0.7151.116	mobile	Android	9	1
+Android Webview	137.0.7151.116	smart tv	Android	12	1
+Android Webview	137.0.7151.116	tablet	Android	13	1
+Android Webview	137.0.7151.117	mobile	Android	16	1
+Android Webview	137.0.7151.117	tablet	Android	11	1
+Android Webview	137.0.7151.117	tablet	Android	15	1
+Android Webview	137.0.7151.118	tablet	Android	12	1
+Android Webview	137.0.7151.14	mobile	Android	10	1
+Android Webview	137.0.7151.14	mobile	Android	12	1
+Android Webview	137.0.7151.14	mobile	Android	13	1
+Android Webview	137.0.7151.23	mobile	Android	14	1
+Android Webview	137.0.7151.44	mobile	Android	10	1
+Android Webview	137.0.7151.44	mobile	Android	12	1
+Android Webview	137.0.7151.44	mobile	Android	9	1
+Android Webview	137.0.7151.61	mobile	Android	9	1
+Android Webview	137.0.7151.61	tablet	Android	13	1
+Android Webview	137.0.7151.61	tablet	Android	15	1
+Android Webview	137.0.7151.62	mobile	Android	9	1
+Android Webview	137.0.7151.73	mobile	Android	9	1
+Android Webview	137.0.7151.76	mobile	Android	11	1
+Android Webview	137.0.7151.88	tablet	Android	14	1
+Android Webview	137.0.7151.89	mobile	Android	16	1
+Android Webview	137.0.7151.89	mobile	Android	8.0.0	1
+Android Webview	137.0.7151.89	smart tv	Android	10	1
+Android Webview	137.0.7151.89	smart tv	Android	12	1
+Android Webview	137.0.7151.89	tablet	Android	11	1
+Android Webview	137.0.7151.89	tablet	Android	12	1
+Android Webview	137.0.7151.89	tablet	Android	8.1.0	1
+Android Webview	137.0.7151.90	mobile	Android	8.1.0	1
+Android Webview	137.0.7151.90	tablet	Android	13	1
+Android Webview	137.0.7151.91	mobile	Android	11	1
+Android Webview	137.0.7151.91	mobile	Android	14	1
+Android Webview	138.0.7204.139	mobile	Android	16	1
+Android Webview	138.0.7204.139	mobile	Android	9	1
+Android Webview	138.0.7204.14	mobile	Android	11	1
+Android Webview	138.0.7204.143	mobile	Android	10	1
+Android Webview	138.0.7204.143	mobile	Android	11	1
+Android Webview	138.0.7204.146	mobile	Android	10	1
+Android Webview	138.0.7204.146	mobile	Android	8.1.0	1
+Android Webview	138.0.7204.146	mobile	Android	9	1
+Android Webview	138.0.7204.150	mobile	Android	14	1
+Android Webview	138.0.7204.153	mobile	Android	10	1
+Android Webview	138.0.7204.153	tablet	Android	9	1
+Android Webview	138.0.7204.157	mobile	Android	16	1
+Android Webview	138.0.7204.157	tablet	Android	9	1
+Android Webview	138.0.7204.161	mobile	Android	14	1
+Android Webview	138.0.7204.161	mobile	Android	15	1
+Android Webview	138.0.7204.25	mobile	Android	10	1
+Android Webview	138.0.7204.25	mobile	Android	15	1
+Android Webview	138.0.7204.3	mobile	Android	13	1
+Android Webview	138.0.7204.3	mobile	Android	14	1
+Android Webview	138.0.7204.3	mobile	Android	15	1
+Android Webview	138.0.7204.32	mobile	Android	11	1
+Android Webview	138.0.7204.32	mobile	Android	16	1
+Android Webview	138.0.7204.35	mobile	Android	9	1
+Android Webview	138.0.7204.42	mobile	Android	8.1.0	1
+Android Webview	138.0.7204.42	tablet	Android	15	1
+Android Webview	138.0.7204.45	mobile	Android	16	1
+Android Webview	138.0.7204.45	mobile	Android	8.1.0	1
+Android Webview	138.0.7204.45	tablet	Android	11	1
+Android Webview	138.0.7204.45	tablet	Android	12	1
+Android Webview	138.0.7204.45	tablet	Android	13	1
+Android Webview	138.0.7204.55	mobile	Android	13	1
+Android Webview	138.0.7204.55	mobile	Android	9	1
+Android Webview	138.0.7204.63	tablet	Android	10	1
+Android Webview	138.0.7204.63	tablet	Android	11	1
+Android Webview	138.0.7204.63	tablet	Android	8.1.0	1
+Android Webview	138.0.7204.64	mobile	Android	8.0.0	1
+Android Webview	138.0.7204.64	mobile	Android	8.1.0	1
+Android Webview	138.0.7204.67	mobile	Android	16	1
+Android Webview	138.0.7204.67	mobile	Android	8.1.0	1
+Android Webview	138.0.7204.67	mobile	Android	9	1
+Android Webview	138.0.7204.67	tablet	Android	10	1
+Android Webview	138.0.7204.68	smart tv	Android	11	1
+Android Webview	138.0.7204.68	smart tv	Android	14	1
+Android Webview	138.0.7204.68	tablet	Android	11	1
+Android Webview	139.0.7258.0	mobile	Android	14	1
+Android Webview	139.0.7258.3	mobile	Android	16	1
+Android Webview	139.0.7258.32	mobile	Android	10	1
+Android Webview	139.0.7258.32	smart tv	Android	11	1
+Android Webview	139.0.7258.32	tablet	Android	15	1
+Android Webview	140.0.7259.0	mobile	Android	14	1
+Android Webview	140.0.7261.0	mobile	Android	14	1
+Android Webview	44.0.2403.119	mobile	Android	9	1
+Android Webview	51.0.2704.108	mobile	Android	6.0.1	1
+Android Webview	56.0.2924.87	mobile	Android	5.1.1	1
+Android Webview	56.0.2924.87	mobile	Android	6.0.1	1
+Android Webview	61.0.3163.98	mobile	Android	7.0	1
+Android Webview	61.0.3163.98	mobile	Android	7.1.2	1
+Android Webview	62.0.3202.84	mobile	Android	5.1	1
+Android Webview	62.0.3202.84	mobile	Android	6.0.1	1
+Android Webview	62.0.3202.97	mobile	Android	8.1.0	1
+Android Webview	63.0.3239.111	mobile	Android	8.0.0	1
+Android Webview	64.0.3282.137	tablet	Android	7.0	1
+Android Webview	64.0.3282.137	tablet	Android	7.1.1	1
+Android Webview	65.0.3325.109	mobile	Android	8.0.0	1
+Android Webview	66.0.3359.126	mobile	Android	8.1.0	1
+Android Webview	67.0.3396.87	mobile	Android	7.0	1
+Android Webview	67.0.3396.87	mobile	Android	8.0.0	1
+Android Webview	68.0.3440.91	mobile	Android	9	1
+Android Webview	69.0.3497.91	tablet	Android	8.1.0	1
+Android Webview	70.0.3538.110	mobile	Android	9	1
+Android Webview	70.0.3538.110	tablet	Android	8.1.0	1
+Android Webview	70.0.3538.80	mobile	Android	10	1
+Android Webview	73.0.3683.90	mobile	Android	9	1
+Android Webview	74.0.3729.136	mobile	Android	10	1
+Android Webview	75.0.3770.101	mobile	Android	8.1.0	1
+Android Webview	76.0.3809.132	mobile	Android	10	1
+Android Webview	78.0.3904.108	mobile	Android	8.1.0	1
+Android Webview	78.0.3904.90	mobile	Android	9	1
+Android Webview	79.0.3945.116	tablet	Android	9	1
+Android Webview	79.0.3945.136	mobile	Android	8.1.0	1
+Android Webview	80.0.3987.149	mobile	Android	10	1
+Android Webview	80.0.3987.149	smart tv	Android	15.1	1
+Android Webview	81.0.4044.138	tablet	Android	10	1
+Android Webview	83.0.4103.96	mobile	Android	10	1
+Android Webview	84.0.4147.125	mobile	Android	7.0	1
+Android Webview	86.0.4240.185	mobile	Android	11	1
+Android Webview	87.0.4280.141	mobile	Android	15	1
+Android Webview	88.0.4324.181	mobile	Android	11	1
+Android Webview	91.0.4472.114	mobile	Android	14	1
+Android Webview	91.0.4472.120	mobile	Android	9	1
+Android Webview	91.0.4472.88	mobile	Android	10	1
+Android Webview	92.0.4515.105	mobile	Android	12	1
+Android Webview	92.0.4515.131	mobile	Android	9	1
+Android Webview	92.0.4515.131	tablet	Android	11	1
+Android Webview	93.0.4577.62	mobile	Android	9	1
+Android Webview	93.0.4577.82	mobile	Android	12	1
+Android Webview	94.0.3282.137	tablet	Android	10.0	1
+Android Webview	95.0.4638.74	mobile	Android	13	1
+Android Webview	95.0.4638.74	mobile	Android	5.0	1
+Android Webview	95.0.4638.74	mobile	Android	5.0.2	1
+Android Webview	95.0.4638.74	mobile	Android	7.1	1
+Android Webview	95.0.4638.74	mobile	Android	8.1	1
+Android Webview	95.0.4638.74	smart tv	Android	6.0.1	1
+Android Webview	96.0.4664.45	mobile	Android	10	1
+Android Webview	97.0.4692.98	mobile	Android	13	1
+Android Webview	99.0.3497.100	mobile	Android	11.0	1
+Android Webview	99.0.4844.88	mobile	Android	13	1
+Android Webview	99.0.4844.88	mobile	Android	8.1.0	1
+Android Webview	99.0.4844.88	mobile	Android	9	1
+BrowserNG	7.1.18124	mobile	SymbianOS	9.4	1
+Chrome	(not set)	desktop	Linux	15.0.0	1
+Chrome	100.0.4896.127	desktop	Linux	5.15.0	1
+Chrome	100.0.4896.127	desktop	Linux	6.12.32	1
+Chrome	100.0.4896.127	desktop	Windows	11	1
+Chrome	100.0.4896.127	mobile	Android	10	1
+Chrome	100.0.4896.127	mobile	Android	12	1
+Chrome	100.0.4896.127	mobile	Android	6.0	1
+Chrome	100.0.4896.133	desktop	Chrome OS	x86_64 14526.89.0	1
+Chrome	100.0.4896.58	mobile	Android	10.0.0	1
+Chrome	100.0.4896.58	mobile	Android	14	1
+Chrome	100.0.4896.75	desktop	Windows	10	1
+Chrome	100.0.4896.88	desktop	Windows	10	1
+Chrome	100.0.4896.88	desktop	Windows	7	1
+Chrome	100.0.4896.88	mobile	Android	11.0.0	1
+Chrome	100.0.4896.88	mobile	Android	12.0.0	1
+Chrome	100.0.612.1	desktop	Linux	(not set)	1
+Chrome	100.0.648.133	desktop	Macintosh	Intel 10.6	1
+Chrome	101.0.0.0	mobile	Android	13.0.0	1
+Chrome	101.0.4951.41	mobile	Android	12.0.0	1
+Chrome	101.0.4951.48	mobile	Android	14.0.0	1
+Chrome	101.0.4951.54	mobile	Android	10	1
+Chrome	101.0.4951.54	mobile	Android	12	1
+Chrome	101.0.4951.59	desktop	Chrome OS	x86_64 14588.98.0	1
+Chrome	101.0.4951.61	mobile	Android	10.0.0	1
+Chrome	101.0.4951.61	mobile	Android	13	1
+Chrome	101.0.4951.61	mobile	Android	9.0.0	1
+Chrome	101.0.4951.64	desktop	Macintosh	Intel 14.3	1
+Chrome	101.0.4951.67	desktop	Macintosh	Intel 10.14	1
+Chrome	101.0.4951.67	desktop	Windows	10	1
+Chrome	102.0.5005.125	mobile	Android	11.0.0	1
+Chrome	102.0.5005.125	tablet	Android	12.0.0	1
+Chrome	102.0.5005.197	desktop	Linux	5.15.0	1
+Chrome	102.0.5005.200	desktop	Macintosh	Intel 15.4	1
+Chrome	102.0.5005.200	desktop	Windows	11	1
+Chrome	102.0.5005.61	desktop	Linux	4.15.0	1
+Chrome	102.0.5005.63	desktop	Windows	10	1
+Chrome	102.0.5005.78	mobile	Android	8.0.0	1
+Chrome	103.0.5013.1	mobile	Android	11.0.0	1
+Chrome	103.0.5013.1	mobile	Android	12.0.0	1
+Chrome	103.0.5013.1	mobile	Android	14.0.0	1
+Chrome	103.0.5013.1	mobile	Android	15.0.0	1
+Chrome	103.0.5060.114	desktop	Linux	5.15.0	1
+Chrome	103.0.5060.114	desktop	Macintosh	Intel 15.5	1
+Chrome	103.0.5060.114	desktop	Windows	10	1
+Chrome	103.0.5060.114	desktop	Windows	7	1
+Chrome	103.0.5060.129	mobile	Android	10.0.0	1
+Chrome	103.0.5060.129	mobile	Android	11	1
+Chrome	103.0.5060.129	mobile	Android	12	1
+Chrome	103.0.5060.129	mobile	Android	14	1
+Chrome	103.0.5060.129	mobile	Android	8.0.0	1
+Chrome	103.0.5060.132	mobile	Android	6.0.1	1
+Chrome	103.0.5060.134	desktop	Linux	5.4.0	1
+Chrome	103.0.5060.134	desktop	Macintosh	Intel 15.1	1
+Chrome	103.0.5060.53	desktop	Linux	5.13.0	1
+Chrome	103.0.5060.53	desktop	Windows	10	1
+Chrome	103.0.5060.53	mobile	Android	11.0.0	1
+Chrome	103.0.5060.53	tablet	Chrome OS	x86_64 14816.64.0	1
+Chrome	103.0.5060.66	desktop	Windows	10	1
+Chrome	103.0.5060.70	mobile	Android	11.0.0	1
+Chrome	103.0.5060.71	mobile	Android	12.0.0	1
+Chrome	103.0.5060.71	mobile	Android	9.0.0	1
+Chrome	103.0.5060.71	tablet	Android	10.0.0	1
+Chrome	104.0.5112.101	desktop	Linux	5.15.0	1
+Chrome	104.0.5112.101	desktop	Linux	5.18.0	1
+Chrome	104.0.5112.105	desktop	Linux	5.15.0	1
+Chrome	104.0.5112.110	desktop	Chrome OS	x86_64 14909.132.0	1
+Chrome	104.0.5112.114	desktop	Windows	10	1
+Chrome	104.0.5112.29	mobile	Android	10.0.0	1
+Chrome	104.0.5112.69	mobile	Android	11.0.0	1
+Chrome	104.0.5112.71	tablet	iOS	16.3	1
+Chrome	104.0.5112.79	desktop	Linux	5.15.0	1
+Chrome	104.0.5112.79	desktop	Macintosh	Intel 15.5	1
+Chrome	104.0.5112.81	desktop	Windows	11	1
+Chrome	104.0.5112.97	mobile	Android	12.0.0	1
+Chrome	104.0.5112.97	tablet	Android	13.0.0	1
+Chrome	105.0.0.0	desktop	Windows	11	1
+Chrome	105.0.0.0	mobile	Android	11.0.0	1
+Chrome	105.0.0.0	mobile	Android	15.0.0	1
+Chrome	105.0.5195.100	mobile	iOS	18.5	1
+Chrome	105.0.5195.125	desktop	Macintosh	Intel 11.7	1
+Chrome	105.0.5195.125	desktop	Macintosh	Intel 13.7	1
+Chrome	105.0.5195.125	desktop	Macintosh	Intel 15.5	1
+Chrome	105.0.5195.134	desktop	Chrome OS	aarch64 14989.107.0	1
+Chrome	105.0.5195.136	mobile	Android	10.0.0	1
+Chrome	105.0.5195.136	mobile	Android	8.1.0	1
+Chrome	105.0.5195.136	tablet	Android	12.0.0	1
+Chrome	105.0.5195.79	mobile	Android	11.0.0	1
+Chrome	105.0.5195.79	mobile	Android	7.0.0	1
+Chrome	106.0.0.0	desktop	Linux	6.15.5	1
+Chrome	106.0.0.0	mobile	Android	12	1
+Chrome	106.0.0.0	mobile	Android	12.0.0	1
+Chrome	106.0.0.0	mobile	Android	6.0.1	1
+Chrome	106.0.1985.67	desktop	Windows	7	1
+Chrome	106.0.2924.87	mobile	Android	11.0	1
+Chrome	106.0.5249.103	desktop	Linux	6.8.0	1
+Chrome	106.0.5249.118	mobile	Android	11.0.0	1
+Chrome	106.0.5249.119	desktop	Linux	5.19.0	1
+Chrome	106.0.5249.119	desktop	Macintosh	Intel 12.7	1
+Chrome	106.0.5249.119	desktop	Windows	7	1
+Chrome	106.0.5249.121	desktop	Windows	11	1
+Chrome	106.0.5249.126	mobile	Android	7.0.0	1
+Chrome	106.0.5249.126	mobile	Android	9.1.0	1
+Chrome	106.0.5249.38	mobile	Android	6.0.1	1
+Chrome	106.0.5249.79	mobile	Android	12.0.0	1
+Chrome	106.0.5249.79	mobile	Android	8.0.0	1
+Chrome	106.0.5249.92	tablet	iOS	18.3	1
+Chrome	107.0.0.0	desktop	Macintosh	Intel 13.0	1
+Chrome	107.0.0.0	desktop	Macintosh	Intel 14.7	1
+Chrome	107.0.0.0	desktop	Windows	7	1
+Chrome	107.0.0.0	mobile	Android	8.1.0	1
+Chrome	107.0.5304.105	mobile	Android	10.0.0	1
+Chrome	107.0.5304.105	mobile	Android	11.0.0	1
+Chrome	107.0.5304.105	mobile	Android	13.0.0	1
+Chrome	107.0.5304.105	mobile	Android	15.0.0	1
+Chrome	107.0.5304.107	desktop	Windows	7	1
+Chrome	107.0.5304.110	desktop	Linux	6.8.0	1
+Chrome	107.0.5304.122	desktop	Windows	7	1
+Chrome	107.0.5304.122	desktop	Windows	8	1
+Chrome	107.0.5304.141	mobile	Android	11.0.0	1
+Chrome	107.0.5304.66	mobile	iOS	18.5	1
+Chrome	107.0.5304.87	desktop	Linux	4.4.0	1
+Chrome	107.0.5304.87	desktop	Linux	5.15.0	1
+Chrome	107.0.5304.87	desktop	Macintosh	Intel 12.5	1
+Chrome	107.0.5304.91	mobile	Android	10.0.0	1
+Chrome	107.0.540.0	desktop	Windows	Server 2003	1
+Chrome	108.0.0.0	desktop	Linux	6.2.0	1
+Chrome	108.0.0.0	desktop	Macintosh	Intel 10.15	1
+Chrome	108.0.0.0	desktop	Windows	11	1
+Chrome	108.0.0.0	mobile	Android	10	1
+Chrome	108.0.0.0	mobile	Android	11	1
+Chrome	108.0.0.0	mobile	Android	13.0.0	1
+Chrome	108.0.0.0	smart tv	Linux	(not set)	1
+Chrome	108.0.0.0	tablet	Android	12	1
+Chrome	108.0.472.53	desktop	Windows	XP	1
+Chrome	108.0.5359.111	desktop	Chrome OS	x86_64 15183.69.0	1
+Chrome	108.0.5359.124	desktop	Linux	4.4.0	1
+Chrome	108.0.5359.125	desktop	Linux	(not set)	1
+Chrome	108.0.5359.125	desktop	Windows	11	1
+Chrome	108.0.5359.125	desktop	Windows	7	1
+Chrome	108.0.5359.125	smart tv	Linux	(not set)	1
+Chrome	108.0.5359.125	tablet	Windows	10	1
+Chrome	108.0.5359.128	mobile	Android	12.0.0	1
+Chrome	108.0.5359.128	mobile	Android	13	1
+Chrome	108.0.5359.128	mobile	Android	9.0.0	1
+Chrome	108.0.5359.215	desktop	Macintosh	Intel 15.4	1
+Chrome	108.0.5359.215	desktop	Windows	11	1
+Chrome	108.0.5359.71	desktop	Linux	6.8.0	1
+Chrome	108.0.5359.98	desktop	Linux	4.15.0	1
+Chrome	108.0.5359.98	desktop	Macintosh	Intel 12.6	1
+Chrome	108.0.5359.99	desktop	Windows	11	1
+Chrome	108.0.5359.99	desktop	Windows	7	1
+Chrome	109.0.0.0	desktop	Macintosh	Intel 14.7	1
+Chrome	109.0.0.0	desktop	Windows	11	1
+Chrome	109.0.5414.112	mobile	iOS	17.6	1
+Chrome	109.0.5414.112	mobile	iOS	18.5	1
+Chrome	109.0.5414.117	mobile	Android	8.1.0	1
+Chrome	109.0.5414.118	mobile	Android	14	1
+Chrome	109.0.5414.118	mobile	Android	15	1
+Chrome	109.0.5414.119	desktop	Linux	6.13.8	1
+Chrome	109.0.5414.119	desktop	Macintosh	Intel 14.4	1
+Chrome	109.0.5414.120	mobile	Android	6.0	1
+Chrome	109.0.5414.121	desktop	Windows	10	1
+Chrome	109.0.5414.129	desktop	Windows	7	1
+Chrome	109.0.5414.132	desktop	Windows	10	1
+Chrome	109.0.5414.132	desktop	Windows	8.1	1
+Chrome	109.0.5414.158	desktop	Windows	11	1
+Chrome	109.0.5414.168	desktop	Windows	10	1
+Chrome	109.0.5414.168	desktop	Windows	7	1
+Chrome	109.0.5414.168	mobile	Android	6.0	1
+Chrome	109.0.5414.25	desktop	Windows	8.1	1
+Chrome	109.0.5414.74	desktop	Linux	4.15.0	1
+Chrome	109.0.5414.74	desktop	Linux	5.15.0	1
+Chrome	109.0.5414.76	desktop	Windows	7	1
+Chrome	109.0.5414.83	mobile	iOS	17.0	1
+Chrome	109.0.5414.85	mobile	Android	11.0.0	1
+Chrome	109.0.5414.87	desktop	Macintosh	Intel 15.5	1
+Chrome	110.0.0.0	desktop	Linux	5.4.0	1
+Chrome	110.0.0.0	desktop	Linux	6.1.81	1
+Chrome	110.0.0.0	desktop	Windows	11	1
+Chrome	110.0.0.0	mobile	Android	11.0.0	1
+Chrome	110.0.0.0	mobile	Android	12.0.0	1
+Chrome	110.0.0.0	mobile	Android	14.0.0	1
+Chrome	110.0.5481.100	desktop	Linux	5.15.0	1
+Chrome	110.0.5481.100	desktop	Linux	6.8.0	1
+Chrome	110.0.5481.100	desktop	Macintosh	Intel 13.2	1
+Chrome	110.0.5481.153	mobile	Android	11.0.0	1
+Chrome	110.0.5481.153	mobile	Android	13	1
+Chrome	110.0.5481.177	desktop	Linux	6.2.15	1
+Chrome	110.0.5481.178	desktop	Windows	11	1
+Chrome	110.0.5481.65	mobile	Android	11.0.0	1
+Chrome	110.0.5481.65	mobile	Android	12.0.0	1
+Chrome	111.0.0.0	desktop	Linux	6.2.9	1
+Chrome	111.0.0.0	desktop	Macintosh	Intel 15.3	1
+Chrome	111.0.222.7	desktop	Windows	XP	1
+Chrome	111.0.5563.101	mobile	iOS	18.5	1
+Chrome	111.0.5563.110	desktop	Linux	5.3.11	1
+Chrome	111.0.5563.111	desktop	Windows	11	1
+Chrome	111.0.5563.112	desktop	Windows	10	1
+Chrome	111.0.5563.115	mobile	Android	10.0.0	1
+Chrome	111.0.5563.115	mobile	Android	12.0.0	1
+Chrome	111.0.5563.115	mobile	Android	8.1.0	1
+Chrome	111.0.5563.116	mobile	Android	11.0.0	1
+Chrome	111.0.5563.116	mobile	Android	13	1
+Chrome	111.0.5563.116	mobile	Android	9.0.0	1
+Chrome	111.0.5563.146	desktop	Linux	5.19.0	1
+Chrome	111.0.5563.146	desktop	Macintosh	Intel 15.5	1
+Chrome	111.0.5563.147	desktop	Windows	10	1
+Chrome	111.0.5563.50	desktop	Windows	11	1
+Chrome	111.0.5563.57	mobile	Android	11.0.0	1
+Chrome	111.0.5563.57	mobile	Android	8.1.0	1
+Chrome	111.0.5563.58	mobile	Android	10.0.0	1
+Chrome	111.0.5563.58	mobile	Android	13.0.0	1
+Chrome	111.0.5563.58	mobile	Android	9.0.0	1
+Chrome	111.0.5563.64	desktop	Linux	5.15.0	1
+Chrome	111.0.5563.64	desktop	Linux	6.8.0	1
+Chrome	111.0.5563.64	desktop	Macintosh	Intel 12.6	1
+Chrome	111.0.5563.64	desktop	Macintosh	Intel 12.7	1
+Chrome	111.0.5563.64	desktop	Macintosh	Intel 13.2	1
+Chrome	111.0.5563.64	desktop	Macintosh	Intel 14.6	1
+Chrome	111.0.5563.64	desktop	Macintosh	Intel 15.4	1
+Chrome	111.0.5563.64	desktop	Windows	10	1
+Chrome	111.0.5563.66	desktop	Windows	10	1
+Chrome	111.0.5563.72	mobile	iOS	18.5	1
+Chrome	111.5563.5.1	desktop	Windows	7	1
+Chrome	112.0.0.0	desktop	Linux	4.15.0	1
+Chrome	112.0.0.0	desktop	Linux	5.0.0	1
+Chrome	112.0.0.0	desktop	Linux	6.15.5	1
+Chrome	112.0.5612.48	mobile	Android	13	1
+Chrome	112.0.5615.121	desktop	Windows	11	1
+Chrome	112.0.5615.135	mobile	Android	8.1.0	1
+Chrome	112.0.5615.135	mobile	Android	9.0.0	1
+Chrome	112.0.5615.136	mobile	Android	10	1
+Chrome	112.0.5615.136	mobile	Android	11	1
+Chrome	112.0.5615.136	mobile	Android	11.0.0	1
+Chrome	112.0.5615.136	mobile	Android	8.1.0	1
+Chrome	112.0.5615.136	mobile	Android	9	1
+Chrome	112.0.5615.137	desktop	Macintosh	Intel 12.5	1
+Chrome	112.0.5615.137	desktop	Macintosh	Intel 14.7	1
+Chrome	112.0.5615.165	desktop	Linux	5.4.0	1
+Chrome	112.0.5615.167	mobile	iOS	16.3	1
+Chrome	112.0.5615.204	desktop	Windows	10	1
+Chrome	112.0.5615.49	desktop	Linux	5.4.0	1
+Chrome	112.0.5615.49	desktop	Macintosh	Intel 15.5	1
+Chrome	112.0.5615.50	desktop	Windows	10	1
+Chrome	112.0.5615.50	desktop	Windows	11	1
+Chrome	112.0.5615.86	desktop	Windows	11	1
+Chrome	112.0.5615.87	desktop	Windows	11	1
+Chrome	113	desktop	Windows	10	1
+Chrome	113.0.2203.57	mobile	Android	10	1
+Chrome	113.0.2876.44	mobile	Android	10	1
+Chrome	113.0.2922.79	mobile	Android	10	1
+Chrome	113.0.2960.64	mobile	Android	10	1
+Chrome	113.0.3081.71	mobile	Android	12	1
+Chrome	113.0.3392.3	mobile	Android	10	1
+Chrome	113.0.4100.63	mobile	Android	12	1
+Chrome	113.0.5672.121	mobile	iOS	14.8	1
+Chrome	113.0.5672.121	mobile	iOS	18.1	1
+Chrome	113.0.5672.121	mobile	iOS	18.5	1
+Chrome	113.0.5672.126	desktop	Linux	5.19.0	1
+Chrome	113.0.5672.126	desktop	Linux	6.8.0	1
+Chrome	113.0.5672.126	desktop	Macintosh	Intel 13.2	1
+Chrome	113.0.5672.126	desktop	Macintosh	Intel 13.7	1
+Chrome	113.0.5672.127	desktop	Windows	10	1
+Chrome	113.0.5672.131	mobile	Android	13.0.0	1
+Chrome	113.0.5672.132	mobile	Android	11.0.0	1
+Chrome	113.0.5672.136	desktop	Windows	10	1
+Chrome	113.0.5672.136	mobile	Android	14.0.0	1
+Chrome	113.0.5672.162	mobile	Android	13.0.0	1
+Chrome	113.0.5672.63	desktop	Linux	6.8.0	1
+Chrome	113.0.5672.76	mobile	Android	13.0.0	1
+Chrome	113.0.5672.77	mobile	Android	10.0.0	1
+Chrome	113.0.5672.77	mobile	Android	14.0.0	1
+Chrome	113.0.5672.92	desktop	Macintosh	Intel 15.5	1
+Chrome	113.0.5672.93	desktop	Windows	11	1
+Chrome	114.0.0.0	desktop	Linux	5.15.148	1
+Chrome	114.0.0.0	mobile	Android	11.0.0	1
+Chrome	114.0.0.0	mobile	Android	14	1
+Chrome	114.0.2189.47	mobile	Android	10	1
+Chrome	114.0.2761.41	mobile	Android	12	1
+Chrome	114.0.2952.5	mobile	Android	10	1
+Chrome	114.0.2988.40	mobile	Android	11	1
+Chrome	114.0.3208.10	mobile	Android	11	1
+Chrome	114.0.3383.57	mobile	Android	12	1
+Chrome	114.0.5735.106	desktop	Linux	5.15.0	1
+Chrome	114.0.5735.124	mobile	iOS	15.8	1
+Chrome	114.0.5735.124	mobile	iOS	18.5	1
+Chrome	114.0.5735.130	mobile	Android	12.0.0	1
+Chrome	114.0.5735.130	mobile	Android	8.1.0	1
+Chrome	114.0.5735.133	desktop	Linux	6.8.0	1
+Chrome	114.0.5735.133	desktop	Macintosh	Intel 10.15	1
+Chrome	114.0.5735.196	mobile	Android	14.0.0	1
+Chrome	114.0.5735.196	mobile	Android	15.0.0	1
+Chrome	114.0.5735.196	mobile	Android	8.1.0	1
+Chrome	114.0.5735.196	tablet	Android	10	1
+Chrome	114.0.5735.196	tablet	Android	12	1
+Chrome	114.0.5735.196	tablet	Android	8.0.0	1
+Chrome	114.0.5735.198	desktop	Macintosh	Intel 12.6	1
+Chrome	114.0.5735.198	desktop	Macintosh	Intel 13.4	1
+Chrome	114.0.5735.198	desktop	Macintosh	Intel 14.5	1
+Chrome	114.0.5735.198	desktop	Macintosh	Intel 15.4	1
+Chrome	114.0.5735.198	desktop	Macintosh	Intel 15.5	1
+Chrome	114.0.5735.289	desktop	Linux	6.8.0	1
+Chrome	114.0.5735.289	desktop	Windows	10	1
+Chrome	114.0.5735.45	desktop	Macintosh	Intel 15.5	1
+Chrome	114.0.5735.57	mobile	Android	12.0.0	1
+Chrome	114.0.5735.57	mobile	Android	13.0.0	1
+Chrome	114.0.5735.60	mobile	Android	8.1.0	1
+Chrome	114.0.5735.60	tablet	Android	13.0.0	1
+Chrome	114.0.5735.61	mobile	Android	11.0.0	1
+Chrome	114.0.5735.90	desktop	Linux	5.4.0	1
+Chrome	114.0.5735.90	desktop	Macintosh	Intel 10.13	1
+Chrome	114.0.5735.90	desktop	Macintosh	Intel 13.1	1
+Chrome	114.0.5735.90	desktop	Macintosh	Intel 13.4	1
+Chrome	114.0.5735.90	desktop	Macintosh	Intel 14.5	1
+Chrome	114.0.5735.90	desktop	Macintosh	Intel 15.3	1
+Chrome	114.0.5735.90	desktop	Windows	10	1
+Chrome	115.0.0.0	desktop	Macintosh	Intel 10.9	1
+Chrome	115.0.5790.102	desktop	Macintosh	Intel 14.7	1
+Chrome	115.0.5790.110	desktop	Linux	5.19.0	1
+Chrome	115.0.5790.110	desktop	Linux	5.4.0	1
+Chrome	115.0.5790.110	desktop	Linux	6.8.0	1
+Chrome	115.0.5790.136	mobile	Android	12.0.0	1
+Chrome	115.0.5790.138	mobile	Android	10.0.0	1
+Chrome	115.0.5790.138	mobile	Android	11.0.0	1
+Chrome	115.0.5790.168	mobile	Android	11.0.0	1
+Chrome	115.0.5790.168	mobile	Android	12	1
+Chrome	115.0.5790.168	mobile	Android	12.0.0	1
+Chrome	115.0.5790.168	mobile	Android	13	1
+Chrome	115.0.5790.168	mobile	Android	13.0.0	1
+Chrome	115.0.5790.168	mobile	Android	15	1
+Chrome	115.0.5790.168	mobile	Android	15.0.0	1
+Chrome	115.0.5790.168	mobile	Android	8.1.0	1
+Chrome	115.0.5790.170	desktop	Linux	5.17.0	1
+Chrome	115.0.5790.170	desktop	Linux	6.8.0	1
+Chrome	115.0.5790.99	desktop	Windows	11	1
+Chrome	116.0.0.0	mobile	Android	11.0.0	1
+Chrome	116.0.0.0	mobile	Android	13.0.0	1
+Chrome	116.0.0.0	mobile	Android	14	1
+Chrome	116.0.5817.0	desktop	Linux	6.8.0	1
+Chrome	116.0.5845.111	desktop	Windows	10	1
+Chrome	116.0.5845.111	desktop	Windows	11	1
+Chrome	116.0.5845.114	mobile	Android	10.0.0	1
+Chrome	116.0.5845.114	mobile	Android	11.0.0	1
+Chrome	116.0.5845.114	mobile	Android	12.0.0	1
+Chrome	116.0.5845.114	mobile	Android	13.0.0	1
+Chrome	116.0.5845.115	mobile	Android	11.0.0	1
+Chrome	116.0.5845.1159	mobile	Android	13.0.0	1
+Chrome	116.0.5845.131	mobile	Android	13	1
+Chrome	116.0.5845.140	desktop	Linux	6.5.0	1
+Chrome	116.0.5845.140	desktop	Macintosh	Intel 12.6	1
+Chrome	116.0.5845.140	desktop	Windows	11	1
+Chrome	116.0.5845.141	desktop	Windows	10	1
+Chrome	116.0.5845.141	mobile	Android	13	1
+Chrome	116.0.5845.163	mobile	Android	11.0.0	1
+Chrome	116.0.5845.163	mobile	Android	8.1.0	1
+Chrome	116.0.5845.164	mobile	Android	13.0.0	1
+Chrome	116.0.5845.173	mobile	Android	10.0.0	1
+Chrome	116.0.5845.173	tablet	Android	7.0.0	1
+Chrome	116.0.5845.179	desktop	Macintosh	Intel 15.5	1
+Chrome	116.0.5845.180	desktop	Windows	10	1
+Chrome	116.0.5845.187	desktop	Macintosh	Intel 10.15	1
+Chrome	116.0.5845.187	desktop	Macintosh	Intel 13.6	1
+Chrome	116.0.5845.188	desktop	Windows	11	1
+Chrome	116.0.5845.190	desktop	Macintosh	Intel 15.4	1
+Chrome	116.0.5845.4	desktop	Macintosh	Intel 15.1	1
+Chrome	116.0.5845.78	mobile	Android	12.0.0	1
+Chrome	116.0.5845.805	mobile	Android	10.0.0	1
+Chrome	116.0.5845.92	mobile	Android	12.0.0	1
+Chrome	116.0.5845.92	tablet	Android	13.0.0	1
+Chrome	116.0.5845.96	desktop	Linux	4.15.0	1
+Chrome	116.0.5845.96	desktop	Linux	5.15.0	1
+Chrome	116.0.5845.96	desktop	Macintosh	Intel 14.7	1
+Chrome	116.0.5845.96	desktop	Windows	11	1
+Chrome	116.0.5845.98	desktop	Windows	11	1
+Chrome	117.0.0.0	desktop	Linux	5.15.148	1
+Chrome	117.0.5938.101	mobile	Android	13	1
+Chrome	117.0.5938.117	mobile	iOS	15.8	1
+Chrome	117.0.5938.117	mobile	iOS	18.5	1
+Chrome	117.0.5938.132	desktop	Windows	11	1
+Chrome	117.0.5938.136	mobile	Android	13	1
+Chrome	117.0.5938.140	mobile	Android	9.0.0	1
+Chrome	117.0.5938.149	desktop	Linux	5.15.0	1
+Chrome	117.0.5938.149	desktop	Linux	6.8.0	1
+Chrome	117.0.5938.152	mobile	Android	13	1
+Chrome	117.0.5938.153	mobile	Android	8.1.0	1
+Chrome	117.0.5938.168	desktop	Windows	10	1
+Chrome	117.0.5938.60	mobile	Android	12.0.0	1
+Chrome	117.0.5938.62	desktop	Linux	6.12.12	1
+Chrome	117.0.5938.62	desktop	Macintosh	Intel 13.7	1
+Chrome	117.0.5938.63	desktop	Windows	11	1
+Chrome	117.0.5938.88	desktop	Linux	5.4.0	1
+Chrome	117.0.5938.92	desktop	Linux	5.15.0	1
+Chrome	117.0.5938.92	desktop	Windows	11	1
+Chrome	117.0.5938.92	mobile	Android	13	1
+Chrome	118	desktop	Windows	10	1
+Chrome	118.0.0.0	desktop	Linux	5.10.0	1
+Chrome	118.0.0.0	desktop	Windows	7	1
+Chrome	118.0.0.0	desktop	Windows	8.1	1
+Chrome	118.0.1.2	desktop	Windows	11	1
+Chrome	118.0.5993.111	mobile	Android	10.0.0	1
+Chrome	118.0.5993.111	mobile	Android	12.0.0	1
+Chrome	118.0.5993.111	mobile	Android	13.0.0	1
+Chrome	118.0.5993.112	mobile	Android	11.0.0	1
+Chrome	118.0.5993.112	mobile	Android	13.0.0	1
+Chrome	118.0.5993.112	mobile	Android	9.0.0	1
+Chrome	118.0.5993.117	desktop	Linux	5.15.0	1
+Chrome	118.0.5993.117	desktop	Linux	6.8.0	1
+Chrome	118.0.5993.117	desktop	Macintosh	Intel 14.5	1
+Chrome	118.0.5993.117	desktop	Windows	11	1
+Chrome	118.0.5993.594	mobile	Android	13.0.0	1
+Chrome	118.0.5993.69	mobile	iOS	17.0	1
+Chrome	118.0.5993.70	desktop	Linux	3.10.0	1
+Chrome	118.0.5993.70	desktop	Linux	5.15.0	1
+Chrome	118.0.5993.70	desktop	Linux	6.14.6	1
+Chrome	118.0.5993.70	desktop	Macintosh	Intel 13.5	1
+Chrome	118.0.5993.70	desktop	Macintosh	Intel 13.7	1
+Chrome	118.0.5993.80	mobile	Android	13	1
+Chrome	118.0.5993.80	mobile	Android	13.0.0	1
+Chrome	118.0.5993.80	mobile	Android	9.0.0	1
+Chrome	118.0.5993.80	tablet	Android	9.0.0	1
+Chrome	118.0.5993.81	mobile	Android	13.0.0	1
+Chrome	118.0.5993.88	desktop	Linux	5.15.34	1
+Chrome	118.0.5993.88	desktop	Linux	6.8.0	1
+Chrome	118.0.5993.89	desktop	Windows	10	1
+Chrome	119.0.0.0	desktop	Linux	6.5.0	1
+Chrome	119.0.6045.105	desktop	Linux	6.15.3	1
+Chrome	119.0.6045.105	desktop	Linux	6.2.0	1
+Chrome	119.0.6045.105	desktop	Macintosh	Intel 13.6	1
+Chrome	119.0.6045.105	desktop	Macintosh	Intel 14.0	1
+Chrome	119.0.6045.105	desktop	Macintosh	Intel 14.7	1
+Chrome	119.0.6045.105	desktop	Windows	10	1
+Chrome	119.0.6045.106	desktop	Windows	10	1
+Chrome	119.0.6045.106	desktop	Windows	11	1
+Chrome	119.0.6045.109	mobile	iOS	18.5	1
+Chrome	119.0.6045.109	tablet	iOS	16.6	1
+Chrome	119.0.6045.123	desktop	Linux	5.15.0	1
+Chrome	119.0.6045.123	desktop	Macintosh	Intel 12.6	1
+Chrome	119.0.6045.123	mobile	Android	13	1
+Chrome	119.0.6045.125	desktop	Windows	10	1
+Chrome	119.0.6045.134	mobile	Android	10.0.0	1
+Chrome	119.0.6045.134	mobile	Android	11.0.0	1
+Chrome	119.0.6045.134	mobile	Android	12.0.0	1
+Chrome	119.0.6045.134	mobile	Android	9.0.0	1
+Chrome	119.0.6045.135	mobile	Android	10.0.0	1
+Chrome	119.0.6045.159	desktop	Linux	5.14.21	1
+Chrome	119.0.6045.159	desktop	Linux	6.0.12	1
+Chrome	119.0.6045.159	desktop	Macintosh	Intel 11.6	1
+Chrome	119.0.6045.159	desktop	Macintosh	Intel 12.7	1
+Chrome	119.0.6045.159	desktop	Macintosh	Intel 14.2	1
+Chrome	119.0.6045.163	mobile	Android	7.0.0	1
+Chrome	119.0.6045.169	tablet	iOS	16.7	1
+Chrome	119.0.6045.193	mobile	Android	13	1
+Chrome	119.0.6045.193	mobile	Android	14.0.0	1
+Chrome	119.0.6045.193	mobile	Android	8.1.0	1
+Chrome	119.0.6045.193	smart tv	Android	7.1.2	1
+Chrome	119.0.6045.193	tablet	Android	7.1.2	1
+Chrome	119.0.6045.194	mobile	Android	11.0.0	1
+Chrome	119.0.6045.194	mobile	Android	13.0.0	1
+Chrome	119.0.6045.194	smart tv	Android	7.1.2	1
+Chrome	119.0.6045.194	tablet	Android	7.0.0	1
+Chrome	119.0.6045.194	tablet	Android	7.1.1	1
+Chrome	119.0.6045.199	desktop	Linux	5.15.0	1
+Chrome	119.0.6045.199	desktop	Macintosh	Intel 12.3	1
+Chrome	119.0.6045.199	desktop	Macintosh	Intel 14.4	1
+Chrome	119.0.6045.199	desktop	Windows	11	1
+Chrome	119.0.6045.66	mobile	Android	11.0.0	1
+Chrome	119.0.6045.66	mobile	Android	12.0.0	1
+Chrome	119.0.6045.66	mobile	Android	8.1.0	1
+Chrome	120	mobile	iOS	(not set)	1
+Chrome	120.0.0.0	desktop	Chrome OS	x86_64 15662.71.18	1
+Chrome	120.0.0.0	desktop	Windows	7	1
+Chrome	120.0.0.0	mobile	Android	10	1
+Chrome	120.0.0.0	mobile	Android	10.0.0	1
+Chrome	120.0.6099.101	mobile	iOS	18.5	1
+Chrome	120.0.6099.109	desktop	Linux	6.2.0	1
+Chrome	120.0.6099.109	desktop	Linux	6.8.0	1
+Chrome	120.0.6099.109	desktop	Macintosh	Intel 14.2	1
+Chrome	120.0.6099.109	desktop	Macintosh	Intel 14.7	1
+Chrome	120.0.6099.109	desktop	Windows	10	1
+Chrome	120.0.6099.111	desktop	Windows	10	1
+Chrome	120.0.6099.115	mobile	Android	10.0.0	1
+Chrome	120.0.6099.115	mobile	Android	13.0.0	1
+Chrome	120.0.6099.116	mobile	Android	12.0.0	1
+Chrome	120.0.6099.116	tablet	Android	11.0.0	1
+Chrome	120.0.6099.119	mobile	iOS	16.7	1
+Chrome	120.0.6099.119	mobile	iOS	17.4	1
+Chrome	120.0.6099.119	mobile	iOS	18.0	1
+Chrome	120.0.6099.119	mobile	iOS	18.1	1
+Chrome	120.0.6099.121	desktop	Windows	11	1
+Chrome	120.0.6099.129	desktop	Macintosh	Intel 12.6	1
+Chrome	120.0.6099.129	desktop	Macintosh	Intel 13.6	1
+Chrome	120.0.6099.144	mobile	Android	12.0.0	1
+Chrome	120.0.6099.145	mobile	Android	11.0.0	1
+Chrome	120.0.6099.145	mobile	Android	12.0.0	1
+Chrome	120.0.6099.193	mobile	Android	11.0.0	1
+Chrome	120.0.6099.193	mobile	Android	13	1
+Chrome	120.0.6099.193	mobile	Android	14	1
+Chrome	120.0.6099.194	mobile	Android	12.0.0	1
+Chrome	120.0.6099.199	desktop	Linux	5.15.0	1
+Chrome	120.0.6099.199	desktop	Linux	6.12.25	1
+Chrome	120.0.6099.199	desktop	Linux	6.8.0	1
+Chrome	120.0.6099.200	desktop	Windows	10	1
+Chrome	120.0.6099.200	desktop	Windows	11	1
+Chrome	120.0.6099.201	desktop	Windows	10	1
+Chrome	120.0.6099.203	desktop	Chrome OS	x86_64 15662.64.0	1
+Chrome	120.0.6099.210	mobile	Android	11.0.0	1
+Chrome	120.0.6099.210	tablet	Android	11.0.0	1
+Chrome	120.0.6099.211	mobile	Android	12.0.0	1
+Chrome	120.0.6099.216	desktop	Macintosh	Intel 13.5	1
+Chrome	120.0.6099.216	desktop	Macintosh	Intel 13.7	1
+Chrome	120.0.6099.216	desktop	Macintosh	Intel 14.5	1
+Chrome	120.0.6099.218	desktop	Windows	10	1
+Chrome	120.0.6099.218	desktop	Windows	11	1
+Chrome	120.0.6099.224	desktop	Linux	5.15.0	1
+Chrome	120.0.6099.224	desktop	Windows	11	1
+Chrome	120.0.6099.227	desktop	Windows	10	1
+Chrome	120.0.6099.230	mobile	Android	11	1
+Chrome	120.0.6099.231	mobile	Android	11.0.0	1
+Chrome	120.0.6099.231	mobile	Android	12.0.0	1
+Chrome	120.0.6099.231	mobile	Android	8.1.0	1
+Chrome	120.0.6099.234	desktop	Macintosh	Intel 14.4	1
+Chrome	120.0.6099.234	desktop	Macintosh	Intel 14.6	1
+Chrome	120.0.6099.238	desktop	Macintosh	Intel 14.2	1
+Chrome	120.0.6099.238	desktop	Windows	10	1
+Chrome	120.0.6099.269	desktop	Macintosh	Intel 15.5	1
+Chrome	120.0.6099.269	desktop	Windows	11	1
+Chrome	120.0.6099.291	desktop	Windows	11	1
+Chrome	120.0.6099.312	desktop	Chrome OS	x86_64 15662.109.0	1
+Chrome	120.0.6099.43	mobile	Android	10.0.0	1
+Chrome	120.0.6099.44	mobile	Android	12.0.0	1
+Chrome	120.0.6099.44	mobile	Android	9.0.0	1
+Chrome	120.0.6099.479	mobile	Android	14.0.0	1
+Chrome	120.0.6099.50	mobile	iOS	17.5	1
+Chrome	120.0.6099.62	desktop	Macintosh	Intel 11.2	1
+Chrome	120.0.6099.62	desktop	Macintosh	Intel 14.1	1
+Chrome	120.0.6099.62	desktop	Macintosh	Intel 14.2	1
+Chrome	120.0.6099.63	desktop	Windows	11	1
+Chrome	120.0.6099.71	desktop	Macintosh	Intel 12.6	1
+Chrome	120.0.6099.72	desktop	Windows	11	1
+Chrome	121.0.0.0	desktop	Windows	8.1	1
+Chrome	121.0.0.0	mobile	Android	11.0	1
+Chrome	121.0.6167.138	mobile	iOS	17.3	1
+Chrome	121.0.6167.139	desktop	Macintosh	Intel 14.2	1
+Chrome	121.0.6167.139	desktop	Macintosh	Intel 14.3	1
+Chrome	121.0.6167.139	desktop	Macintosh	Intel 14.6	1
+Chrome	121.0.6167.139	mobile	Macintosh	 14.2	1
+Chrome	121.0.6167.143	mobile	Android	10.0.0	1
+Chrome	121.0.6167.159	desktop	Chrome OS	aarch64 15699.58.0	1
+Chrome	121.0.6167.160	desktop	Linux	4.17.12	1
+Chrome	121.0.6167.160	desktop	Macintosh	Intel 14.3	1
+Chrome	121.0.6167.160	desktop	Windows	10	1
+Chrome	121.0.6167.164	mobile	Android	10.0.0	1
+Chrome	121.0.6167.164	mobile	Android	13.0.0	1
+Chrome	121.0.6167.164	mobile	Android	9.0.0	1
+Chrome	121.0.6167.165	mobile	Android	14.0.0	1
+Chrome	121.0.6167.171	mobile	iOS	16.7	1
+Chrome	121.0.6167.171	mobile	iOS	18.5	1
+Chrome	121.0.6167.180	mobile	Android	12.0.0	1
+Chrome	121.0.6167.180	mobile	Android	13.0.0	1
+Chrome	121.0.6167.180	mobile	Android	14.0.0	1
+Chrome	121.0.6167.184	desktop	Linux	6.11.0	1
+Chrome	121.0.6167.184	desktop	Linux	6.5.0	1
+Chrome	121.0.6167.184	desktop	Macintosh	Intel 14.6	1
+Chrome	121.0.6167.184	desktop	Windows	10	1
+Chrome	121.0.6167.185	mobile	Android	6.0	1
+Chrome	121.0.6167.189	desktop	Windows	10	1
+Chrome	121.0.6167.189	desktop	Windows	11	1
+Chrome	121.0.6167.66	mobile	iOS	17.6	1
+Chrome	121.0.6167.66	mobile	iOS	18.5	1
+Chrome	121.0.6167.66	tablet	iOS	17.0	1
+Chrome	121.0.6167.85	desktop	Linux	5.15.0	1
+Chrome	121.0.6167.85	desktop	Macintosh	Intel 12.6	1
+Chrome	121.0.6167.85	desktop	Macintosh	Intel 14.4	1
+Chrome	121.0.6167.85	desktop	Macintosh	Intel 14.6	1
+Chrome	121.0.6167.85	desktop	Windows	10	1
+Chrome	121.0.6167.86	desktop	Macintosh	Intel 13.5	1
+Chrome	121.0.6167.86	desktop	Macintosh	Intel 15.5	1
+Chrome	122.0.0.0	desktop	Linux	14.3.0	1
+Chrome	122.0.0.0	desktop	Linux	5.4.0	1
+Chrome	122.0.0.0	desktop	Linux	6.6.63	1
+Chrome	122.0.0.0	desktop	Macintosh	Intel 10.15	1
+Chrome	122.0.587.0	desktop	Windows	NT	1
+Chrome	122.0.597.107	desktop	Linux	(not set)	1
+Chrome	122.0.6225.0	mobile	Android	14.0.0	1
+Chrome	122.0.6261.105	mobile	Android	12.0.0	1
+Chrome	122.0.6261.105	mobile	Android	14	1
+Chrome	122.0.6261.105	mobile	Android	14.0.0	1
+Chrome	122.0.6261.105	tablet	Android	12.0.0	1
+Chrome	122.0.6261.106	mobile	Android	13.0.0	1
+Chrome	122.0.6261.111	desktop	Linux	4.18.0	1
+Chrome	122.0.6261.111	desktop	Linux	5.4.0	1
+Chrome	122.0.6261.111	desktop	Linux	6.1.0	1
+Chrome	122.0.6261.111	desktop	Linux	6.5.0	1
+Chrome	122.0.6261.111	desktop	Linux	6.6.15	1
+Chrome	122.0.6261.111	desktop	Windows	10	1
+Chrome	122.0.6261.112	desktop	Macintosh	Intel 13.2	1
+Chrome	122.0.6261.112	desktop	Macintosh	Intel 13.5	1
+Chrome	122.0.6261.112	desktop	Macintosh	Intel 14.4	1
+Chrome	122.0.6261.119	mobile	Android	12	1
+Chrome	122.0.6261.119	mobile	Android	13.0.0	1
+Chrome	122.0.6261.119	mobile	Android	14.0.0	1
+Chrome	122.0.6261.119	mobile	Android	15.0.0	1
+Chrome	122.0.6261.119	mobile	Android	8.1.0	1
+Chrome	122.0.6261.119	tablet	Android	15	1
+Chrome	122.0.6261.120	mobile	Android	11.0.0	1
+Chrome	122.0.6261.129	desktop	Macintosh	Intel 14.1	1
+Chrome	122.0.6261.129	desktop	Macintosh	Intel 14.6	1
+Chrome	122.0.6261.156	desktop	Windows	10	1
+Chrome	122.0.6261.162	mobile	iOS	17.4	1
+Chrome	122.0.6261.43	mobile	Android	14.0.0	1
+Chrome	122.0.6261.51	mobile	iOS	17.0	1
+Chrome	122.0.6261.51	mobile	iOS	17.3	1
+Chrome	122.0.6261.51	mobile	iOS	18.3	1
+Chrome	122.0.6261.57	desktop	Linux	6.8.0	1
+Chrome	122.0.6261.57	desktop	Macintosh	Intel 14.0	1
+Chrome	122.0.6261.57	desktop	Macintosh	Intel 14.3	1
+Chrome	122.0.6261.57	desktop	Macintosh	Intel 14.5	1
+Chrome	122.0.6261.57	desktop	Macintosh	Intel 14.7	1
+Chrome	122.0.6261.57	desktop	Windows	11	1
+Chrome	122.0.6261.58	desktop	Windows	10	1
+Chrome	122.0.6261.62	mobile	iOS	16.1	1
+Chrome	122.0.6261.62	mobile	iOS	17.1	1
+Chrome	122.0.6261.62	tablet	iOS	15.5	1
+Chrome	122.0.6261.64	mobile	Android	10.0.0	1
+Chrome	122.0.6261.64	mobile	Android	14	1
+Chrome	122.0.6261.64	tablet	Android	10.0.0	1
+Chrome	122.0.6261.64	tablet	Android	13.0.0	1
+Chrome	122.0.6261.69	desktop	Linux	5.10.89	1
+Chrome	122.0.6261.69	desktop	Linux	5.15.0	1
+Chrome	122.0.6261.69	desktop	Linux	5.9.10	1
+Chrome	122.0.6261.69	desktop	Macintosh	Intel 11.7	1
+Chrome	122.0.6261.69	desktop	Windows	10	1
+Chrome	122.0.6261.89	mobile	iOS	17.2	1
+Chrome	122.0.6261.89	mobile	iOS	17.7	1
+Chrome	122.0.6261.89	mobile	iOS	18.3	1
+Chrome	122.0.6261.89	tablet	iOS	17.1	1
+Chrome	122.0.6261.90	mobile	Android	10.0.0	1
+Chrome	122.0.6261.90	mobile	Android	14.0.0	1
+Chrome	122.0.6261.90	mobile	Android	9.0.0	1
+Chrome	122.0.6261.91	mobile	Android	14.0.0	1
+Chrome	122.0.6261.94	desktop	Linux	5.10.0	1
+Chrome	122.0.6261.94	desktop	Linux	5.14.0	1
+Chrome	122.0.6261.94	desktop	Linux	6.5.0	1
+Chrome	122.0.6261.94	desktop	Macintosh	Intel 12.6	1
+Chrome	122.0.6261.94	desktop	Macintosh	Intel 13.6	1
+Chrome	122.0.6261.94	desktop	Macintosh	Intel 14.3	1
+Chrome	122.0.6261.94	desktop	Macintosh	Intel 14.6	1
+Chrome	122.0.6261.94	desktop	Macintosh	Intel 15.3	1
+Chrome	122.0.6261.94	desktop	Macintosh	Intel 15.5	1
+Chrome	122.0.6261.992	mobile	Android	10.0.0	1
+Chrome	122.0.6291.202	desktop	Linux	(not set)	1
+Chrome	123.0.0.0	desktop	Linux	6.6.9	1
+Chrome	123.0.0.0	desktop	Macintosh	Intel 10.15	1
+Chrome	123.0.0.0	desktop	Macintosh	Intel 14.3	1
+Chrome	123.0.6312.100	mobile	Android	12.0.0	1
+Chrome	123.0.6312.105	desktop	Linux	5.0.0	1
+Chrome	123.0.6312.105	desktop	Linux	6.5.0	1
+Chrome	123.0.6312.105	mobile	Android	13.0.0	1
+Chrome	123.0.6312.107	desktop	Macintosh	Intel 10.15	1
+Chrome	123.0.6312.107	desktop	Macintosh	Intel 14.7	1
+Chrome	123.0.6312.118	desktop	Linux	10.0.0	1
+Chrome	123.0.6312.118	mobile	Android	12.0.0	1
+Chrome	123.0.6312.118	mobile	Linux	11.0.0	1
+Chrome	123.0.6312.118	tablet	Android	14.0.0	1
+Chrome	123.0.6312.118	tablet	Android	15.0.0	1
+Chrome	123.0.6312.120	mobile	Android	12.0.0	1
+Chrome	123.0.6312.120	mobile	Android	8.1.0	1
+Chrome	123.0.6312.121	mobile	Android	8.1.0	1
+Chrome	123.0.6312.122	desktop	Linux	5.4.0	1
+Chrome	123.0.6312.122	desktop	Linux	6.14.0	1
+Chrome	123.0.6312.122	desktop	Linux	6.8.0	1
+Chrome	123.0.6312.122	desktop	Macintosh	Intel 14.7	1
+Chrome	123.0.6312.123	desktop	Macintosh	Intel 10.15	1
+Chrome	123.0.6312.123	desktop	Macintosh	Intel 13.4	1
+Chrome	123.0.6312.124	desktop	Macintosh	Intel 14.4	1
+Chrome	123.0.6312.40	mobile	Android	12.0.0	1
+Chrome	123.0.6312.40	mobile	Android	14.0.0	1
+Chrome	123.0.6312.41	mobile	Android	12.0.0	1
+Chrome	123.0.6312.41	mobile	Android	9.0.0	1
+Chrome	123.0.6312.50	mobile	Android	14	1
+Chrome	123.0.6312.52	mobile	iOS	17.3	1
+Chrome	123.0.6312.52	mobile	iOS	18.5	1
+Chrome	123.0.6312.58	desktop	Linux	5.4.0	1
+Chrome	123.0.6312.58	desktop	Linux	6.5.0	1
+Chrome	123.0.6312.58	desktop	Linux	6.8.0	1
+Chrome	123.0.6312.59	desktop	Macintosh	Intel 14.4	1
+Chrome	123.0.6312.59	desktop	Macintosh	Intel 15.5	1
+Chrome	123.0.6312.80	mobile	Android	10.0.0	1
+Chrome	123.0.6312.80	mobile	Android	11.0.0	1
+Chrome	123.0.6312.81	mobile	Android	9.0.0	1
+Chrome	123.0.6312.86	desktop	Linux	4.18.0	1
+Chrome	123.0.6312.87	desktop	Macintosh	Intel 15.1	1
+Chrome	123.0.6312.88	desktop	Windows	10	1
+Chrome	123.0.6312.99	mobile	Android	10.0.0	1
+Chrome	123.0.6312.99	mobile	Android	13.0.0	1
+Chrome	123.0.6312.99	mobile	Android	14.0.0	1
+Chrome	123.0.6312.99	mobile	Android	9.0.0	1
+Chrome	123.0.6312.99	tablet	Android	13.0.0	1
+Chrome	123.0.6312.99	tablet	Android	14.0.0	1
+Chrome	123.0.6312.99	tablet	Android	9.0.0	1
+Chrome	123.0.6322.198	mobile	Android	13	1
+Chrome	124.0.0.0	desktop	Windows	7	1
+Chrome	124.0.0.0	mobile	Android	10	1
+Chrome	124.0.0.0	mobile	Android	12	1
+Chrome	124.0.0.0	mobile	Android	12.0.0	1
+Chrome	124.0.0.0	mobile	Android	14.0.0	1
+Chrome	124.0.0.0	mobile	Android	15.0.0	1
+Chrome	124.0.0.0	tablet	Android	12.0.0	1
+Chrome	124.0.0.0	tablet	Android	15	1
+Chrome	124.0.6327.2	mobile	Android	13.0.0	1
+Chrome	124.0.6328.0	mobile	Android	12.0.0	1
+Chrome	124.0.6342.3	desktop	Macintosh	Intel 14.6	1
+Chrome	124.0.6342.3	desktop	Windows	10	1
+Chrome	124.0.6367.111	tablet	iOS	15.7	1
+Chrome	124.0.6367.111	tablet	iOS	15.8	1
+Chrome	124.0.6367.113	mobile	Android	13.0.0	1
+Chrome	124.0.6367.113	mobile	Android	15.0.0	1
+Chrome	124.0.6367.113	mobile	Android	9.0.0	1
+Chrome	124.0.6367.114	mobile	Android	9.0.0	1
+Chrome	124.0.6367.118	desktop	Linux	5.15.0	1
+Chrome	124.0.6367.118	desktop	Linux	6.11.0	1
+Chrome	124.0.6367.118	desktop	Linux	6.14.0	1
+Chrome	124.0.6367.118	desktop	Windows	10	1
+Chrome	124.0.6367.119	desktop	Macintosh	Intel 11.7	1
+Chrome	124.0.6367.119	desktop	Macintosh	Intel 13.5	1
+Chrome	124.0.6367.119	desktop	Macintosh	Intel 14.1	1
+Chrome	124.0.6367.119	desktop	Macintosh	Intel 14.6	1
+Chrome	124.0.6367.119	desktop	Macintosh	Intel 15.3	1
+Chrome	124.0.6367.120	mobile	Android	13.0.0	1
+Chrome	124.0.6367.155	desktop	Linux	5.4.0	1
+Chrome	124.0.6367.155	desktop	Linux	6.8.0	1
+Chrome	124.0.6367.155	desktop	Windows	10	1
+Chrome	124.0.6367.155	desktop	Windows	11	1
+Chrome	124.0.6367.156	desktop	Macintosh	Intel 15.4	1
+Chrome	124.0.6367.156	desktop	Macintosh	Intel 15.5	1
+Chrome	124.0.6367.156	desktop	Windows	10	1
+Chrome	124.0.6367.156	desktop	Windows	11	1
+Chrome	124.0.6367.159	mobile	Android	12.0.0	1
+Chrome	124.0.6367.159	mobile	Android	13.0.0	1
+Chrome	124.0.6367.159	mobile	Android	14.0.0	1
+Chrome	124.0.6367.159	mobile	Android	8.1.0	1
+Chrome	124.0.6367.171	mobile	Android	8.0.0	1
+Chrome	124.0.6367.172	mobile	Android	11.0.0	1
+Chrome	124.0.6367.179	mobile	Android	10.0.0	1
+Chrome	124.0.6367.179	mobile	Android	12.0.0	1
+Chrome	124.0.6367.179	mobile	Android	14	1
+Chrome	124.0.6367.179	mobile	Android	8.1.0	1
+Chrome	124.0.6367.179	tablet	Android	14.0.0	1
+Chrome	124.0.6367.1941	mobile	Android	11.0.0	1
+Chrome	124.0.6367.201	desktop	Linux	5.10.0	1
+Chrome	124.0.6367.201	desktop	Linux	5.15.0	1
+Chrome	124.0.6367.201	desktop	Linux	6.8.0	1
+Chrome	124.0.6367.201	desktop	Macintosh	Intel 14.3	1
+Chrome	124.0.6367.202	desktop	Macintosh	Intel 14.4	1
+Chrome	124.0.6367.202	desktop	Windows	11	1
+Chrome	124.0.6367.207	desktop	Windows	10	1
+Chrome	124.0.6367.207	desktop	Windows	11	1
+Chrome	124.0.6367.208	desktop	Macintosh	Intel 15.5	1
+Chrome	124.0.6367.219	mobile	Android	15.0.0	1
+Chrome	124.0.6367.236	desktop	Windows	11	1
+Chrome	124.0.6367.243	desktop	Windows	11	1
+Chrome	124.0.6367.503	mobile	Android	13.0.0	1
+Chrome	124.0.6367.503	mobile	Android	9.0.0	1
+Chrome	124.0.6367.509	mobile	Android	10.0.0	1
+Chrome	124.0.6367.509	mobile	Android	8.0.0	1
+Chrome	124.0.6367.512	mobile	Android	14.0.0	1
+Chrome	124.0.6367.54	mobile	Android	12.0.0	1
+Chrome	124.0.6367.54	mobile	Android	13.0.0	1
+Chrome	124.0.6367.54	mobile	Android	15.0.0	1
+Chrome	124.0.6367.54	mobile	Android	8.1.0	1
+Chrome	124.0.6367.60	desktop	Linux	6.8.0	1
+Chrome	124.0.6367.61	desktop	Macintosh	Intel 10.15	1
+Chrome	124.0.6367.62	desktop	Macintosh	Intel 11.3	1
+Chrome	124.0.6367.62	desktop	Macintosh	Intel 12.7	1
+Chrome	124.0.6367.62	desktop	Macintosh	Intel 13.7	1
+Chrome	124.0.6367.62	desktop	Macintosh	Intel 14.4	1
+Chrome	124.0.6367.62	desktop	Macintosh	Intel 15.5	1
+Chrome	124.0.6367.63	desktop	Windows	10	1
+Chrome	124.0.6367.678	mobile	Android	10.0.0	1
+Chrome	124.0.6367.71	mobile	iOS	18.3	1
+Chrome	124.0.6367.78	desktop	Linux	5.15.0	1
+Chrome	124.0.6367.78	desktop	Linux	6.14.0	1
+Chrome	124.0.6367.78	desktop	Macintosh	Intel 13.0	1
+Chrome	124.0.6367.80	desktop	Macintosh	Intel 13.2	1
+Chrome	124.0.6367.80	desktop	Macintosh	Intel 15.4	1
+Chrome	124.0.6367.82	mobile	Android	12.0.0	1
+Chrome	124.0.6367.82	mobile	Android	13.0.0	1
+Chrome	124.0.6367.82	mobile	Android	14.0.0	1
+Chrome	124.0.6367.82	mobile	Android	15.0.0	1
+Chrome	124.0.6367.82	mobile	Android	8.1.0	1
+Chrome	124.0.6367.82	mobile	Android	9	1
+Chrome	124.0.6367.82	mobile	Android	9.0.0	1
+Chrome	124.0.6367.83	mobile	Android	8.0.0	1
+Chrome	124.0.6367.83	mobile	Android	9.0.0	1
+Chrome	124.0.6367.91	desktop	Linux	5.14.0	1
+Chrome	124.0.6367.91	desktop	Windows	11	1
+Chrome	124.0.6367.92	desktop	Windows	11	1
+Chrome	124.0.6367.93	desktop	Macintosh	Intel 15.1	1
+Chrome	124.0.6367.93	desktop	Macintosh	Intel 15.4	1
+Chrome	124.0.6367.93	desktop	Windows	10	1
+Chrome	124.0.6998.178	desktop	Windows	10	1
+Chrome	124.61.1.50259	desktop	Linux	5.15.0	1
+Chrome	124.61.1.50292	desktop	Macintosh	Intel 14.4	1
+Chrome	124.61.1.50292	desktop	Macintosh	Intel 15.4	1
+Chrome	124.61.1.50294	desktop	Windows	10	1
+Chrome	124.61.1.50294	desktop	Windows	11	1
+Chrome	125.0.0.0	desktop	Linux	6.5.0	1
+Chrome	125.0.0.0	mobile	Android	16.0.0	1
+Chrome	125.0.6396.3	desktop	Macintosh	Intel 10.15	1
+Chrome	125.0.6422.0	desktop	Windows	10	1
+Chrome	125.0.6422.112	desktop	Linux	5.4.0	1
+Chrome	125.0.6422.112	desktop	Linux	6.1.0	1
+Chrome	125.0.6422.112	desktop	Linux	6.13.5	1
+Chrome	125.0.6422.112	desktop	Macintosh	Intel 14.5	1
+Chrome	125.0.6422.112	desktop	Macintosh	Intel 15.5	1
+Chrome	125.0.6422.113	desktop	Macintosh	Intel 12.7	1
+Chrome	125.0.6422.113	mobile	Android	10.0.0	1
+Chrome	125.0.6422.113	mobile	Android	12.0.0	1
+Chrome	125.0.6422.113	mobile	Android	14.0.0	1
+Chrome	125.0.6422.113	mobile	Android	8.1.0	1
+Chrome	125.0.6422.114	desktop	Windows	10	1
+Chrome	125.0.6422.140	desktop	Chrome OS	x86_64 15853.53.0	1
+Chrome	125.0.6422.141	desktop	Linux	5.4.0	1
+Chrome	125.0.6422.141	desktop	Linux	6.14.0	1
+Chrome	125.0.6422.141	desktop	Linux	6.5.0	1
+Chrome	125.0.6422.141	desktop	Linux	6.6.15	1
+Chrome	125.0.6422.141	desktop	Windows	11	1
+Chrome	125.0.6422.142	desktop	Macintosh	Intel 10.15	1
+Chrome	125.0.6422.142	desktop	Macintosh	Intel 14.3	1
+Chrome	125.0.6422.142	desktop	Macintosh	Intel 14.4	1
+Chrome	125.0.6422.142	desktop	Macintosh	Intel 14.5	1
+Chrome	125.0.6422.142	desktop	Macintosh	Intel 14.6	1
+Chrome	125.0.6422.142	desktop	Macintosh	Intel 15.3	1
+Chrome	125.0.6422.142	mobile	Android	6.0	1
+Chrome	125.0.6422.144	desktop	Windows	10	1
+Chrome	125.0.6422.145	mobile	iOS	15.0	1
+Chrome	125.0.6422.145	mobile	iOS	15.1	1
+Chrome	125.0.6422.145	mobile	iOS	15.3	1
+Chrome	125.0.6422.145	mobile	iOS	15.4	1
+Chrome	125.0.6422.145	mobile	iOS	15.6	1
+Chrome	125.0.6422.145	mobile	iOS	18.1	1
+Chrome	125.0.6422.145	tablet	iOS	15.7	1
+Chrome	125.0.6422.145	tablet	iOS	15.8	1
+Chrome	125.0.6422.145	tablet	iOS	18.5	1
+Chrome	125.0.6422.146	mobile	Android	11.0.0	1
+Chrome	125.0.6422.147	mobile	Android	10.0.0	1
+Chrome	125.0.6422.147	mobile	Android	13.0.0	1
+Chrome	125.0.6422.164	mobile	Android	13.0.0	1
+Chrome	125.0.6422.164	mobile	Android	9	1
+Chrome	125.0.6422.165	mobile	Android	8.0.0	1
+Chrome	125.0.6422.167	mobile	Android	13.0.0	1
+Chrome	125.0.6422.176	desktop	Windows	10	1
+Chrome	125.0.6422.186	mobile	Android	11.0.0	1
+Chrome	125.0.6422.186	mobile	Android	8.1.0	1
+Chrome	125.0.6422.26	desktop	Windows	10	1
+Chrome	125.0.6422.3	mobile	Android	10.0.0	1
+Chrome	125.0.6422.41	desktop	Windows	10	1
+Chrome	125.0.6422.51	mobile	iOS	15.8	1
+Chrome	125.0.6422.51	mobile	iOS	17.5	1
+Chrome	125.0.6422.52	mobile	Android	10.0.0	1
+Chrome	125.0.6422.52	mobile	Android	14.0.0	1
+Chrome	125.0.6422.52	mobile	Android	8.1.0	1
+Chrome	125.0.6422.53	mobile	Android	11	1
+Chrome	125.0.6422.53	mobile	Android	13.0.0	1
+Chrome	125.0.6422.60	desktop	Linux	5.15.0	1
+Chrome	125.0.6422.60	desktop	Linux	6.1.0	1
+Chrome	125.0.6422.60	desktop	Linux	6.11.0	1
+Chrome	125.0.6422.60	desktop	Linux	6.8.0	1
+Chrome	125.0.6422.60	desktop	Macintosh	Intel 15.5	1
+Chrome	125.0.6422.60	desktop	Windows	11	1
+Chrome	125.0.6422.76	desktop	Windows	10	1
+Chrome	125.0.6422.77	desktop	Macintosh	Intel 14.5	1
+Chrome	125.0.6422.78	desktop	Windows	10	1
+Chrome	125.0.6422.80	mobile	iOS	15.0	1
+Chrome	125.0.6422.80	mobile	iOS	15.4	1
+Chrome	125.0.6422.80	mobile	iOS	15.5	1
+Chrome	125.0.6422.80	mobile	iOS	15.7	1
+Chrome	125.0.6422.80	mobile	iOS	16.5	1
+Chrome	125.0.6422.80	mobile	iOS	16.6.1	1
+Chrome	125.0.6422.80	tablet	iOS	15.8	1
+Chrome	126.0.0.0	desktop	Chrome OS	x86_64 15886.75.0	1
+Chrome	126.0.0.0	desktop	Chrome OS	x86_64 2.1.2	1
+Chrome	126.0.0.0	desktop	Linux	6.9.6	1
+Chrome	126.0.0.0	desktop	Macintosh	Intel 12.6	1
+Chrome	126.0.0.0	desktop	Macintosh	Intel 14.7	1
+Chrome	126.0.0.0	desktop	Windows	11	1
+Chrome	126.0.0.0	mobile	Android	11.0.0	1
+Chrome	126.0.0.0	mobile	Android	14.0.0	1
+Chrome	126.0.0.0	mobile	iOS	14.6	1
+Chrome	126.0.0.0	mobile	iOS	14.7	1
+Chrome	126.0.0.0	mobile	iOS	14.8	1
+Chrome	126.0.0.0	mobile	iOS	15.1	1
+Chrome	126.0.0.0	mobile	iOS	15.4	1
+Chrome	126.0.0.0	mobile	iOS	15.5	1
+Chrome	126.0.0.0	mobile	iOS	15.6	1
+Chrome	126.0.0.0	mobile	iOS	16.6	1
+Chrome	126.0.0.0	mobile	iOS	17.1	1
+Chrome	126.0.0.0	mobile	iOS	17.3	1
+Chrome	126.0.0.0	mobile	iOS	17.5	1
+Chrome	126.0.6439.0	desktop	Linux	6.8.0	1
+Chrome	126.0.6478.110	mobile	Android	10.0.0	1
+Chrome	126.0.6478.110	mobile	Android	14	1
+Chrome	126.0.6478.110	mobile	Android	8.1.0	1
+Chrome	126.0.6478.110	mobile	Android	9.0.0	1
+Chrome	126.0.6478.111	mobile	Android	10.0.0	1
+Chrome	126.0.6478.111	mobile	Android	11.0.0	1
+Chrome	126.0.6478.114	desktop	Linux	5.4.0	1
+Chrome	126.0.6478.114	desktop	Linux	6.12.6	1
+Chrome	126.0.6478.114	desktop	Windows	7	1
+Chrome	126.0.6478.115	desktop	Macintosh	Intel 14.3	1
+Chrome	126.0.6478.115	desktop	Macintosh	Intel 15.5	1
+Chrome	126.0.6478.116	desktop	Windows	11	1
+Chrome	126.0.6478.122	mobile	Android	10	1
+Chrome	126.0.6478.122	mobile	Android	13	1
+Chrome	126.0.6478.122	tablet	Android	14.0.0	1
+Chrome	126.0.6478.122	tablet	Android	8.1.0	1
+Chrome	126.0.6478.123	mobile	Android	13.0.0	1
+Chrome	126.0.6478.123	mobile	Android	14.0.0	1
+Chrome	126.0.6478.126	desktop	Linux	4.18.0	1
+Chrome	126.0.6478.126	desktop	Linux	5.10.0	1
+Chrome	126.0.6478.126	desktop	Linux	6.15.4	1
+Chrome	126.0.6478.126	desktop	Linux	6.6.6	1
+Chrome	126.0.6478.126	desktop	Macintosh	Intel 15.4	1
+Chrome	126.0.6478.126	desktop	Windows	11	1
+Chrome	126.0.6478.127	desktop	Macintosh	Intel 12.5	1
+Chrome	126.0.6478.127	desktop	Macintosh	Intel 13.2	1
+Chrome	126.0.6478.127	desktop	Macintosh	Intel 13.7	1
+Chrome	126.0.6478.153	mobile	iOS	16.0	1
+Chrome	126.0.6478.153	mobile	iOS	17.6	1
+Chrome	126.0.6478.182	desktop	Linux	5.13.0	1
+Chrome	126.0.6478.182	desktop	Linux	6.11.9	1
+Chrome	126.0.6478.182	desktop	Linux	6.4.13	1
+Chrome	126.0.6478.182	desktop	Linux	6.9.10	1
+Chrome	126.0.6478.183	desktop	Linux	(not set)	1
+Chrome	126.0.6478.183	desktop	Macintosh	Intel 13.2	1
+Chrome	126.0.6478.183	desktop	Macintosh	Intel 13.7	1
+Chrome	126.0.6478.183	desktop	Macintosh	Intel 14.4	1
+Chrome	126.0.6478.183	desktop	Macintosh	Intel 15.1	1
+Chrome	126.0.6478.183	desktop	Macintosh	Intel 15.5	1
+Chrome	126.0.6478.183	mobile	Android	14	1
+Chrome	126.0.6478.185	desktop	Macintosh	Intel 13.6	1
+Chrome	126.0.6478.185	desktop	Windows	11	1
+Chrome	126.0.6478.186	mobile	Android	10.0.0	1
+Chrome	126.0.6478.186	mobile	Android	11.0.0	1
+Chrome	126.0.6478.186	mobile	Android	13.0.0	1
+Chrome	126.0.6478.186	mobile	Android	14.0.0	1
+Chrome	126.0.6478.187	mobile	Android	15.0.0	1
+Chrome	126.0.6478.188	mobile	Android	10.0.0	1
+Chrome	126.0.6478.188	mobile	Android	11.0.0	1
+Chrome	126.0.6478.188	mobile	Android	12.0.0	1
+Chrome	126.0.6478.188	mobile	Android	13.0.0	1
+Chrome	126.0.6478.2429	mobile	Android	11.0.0	1
+Chrome	126.0.6478.256	desktop	Windows	11	1
+Chrome	126.0.6478.40	mobile	Android	8.0.0	1
+Chrome	126.0.6478.40	mobile	Android	9.0.0	1
+Chrome	126.0.6478.54	mobile	iOS	18.0.1	1
+Chrome	126.0.6478.55	desktop	Linux	6.2.13	1
+Chrome	126.0.6478.55	desktop	Linux	6.8.0	1
+Chrome	126.0.6478.56	desktop	Windows	10	1
+Chrome	126.0.6478.57	desktop	Macintosh	Intel 15.3	1
+Chrome	126.0.6478.57	desktop	Windows	11	1
+Chrome	126.0.6478.61	desktop	Linux	5.14.0	1
+Chrome	126.0.6478.61	desktop	Linux	6.9.3	1
+Chrome	126.0.6478.62	desktop	Macintosh	Intel 13.6	1
+Chrome	126.0.6478.62	desktop	Macintosh	Intel 13.7	1
+Chrome	126.0.6478.62	desktop	Macintosh	Intel 14.1	1
+Chrome	126.0.6478.62	desktop	Macintosh	Intel 14.7	1
+Chrome	126.0.6478.62	desktop	Windows	11	1
+Chrome	126.0.6478.63	desktop	Windows	10	1
+Chrome	126.0.6478.63	desktop	Windows	11	1
+Chrome	126.0.6478.71	mobile	Android	10.0.0	1
+Chrome	126.0.6478.71	mobile	Android	11.0.0	1
+Chrome	126.0.6478.71	mobile	Android	15	1
+Chrome	126.0.6478.72	mobile	Android	10.0.0	1
+Chrome	126.0.6478.72	mobile	Android	12.0.0	1
+Chrome	126.0.6478.72	mobile	Android	13.0.0	1
+Chrome	126.0.6478.806	mobile	Android	12.0.0	1
+Chrome	127	desktop	Windows	10	1
+Chrome	127.0.0.0	desktop	Linux	3.10.0	1
+Chrome	127.0.0.0	desktop	Linux	5.15.0	1
+Chrome	127.0.0.0	desktop	Linux	6.10.3	1
+Chrome	127.0.0.0	desktop	Linux	6.6.84	1
+Chrome	127.0.0.0	desktop	Macintosh	Intel 13.7	1
+Chrome	127.0.0.0	desktop	Windows	11	1
+Chrome	127.0.0.0	mobile	Android	10	1
+Chrome	127.0.0.0	mobile	Android	11.0.0	1
+Chrome	127.0.0.0	mobile	Android	13.0.0	1
+Chrome	127.0.0.0	mobile	Android	9.0.0	1
+Chrome	127.0.6533.100	desktop	Macintosh	Intel 13.5	1
+Chrome	127.0.6533.100	desktop	Macintosh	Intel 15.4	1
+Chrome	127.0.6533.101	desktop	Macintosh	Intel 13.4	1
+Chrome	127.0.6533.101	desktop	Macintosh	Intel 14.4	1
+Chrome	127.0.6533.101	desktop	Macintosh	Intel 15.4	1
+Chrome	127.0.6533.101	desktop	Windows	10	1
+Chrome	127.0.6533.101	mobile	Android	10	1
+Chrome	127.0.6533.103	desktop	Macintosh	Intel 10.15	1
+Chrome	127.0.6533.103	mobile	Android	9.0.0	1
+Chrome	127.0.6533.104	mobile	Android	14.0.0	1
+Chrome	127.0.6533.105	mobile	Android	14.0.0	1
+Chrome	127.0.6533.105	mobile	Android	8.0.0	1
+Chrome	127.0.6533.106	mobile	Android	11.0.0	1
+Chrome	127.0.6533.106	mobile	Android	12.0.0	1
+Chrome	127.0.6533.107	mobile	iOS	16.7	1
+Chrome	127.0.6533.107	mobile	iOS	18.6	1
+Chrome	127.0.6533.119	desktop	Linux	6.11.0	1
+Chrome	127.0.6533.119	desktop	Linux	6.5.0	1
+Chrome	127.0.6533.119	desktop	Windows	10	1
+Chrome	127.0.6533.120	desktop	Macintosh	Intel 12.7	1
+Chrome	127.0.6533.120	desktop	Macintosh	Intel 13.3	1
+Chrome	127.0.6533.120	desktop	Macintosh	Intel 13.6	1
+Chrome	127.0.6533.120	desktop	Macintosh	Intel 14.2	1
+Chrome	127.0.6533.120	desktop	Macintosh	Intel 14.7	1
+Chrome	127.0.6533.120	desktop	Macintosh	Intel 15.0	1
+Chrome	127.0.6533.120	desktop	Macintosh	Intel 15.1	1
+Chrome	127.0.6533.120	desktop	Macintosh	Intel 15.4	1
+Chrome	127.0.6533.122	desktop	Macintosh	Intel 12.5	1
+Chrome	127.0.6533.138	desktop	Chrome OS	x86_64 15917.78.0	1
+Chrome	127.0.6533.56	mobile	iOS	17.5	1
+Chrome	127.0.6533.64	mobile	Android	11.0.0	1
+Chrome	127.0.6533.64	mobile	Android	12.0.0	1
+Chrome	127.0.6533.64	mobile	Android	8.1.0	1
+Chrome	127.0.6533.65	mobile	Android	13.0.0	1
+Chrome	127.0.6533.65	mobile	Android	15.0.0	1
+Chrome	127.0.6533.72	desktop	Linux	(not set)	1
+Chrome	127.0.6533.72	desktop	Linux	4.18.0	1
+Chrome	127.0.6533.72	desktop	Linux	5.4.0	1
+Chrome	127.0.6533.72	desktop	Linux	6.2.6	1
+Chrome	127.0.6533.72	desktop	Windows	10	1
+Chrome	127.0.6533.73	desktop	Macintosh	Intel 15.3	1
+Chrome	127.0.6533.73	desktop	Macintosh	Intel 15.4	1
+Chrome	127.0.6533.74	desktop	Windows	10	1
+Chrome	127.0.6533.77	mobile	iOS	18.5	1
+Chrome	127.0.6533.77	tablet	iOS	17.7	1
+Chrome	127.0.6533.84	tablet	Android	11.0.0	1
+Chrome	127.0.6533.85	mobile	Android	10.0.0	1
+Chrome	127.0.6533.85	mobile	Android	11.0.0	1
+Chrome	127.0.6533.85	mobile	Android	8.0.0	1
+Chrome	127.0.6533.88	desktop	Linux	6.5.0	1
+Chrome	127.0.6533.88	desktop	Macintosh	Intel 15.5	1
+Chrome	127.0.6533.89	desktop	Macintosh	Intel 12.5	1
+Chrome	127.0.6533.89	desktop	Macintosh	Intel 14.4	1
+Chrome	127.0.6533.89	desktop	Macintosh	Intel 14.7	1
+Chrome	127.0.6533.89	desktop	Macintosh	Intel 15.3	1
+Chrome	127.0.6533.90	desktop	Windows	11	1
+Chrome	127.0.6533.99	desktop	Linux	6.2.0	1
+Chrome	127.0.6533.99	desktop	Windows	10	1
+Chrome	127.0.6533.99	desktop	Windows	11	1
+Chrome	128.0.0.0	desktop	Linux	5.15.0	1
+Chrome	128.0.0.0	desktop	Linux	5.15.62	1
+Chrome	128.0.0.0	desktop	Linux	6.1.110	1
+Chrome	128.0.0.0	desktop	Macintosh	Intel 12.7	1
+Chrome	128.0.0.0	mobile	Android	10	1
+Chrome	128.0.6613.100	mobile	Android	11.0.0	1
+Chrome	128.0.6613.100	mobile	Android	9.0.0	1
+Chrome	128.0.6613.113	desktop	Linux	6.11.0	1
+Chrome	128.0.6613.113	desktop	Macintosh	Intel 15.3	1
+Chrome	128.0.6613.113	desktop	Windows	11	1
+Chrome	128.0.6613.114	desktop	Macintosh	Intel 10.15	1
+Chrome	128.0.6613.114	desktop	Macintosh	Intel 13.0	1
+Chrome	128.0.6613.114	desktop	Macintosh	Intel 13.7	1
+Chrome	128.0.6613.114	desktop	Macintosh	Intel 14.2	1
+Chrome	128.0.6613.114	desktop	Macintosh	Intel 14.3	1
+Chrome	128.0.6613.114	desktop	Macintosh	Intel 14.6	1
+Chrome	128.0.6613.115	desktop	Macintosh	Intel 10.15	1
+Chrome	128.0.6613.115	desktop	Windows	11	1
+Chrome	128.0.6613.119	desktop	Linux	6.11.0	1
+Chrome	128.0.6613.119	desktop	Macintosh	Intel 13.2	1
+Chrome	128.0.6613.119	desktop	Windows	10	1
+Chrome	128.0.6613.120	desktop	Macintosh	Intel 13.2	1
+Chrome	128.0.6613.120	desktop	Macintosh	Intel 14.3	1
+Chrome	128.0.6613.120	desktop	Macintosh	Intel 14.5	1
+Chrome	128.0.6613.120	desktop	Macintosh	Intel 15.0	1
+Chrome	128.0.6613.120	desktop	Macintosh	Intel 15.2	1
+Chrome	128.0.6613.120	desktop	Macintosh	Intel 15.4	1
+Chrome	128.0.6613.1203	desktop	Windows	10	1
+Chrome	128.0.6613.127	mobile	Android	10.0.0	1
+Chrome	128.0.6613.127	mobile	Android	12.0.0	1
+Chrome	128.0.6613.127	mobile	Android	9.0.0	1
+Chrome	128.0.6613.127	tablet	Android	13.0.0	1
+Chrome	128.0.6613.137	desktop	Linux	5.15.0	1
+Chrome	128.0.6613.137	desktop	Linux	5.4.0	1
+Chrome	128.0.6613.137	desktop	Linux	6.11.0	1
+Chrome	128.0.6613.137	desktop	Macintosh	Intel 14.6	1
+Chrome	128.0.6613.137	mobile	Windows	10	1
+Chrome	128.0.6613.138	desktop	Macintosh	Intel 11.7	1
+Chrome	128.0.6613.138	desktop	Macintosh	Intel 13.5	1
+Chrome	128.0.6613.138	desktop	Macintosh	Intel 13.7	1
+Chrome	128.0.6613.138	desktop	Macintosh	Intel 14.2	1
+Chrome	128.0.6613.138	desktop	Macintosh	Intel 14.5	1
+Chrome	128.0.6613.138	desktop	Macintosh	Intel 14.7	1
+Chrome	128.0.6613.138	desktop	Macintosh	Intel 15.1	1
+Chrome	128.0.6613.138	desktop	Macintosh	Intel 15.3	1
+Chrome	128.0.6613.146	mobile	Android	8.1.0	1
+Chrome	128.0.6613.147	mobile	Android	11.0.0	1
+Chrome	128.0.6613.148	mobile	Android	10	1
+Chrome	128.0.6613.148	mobile	Android	12.0.0	1
+Chrome	128.0.6613.162	desktop	Windows	10	1
+Chrome	128.0.6613.163	desktop	Chrome OS	x86_64 15964.59.0	1
+Chrome	128.0.6613.186	desktop	Macintosh	Intel 15.2	1
+Chrome	128.0.6613.36	desktop	Macintosh	Intel 13.0	1
+Chrome	128.0.6613.40	mobile	Android	12.0.0	1
+Chrome	128.0.6613.84	desktop	Linux	5.15.165	1
+Chrome	128.0.6613.84	desktop	Linux	6.11.0	1
+Chrome	128.0.6613.84	desktop	Linux	6.6.36	1
+Chrome	128.0.6613.84	desktop	Macintosh	Intel 15.5	1
+Chrome	128.0.6613.85	desktop	Macintosh	Intel 10.15	1
+Chrome	128.0.6613.85	desktop	Macintosh	Intel 12.6	1
+Chrome	128.0.6613.85	desktop	Macintosh	Intel 13.0	1
+Chrome	128.0.6613.85	desktop	Macintosh	Intel 13.3	1
+Chrome	128.0.6613.85	desktop	Macintosh	Intel 13.5	1
+Chrome	128.0.6613.85	desktop	Macintosh	Intel 13.6	1
+Chrome	128.0.6613.85	desktop	Macintosh	Intel 14.5	1
+Chrome	128.0.6613.85	desktop	Macintosh	Intel 15.0	1
+Chrome	128.0.6613.85	desktop	Macintosh	Intel 15.3	1
+Chrome	128.0.6613.86	desktop	Windows	11	1
+Chrome	128.0.6613.88	mobile	Android	13.0.0	1
+Chrome	128.0.6613.88	mobile	Android	14.0.0	1
+Chrome	128.0.6613.88	mobile	Android	8.1.0	1
+Chrome	128.0.6613.88	tablet	Android	15.0.0	1
+Chrome	128.0.6613.92	mobile	iOS	17.4	1
+Chrome	128.0.6613.92	mobile	iOS	17.6	1
+Chrome	128.0.6613.92	mobile	iOS	18.0	1
+Chrome	128.0.6613.92	mobile	iOS	18.5	1
+Chrome	128.0.6613.98	mobile	iOS	18.0	1
+Chrome	128.0.6613.98	tablet	iOS	17.6	1
+Chrome	128.0.6613.98	tablet	iOS	18.5	1
+Chrome	128.0.6613.99	mobile	Android	8.0.0	1
+Chrome	128.0.6613.99	mobile	Android	9.0.0	1
+Chrome	129.0.0.0	desktop	(not set)	(not set)	1
+Chrome	129.0.0.0	desktop	Linux	6.10.10	1
+Chrome	129.0.0.0	desktop	Linux	6.8.0	1
+Chrome	129.0.0.0	desktop	Macintosh	Intel 12.7	1
+Chrome	129.0.0.0	desktop	Macintosh	Intel 14.3	1
+Chrome	129.0.0.0	desktop	Macintosh	Intel 14.7	1
+Chrome	129.0.0.0	mobile	Android	10	1
+Chrome	129.0.0.0	mobile	Android	13.0.0	1
+Chrome	129.0.6628.3	desktop	Linux	6.8.0	1
+Chrome	129.0.6643.2	desktop	Windows	11	1
+Chrome	129.0.6668.100	desktop	Linux	4.15.0	1
+Chrome	129.0.6668.100	desktop	Linux	6.15.4	1
+Chrome	129.0.6668.100	desktop	Linux	6.2.0	1
+Chrome	129.0.6668.100	desktop	Linux	6.5.0	1
+Chrome	129.0.6668.100	desktop	Linux	6.9.3	1
+Chrome	129.0.6668.100	desktop	Macintosh	Intel 14.2	1
+Chrome	129.0.6668.100	desktop	Macintosh	Intel 15.5	1
+Chrome	129.0.6668.100	mobile	Android	8.1.0	1
+Chrome	129.0.6668.100	mobile	Android	9.0.0	1
+Chrome	129.0.6668.100	tablet	Android	8.1.0	1
+Chrome	129.0.6668.101	desktop	Macintosh	Intel 12.7	1
+Chrome	129.0.6668.101	desktop	Macintosh	Intel 14.0	1
+Chrome	129.0.6668.101	desktop	Macintosh	Intel 14.6	1
+Chrome	129.0.6668.101	mobile	Android	14.0.0	1
+Chrome	129.0.6668.102	mobile	Android	11.0.0	1
+Chrome	129.0.6668.102	mobile	Android	12.0.0	1
+Chrome	129.0.6668.102	mobile	Android	15.0.0	1
+Chrome	129.0.6668.112	desktop	Chrome OS	x86_64 16002.60.0	1
+Chrome	129.0.6668.46	mobile	iOS	17.5	1
+Chrome	129.0.6668.46	mobile	iOS	18.3	1
+Chrome	129.0.6668.46	mobile	iOS	18.5	1
+Chrome	129.0.6668.54	mobile	Android	11.0.0	1
+Chrome	129.0.6668.54	mobile	Android	12.0.0	1
+Chrome	129.0.6668.54	mobile	Android	8.1.0	1
+Chrome	129.0.6668.54	mobile	Android	9.0.0	1
+Chrome	129.0.6668.58	desktop	Linux	5.14.0	1
+Chrome	129.0.6668.58	desktop	Linux	5.4.0	1
+Chrome	129.0.6668.58	desktop	Linux	6.6.32	1
+Chrome	129.0.6668.58	desktop	Linux	6.6.47	1
+Chrome	129.0.6668.58	desktop	Windows	11	1
+Chrome	129.0.6668.59	desktop	Macintosh	Intel 14.4	1
+Chrome	129.0.6668.59	desktop	Macintosh	Intel 14.6	1
+Chrome	129.0.6668.59	desktop	Macintosh	Intel 15.3	1
+Chrome	129.0.6668.60	desktop	Macintosh	Intel 14.5	1
+Chrome	129.0.6668.69	mobile	iOS	17.5	1
+Chrome	129.0.6668.69	mobile	iOS	18.1	1
+Chrome	129.0.6668.70	desktop	Linux	5.10.0	1
+Chrome	129.0.6668.70	desktop	Linux	6.14.6	1
+Chrome	129.0.6668.70	desktop	Macintosh	Intel 13.0	1
+Chrome	129.0.6668.70	desktop	Macintosh	Intel 14.3	1
+Chrome	129.0.6668.70	desktop	Macintosh	Intel 15.5	1
+Chrome	129.0.6668.70	mobile	Android	8.1.0	1
+Chrome	129.0.6668.70	mobile	Android	9.0.0	1
+Chrome	129.0.6668.70	tablet	Android	13.0.0	1
+Chrome	129.0.6668.70	tablet	Android	9.0.0	1
+Chrome	129.0.6668.71	desktop	Macintosh	Intel 10.15	1
+Chrome	129.0.6668.71	desktop	Macintosh	Intel 13.6	1
+Chrome	129.0.6668.71	desktop	Macintosh	Intel 14.4	1
+Chrome	129.0.6668.71	desktop	Macintosh	Intel 15.5	1
+Chrome	129.0.6668.71	mobile	Android	13.0.0	1
+Chrome	129.0.6668.71	mobile	Android	14.0.0	1
+Chrome	129.0.6668.72	desktop	Windows	10	1
+Chrome	129.0.6668.81	desktop	Windows	10	1
+Chrome	129.0.6668.81	mobile	Android	9	1
+Chrome	129.0.6668.81	mobile	Android	9.0.0	1
+Chrome	129.0.6668.81	tablet	Android	14.0.0	1
+Chrome	129.0.6668.82	mobile	Android	11.0.0	1
+Chrome	129.0.6668.82	mobile	Android	13.0.0	1
+Chrome	129.0.6668.82	mobile	Android	14.0.0	1
+Chrome	129.0.6668.89	desktop	Linux	6.11.0	1
+Chrome	129.0.6668.89	desktop	Linux	6.5.0	1
+Chrome	129.0.6668.89	desktop	Linux	6.9.3	1
+Chrome	129.0.6668.89	desktop	Macintosh	Intel 15.5	1
+Chrome	129.0.6668.90	desktop	Macintosh	Intel 14.0	1
+Chrome	129.0.6668.90	desktop	Macintosh	Intel 14.4	1
+Chrome	129.0.6668.90	desktop	Macintosh	Intel 14.5	1
+Chrome	129.0.6668.90	desktop	Macintosh	Intel 15.0	1
+Chrome	129.0.6668.90	mobile	Android	11.0	1
+Chrome	129.0.6668.90	mobile	Android	6.0	1
+Chrome	129.0.6668.90	mobile	Windows	10	1
+Chrome	129.0.6668.91	desktop	Macintosh	Intel 12.5	1
+Chrome	129.0.6668.91	desktop	Macintosh	Intel 14.4	1
+Chrome	129.0.6668.91	desktop	Macintosh	Intel 14.5	1
+Chrome	129.0.6668.91	desktop	Macintosh	Intel 15.0	1
+Chrome	130	mobile	iOS	(not set)	1
+Chrome	130.0.0.0	desktop	Linux	6.1.0	1
+Chrome	130.0.0.0	desktop	Linux	6.1.90	1
+Chrome	130.0.0.0	desktop	Linux	6.11.0	1
+Chrome	130.0.0.0	desktop	Linux	6.11.9	1
+Chrome	130.0.0.0	desktop	Linux	6.12.1	1
+Chrome	130.0.0.0	desktop	Linux	6.12.10	1
+Chrome	130.0.0.0	desktop	Linux	6.14.11	1
+Chrome	130.0.0.0	desktop	Linux	6.15.1	1
+Chrome	130.0.0.0	desktop	Macintosh	Intel 12.0	1
+Chrome	130.0.0.0	desktop	Macintosh	Intel 13.2	1
+Chrome	130.0.0.0	desktop	Macintosh	Intel 15.3	1
+Chrome	130.0.0.0	desktop	Windows	7	1
+Chrome	130.0.0.0	mobile	Android	13.0.0	1
+Chrome	130.0.0.0	mobile	Android	14.0.0	1
+Chrome	130.0.0.0	mobile	Tizen	6.6.60	1
+Chrome	130.0.6723.1012	mobile	Android	14.0.0	1
+Chrome	130.0.6723.102	tablet	Android	13.0.0	1
+Chrome	130.0.6723.103	mobile	Android	10.0.0	1
+Chrome	130.0.6723.103	mobile	Android	12.0.0	1
+Chrome	130.0.6723.107	mobile	Android	11	1
+Chrome	130.0.6723.107	mobile	Android	14	1
+Chrome	130.0.6723.116	desktop	Linux	5.8.0	1
+Chrome	130.0.6723.116	desktop	Macintosh	Intel 12.5	1
+Chrome	130.0.6723.116	desktop	Macintosh	Intel 13.6	1
+Chrome	130.0.6723.116	mobile	Tizen	10	1
+Chrome	130.0.6723.117	desktop	Macintosh	Intel 12.6	1
+Chrome	130.0.6723.117	desktop	Macintosh	Intel 15.0	1
+Chrome	130.0.6723.119	desktop	Macintosh	Intel 14.5	1
+Chrome	130.0.6723.119	desktop	Macintosh	Intel 15.5	1
+Chrome	130.0.6723.129	desktop	Linux	6.8.0	1
+Chrome	130.0.6723.1823	mobile	Android	10.0.0	1
+Chrome	130.0.6723.1823	mobile	Android	12.0.0	1
+Chrome	130.0.6723.191	desktop	Windows	11	1
+Chrome	130.0.6723.204	mobile	iOS	18.5	1
+Chrome	130.0.6723.37	mobile	iOS	18.1	1
+Chrome	130.0.6723.37	mobile	iOS	18.2	1
+Chrome	130.0.6723.37	mobile	iOS	18.4	1
+Chrome	130.0.6723.37	tablet	iOS	18.5	1
+Chrome	130.0.6723.40	mobile	Android	14.0.0	1
+Chrome	130.0.6723.40	mobile	Android	15.0.0	1
+Chrome	130.0.6723.58	mobile	Android	8.1.0	1
+Chrome	130.0.6723.59	desktop	Macintosh	Intel 12.6	1
+Chrome	130.0.6723.59	desktop	Macintosh	Intel 15.0	1
+Chrome	130.0.6723.59	desktop	Macintosh	Intel 15.1	1
+Chrome	130.0.6723.59	desktop	Macintosh	Intel 15.4	1
+Chrome	130.0.6723.60	desktop	Macintosh	Intel 15.1	1
+Chrome	130.0.6723.60	desktop	Windows	10	1
+Chrome	130.0.6723.69	desktop	Linux	5.11.0	1
+Chrome	130.0.6723.69	desktop	Linux	5.14.18	1
+Chrome	130.0.6723.69	desktop	Linux	6.14.5	1
+Chrome	130.0.6723.69	desktop	Macintosh	Intel 14.7	1
+Chrome	130.0.6723.69	desktop	Windows	10	1
+Chrome	130.0.6723.70	desktop	Macintosh	Intel 14.3	1
+Chrome	130.0.6723.70	desktop	Macintosh	Intel 14.5	1
+Chrome	130.0.6723.70	desktop	Macintosh	Intel 15.4	1
+Chrome	130.0.6723.71	desktop	Macintosh	Intel 15.3	1
+Chrome	130.0.6723.73	mobile	Android	14	1
+Chrome	130.0.6723.73	mobile	Android	8.1.0	1
+Chrome	130.0.6723.74	mobile	Android	11.0.0	1
+Chrome	130.0.6723.78	tablet	iOS	18.4	1
+Chrome	130.0.6723.86	mobile	Android	8.0.0	1
+Chrome	130.0.6723.86	mobile	Android	8.1.0	1
+Chrome	130.0.6723.86	mobile	Android	9.0.0	1
+Chrome	130.0.6723.86	smart tv	Android	10.0.0	1
+Chrome	130.0.6723.87	mobile	Android	9.0.0	1
+Chrome	130.0.6723.90	mobile	iOS	16.6	1
+Chrome	130.0.6723.90	mobile	iOS	18.3	1
+Chrome	130.0.6723.91	desktop	Linux	6.2.0	1
+Chrome	130.0.6723.91	mobile	Android	12.0.0	1
+Chrome	130.0.6723.91	tablet	Android	15.0.0	1
+Chrome	130.0.6723.92	desktop	Macintosh	Intel 11.6	1
+Chrome	130.0.6723.92	desktop	Macintosh	Intel 12.6	1
+Chrome	130.0.6723.92	desktop	Macintosh	Intel 13.5	1
+Chrome	130.0.6723.92	desktop	Macintosh	Intel 14.1	1
+Chrome	130.0.6723.92	desktop	Macintosh	Intel 15.1	1
+Chrome	130.0.6723.92	desktop	Macintosh	Intel 15.2	1
+Chrome	130.0.6723.93	desktop	Macintosh	Intel 13.1	1
+Chrome	130.0.6723.96	desktop	Windows	11	1
+Chrome	131	desktop	Windows	10	1
+Chrome	131.0.0.0	desktop	Linux	6.1.0	1
+Chrome	131.0.0.0	desktop	Linux	6.10.11	1
+Chrome	131.0.0.0	desktop	Linux	6.8.0	1
+Chrome	131.0.0.0	desktop	Macintosh	 13.0	1
+Chrome	131.0.0.0	desktop	Macintosh	Intel 14.6	1
+Chrome	131.0.0.0	mobile	Android	13	1
+Chrome	131.0.0.0	mobile	Android	8.0.0	1
+Chrome	131.0.0.0	mobile	Android	9.0.0	1
+Chrome	131.0.6541.80	tablet	Android	14	1
+Chrome	131.0.6778.103	mobile	iOS	17.6.1	1
+Chrome	131.0.6778.104	mobile	Android	15	1
+Chrome	131.0.6778.104	mobile	Android	8.0.0	1
+Chrome	131.0.6778.104	mobile	Android	8.1.0	1
+Chrome	131.0.6778.104	mobile	Android	9.0.0	1
+Chrome	131.0.6778.105	mobile	Android	13	1
+Chrome	131.0.6778.105	mobile	Android	13.0.0	1
+Chrome	131.0.6778.105	mobile	Android	14.0.0	1
+Chrome	131.0.6778.105	tablet	Android	12.0.0	1
+Chrome	131.0.6778.108	desktop	Linux	5.4.0	1
+Chrome	131.0.6778.108	desktop	Linux	6.11.10	1
+Chrome	131.0.6778.108	desktop	Linux	6.11.2	1
+Chrome	131.0.6778.108	desktop	Linux	6.14.0	1
+Chrome	131.0.6778.108	desktop	Linux	6.15.4	1
+Chrome	131.0.6778.108	desktop	Linux	6.15.5	1
+Chrome	131.0.6778.108	desktop	Linux	6.2.0	1
+Chrome	131.0.6778.108	desktop	Linux	6.6.0	1
+Chrome	131.0.6778.108	desktop	Macintosh	Intel 15.1	1
+Chrome	131.0.6778.109	desktop	Macintosh	Intel 12.3	1
+Chrome	131.0.6778.109	desktop	Macintosh	Intel 13.2	1
+Chrome	131.0.6778.109	desktop	Macintosh	Intel 14.4	1
+Chrome	131.0.6778.109	desktop	Macintosh	Intel 15.3	1
+Chrome	131.0.6778.109	desktop	Macintosh	Intel 15.4	1
+Chrome	131.0.6778.110	desktop	Windows	10	1
+Chrome	131.0.6778.134	mobile	iOS	17.1.1	1
+Chrome	131.0.6778.134	mobile	iOS	17.7.0	1
+Chrome	131.0.6778.134	mobile	iOS	18.2.1	1
+Chrome	131.0.6778.136	mobile	Android	12.0.0	1
+Chrome	131.0.6778.136	mobile	Android	13	1
+Chrome	131.0.6778.136	mobile	Android	13.0.0	1
+Chrome	131.0.6778.136	mobile	Android	15.0.0	1
+Chrome	131.0.6778.136	mobile	Android	9.0.0	1
+Chrome	131.0.6778.139	desktop	Linux	5.14.0	1
+Chrome	131.0.6778.139	desktop	Linux	6.1.0	1
+Chrome	131.0.6778.139	desktop	Windows	11	1
+Chrome	131.0.6778.14	mobile	Android	13.0.0	1
+Chrome	131.0.6778.14	mobile	Android	14.0.0	1
+Chrome	131.0.6778.140	desktop	Macintosh	Intel 12.2	1
+Chrome	131.0.6778.140	desktop	Macintosh	Intel 12.7	1
+Chrome	131.0.6778.140	desktop	Macintosh	Intel 13.4	1
+Chrome	131.0.6778.140	desktop	Macintosh	Intel 13.5	1
+Chrome	131.0.6778.140	desktop	Macintosh	Intel 14.4	1
+Chrome	131.0.6778.140	desktop	Macintosh	Intel 14.5	1
+Chrome	131.0.6778.140	desktop	Macintosh	Intel 15.2	1
+Chrome	131.0.6778.141	desktop	Windows	10	1
+Chrome	131.0.6778.154	mobile	iOS	16.2.0	1
+Chrome	131.0.6778.154	mobile	iOS	16.3.1	1
+Chrome	131.0.6778.154	mobile	iOS	17.5.1	1
+Chrome	131.0.6778.154	mobile	iOS	17.6.1	1
+Chrome	131.0.6778.154	mobile	iOS	18.1.1	1
+Chrome	131.0.6778.154	mobile	iOS	18.2.1	1
+Chrome	131.0.6778.154	mobile	iOS	18.3.1	1
+Chrome	131.0.6778.154	mobile	iOS	19.0.0	1
+Chrome	131.0.6778.154	tablet	iOS	18.5.0	1
+Chrome	131.0.6778.201	mobile	Android	11.0.0	1
+Chrome	131.0.6778.202	mobile	Android	11.0.0	1
+Chrome	131.0.6778.204	desktop	Linux	5.10.224	1
+Chrome	131.0.6778.204	desktop	Linux	6.1.0	1
+Chrome	131.0.6778.204	desktop	Linux	6.11.9	1
+Chrome	131.0.6778.204	desktop	Linux	6.12.6	1
+Chrome	131.0.6778.204	desktop	Linux	6.13.6	1
+Chrome	131.0.6778.204	desktop	Linux	6.14.0	1
+Chrome	131.0.6778.204	desktop	Linux	6.15.2	1
+Chrome	131.0.6778.204	desktop	Linux	6.9.3	1
+Chrome	131.0.6778.205	desktop	Linux	(not set)	1
+Chrome	131.0.6778.205	desktop	Macintosh	 10.15	1
+Chrome	131.0.6778.205	desktop	Macintosh	Intel 10.15	1
+Chrome	131.0.6778.205	desktop	Macintosh	Intel 13.1	1
+Chrome	131.0.6778.205	desktop	Macintosh	Intel 13.7	1
+Chrome	131.0.6778.205	desktop	Macintosh	Intel 14.0	1
+Chrome	131.0.6778.205	desktop	Macintosh	Intel 14.1	1
+Chrome	131.0.6778.205	desktop	Macintosh	Intel 14.7	1
+Chrome	131.0.6778.205	desktop	Macintosh	Intel 26.0	1
+Chrome	131.0.6778.205	mobile	Android	11.0	1
+Chrome	131.0.6778.205	mobile	Android	6.0	1
+Chrome	131.0.6778.205	mobile	Macintosh	 10.15	1
+Chrome	131.0.6778.206	desktop	Macintosh	Intel 12.7	1
+Chrome	131.0.6778.206	desktop	Macintosh	Intel 14.4	1
+Chrome	131.0.6778.206	desktop	Windows	11	1
+Chrome	131.0.6778.210	desktop	Windows	10	1
+Chrome	131.0.6778.22	mobile	Android	14.0.0	1
+Chrome	131.0.6778.241	desktop	Chrome OS	x86_64 16063.68.0	1
+Chrome	131.0.6778.260	mobile	Android	8.0.0	1
+Chrome	131.0.6778.260	tablet	Android	12.0.0	1
+Chrome	131.0.6778.260	tablet	Android	13.0.0	1
+Chrome	131.0.6778.260	tablet	Android	15	1
+Chrome	131.0.6778.261	mobile	Android	10.0.0	1
+Chrome	131.0.6778.264	desktop	Linux	5.14.0	1
+Chrome	131.0.6778.264	desktop	Linux	5.4.0	1
+Chrome	131.0.6778.264	desktop	Linux	6.1.0	1
+Chrome	131.0.6778.264	desktop	Linux	6.14.0	1
+Chrome	131.0.6778.264	desktop	Linux	6.15.3	1
+Chrome	131.0.6778.264	desktop	Macintosh	Intel 12.0	1
+Chrome	131.0.6778.265	desktop	Macintosh	Intel 12.2	1
+Chrome	131.0.6778.265	desktop	Macintosh	Intel 13.2	1
+Chrome	131.0.6778.265	desktop	Macintosh	Intel 13.7	1
+Chrome	131.0.6778.265	desktop	Macintosh	Intel 14.4	1
+Chrome	131.0.6778.265	desktop	Macintosh	Intel 15.0	1
+Chrome	131.0.6778.265	desktop	Macintosh	Intel 15.1	1
+Chrome	131.0.6778.265	mobile	Android	11.0	1
+Chrome	131.0.6778.266	desktop	Macintosh	Intel 12.7	1
+Chrome	131.0.6778.266	desktop	Macintosh	Intel 13.7	1
+Chrome	131.0.6778.266	desktop	Macintosh	Intel 14.1	1
+Chrome	131.0.6778.266	desktop	Macintosh	Intel 14.5	1
+Chrome	131.0.6778.266	desktop	Macintosh	Intel 14.6	1
+Chrome	131.0.6778.266	desktop	Macintosh	Intel 15.1	1
+Chrome	131.0.6778.267	desktop	Macintosh	Intel 15.5	1
+Chrome	131.0.6778.31	mobile	iOS	18.5.0	1
+Chrome	131.0.6778.31	tablet	iOS	16.6.1	1
+Chrome	131.0.6778.33	desktop	Windows	10	1
+Chrome	131.0.6778.39	mobile	Android	15.0.0	1
+Chrome	131.0.6778.39	tablet	Android	10.0.0	1
+Chrome	131.0.6778.40	mobile	Android	14.0.0	1
+Chrome	131.0.6778.40	tablet	Android	14.0.0	1
+Chrome	131.0.6778.69	desktop	Linux	4.15.0	1
+Chrome	131.0.6778.69	desktop	Linux	5.14.0	1
+Chrome	131.0.6778.69	desktop	Linux	6.1.0	1
+Chrome	131.0.6778.69	desktop	Windows	10	1
+Chrome	131.0.6778.69	desktop	Windows	11	1
+Chrome	131.0.6778.70	desktop	Macintosh	Intel 14.1	1
+Chrome	131.0.6778.70	desktop	Macintosh	Intel 14.2	1
+Chrome	131.0.6778.70	desktop	Macintosh	Intel 14.3	1
+Chrome	131.0.6778.70	desktop	Macintosh	Intel 14.5	1
+Chrome	131.0.6778.70	desktop	Macintosh	Intel 15.1	1
+Chrome	131.0.6778.70	desktop	Macintosh	Intel 15.4	1
+Chrome	131.0.6778.71	desktop	Windows	10	1
+Chrome	131.0.6778.71	desktop	Windows	11	1
+Chrome	131.0.6778.73	mobile	iOS	18.3.1	1
+Chrome	131.0.6778.73	mobile	iOS	18.4.1	1
+Chrome	131.0.6778.81	mobile	Android	14	1
+Chrome	131.0.6778.81	mobile	Android	9	1
+Chrome	131.0.6778.81	tablet	Android	10.0.0	1
+Chrome	131.0.6778.81	tablet	Android	14.0.0	1
+Chrome	131.0.6778.81	tablet	Android	9.0.0	1
+Chrome	131.0.6778.82	mobile	Android	11.0.0	1
+Chrome	131.0.6778.82	mobile	Android	13.0.0	1
+Chrome	131.0.6778.82	mobile	Android	14.0.0	1
+Chrome	131.0.6778.82	mobile	Android	15.0.0	1
+Chrome	131.0.6778.82	mobile	Android	9.0.0	1
+Chrome	131.0.6778.82	tablet	Android	11.0.0	1
+Chrome	131.0.6778.85	desktop	Linux	5.10.60	1
+Chrome	131.0.6778.85	desktop	Linux	6.14.0	1
+Chrome	131.0.6778.85	desktop	Linux	6.14.5	1
+Chrome	131.0.6778.85	desktop	Macintosh	Intel 15.5	1
+Chrome	131.0.6778.85	mobile	Android	11.0	1
+Chrome	131.0.6778.86	desktop	Macintosh	Intel 11.4	1
+Chrome	131.0.6778.86	desktop	Macintosh	Intel 11.5	1
+Chrome	131.0.6778.86	desktop	Macintosh	Intel 13.2	1
+Chrome	131.0.6778.86	desktop	Macintosh	Intel 13.4	1
+Chrome	131.0.6778.86	desktop	Macintosh	Intel 14.2	1
+Chrome	131.0.6778.86	desktop	Macintosh	Intel 14.6	1
+Chrome	131.0.6778.86	desktop	Macintosh	Intel 15.1	1
+Chrome	131.0.6778.86	desktop	Macintosh	Intel 15.4	1
+Chrome	131.0.6778.87	desktop	Macintosh	Intel 15.5	1
+Chrome	131.6778.260	mobile	Android	10.0.0	1
+Chrome	132	desktop	Linux	6.5.0	1
+Chrome	132.0.0.0	desktop	Linux	6.1.124	1
+Chrome	132.0.0.0	desktop	Linux	6.11.2	1
+Chrome	132.0.0.0	desktop	Linux	6.8.0	1
+Chrome	132.0.0.0	desktop	Macintosh	Intel 10.15	1
+Chrome	132.0.0.0	desktop	Macintosh	Intel 15.2	1
+Chrome	132.0.0.0	desktop	Macintosh	Intel 15.3	1
+Chrome	132.0.0.0	desktop	Macintosh	Intel 15.4	1
+Chrome	132.0.0.0	mobile	Android	16.0.0	1
+Chrome	132.0.0.0	mobile	Android	9.0.0	1
+Chrome	132.0.6478.261	desktop	Windows	10	1
+Chrome	132.0.6779.0	desktop	Linux	6.14.9	1
+Chrome	132.0.6834.100	mobile	iOS	16.6.0	1
+Chrome	132.0.6834.100	mobile	iOS	17.6.1	1
+Chrome	132.0.6834.100	mobile	iOS	18.1.1	1
+Chrome	132.0.6834.100	mobile	iOS	18.2.0	1
+Chrome	132.0.6834.100	mobile	iOS	18.3.1	1
+Chrome	132.0.6834.100	tablet	iOS	17.7.6	1
+Chrome	132.0.6834.100	tablet	iOS	17.7.8	1
+Chrome	132.0.6834.110	desktop	Linux	6.11.2	1
+Chrome	132.0.6834.110	desktop	Linux	6.13.7	1
+Chrome	132.0.6834.110	desktop	Linux	6.14.4	1
+Chrome	132.0.6834.110	desktop	Linux	6.2.0	1
+Chrome	132.0.6834.110	desktop	Macintosh	Intel 10.15	1
+Chrome	132.0.6834.110	desktop	Macintosh	Intel 15.5	1
+Chrome	132.0.6834.111	desktop	Macintosh	Intel 10.15	1
+Chrome	132.0.6834.111	desktop	Macintosh	Intel 14.5	1
+Chrome	132.0.6834.111	desktop	Macintosh	Intel 14.6	1
+Chrome	132.0.6834.111	desktop	Macintosh	Intel 14.7	1
+Chrome	132.0.6834.111	desktop	Macintosh	Intel 15.2	1
+Chrome	132.0.6834.111	desktop	Macintosh	Intel 15.3	1
+Chrome	132.0.6834.112	desktop	Macintosh	Intel 12.4	1
+Chrome	132.0.6834.112	desktop	Macintosh	Intel 13.5	1
+Chrome	132.0.6834.112	desktop	Macintosh	Intel 14.5	1
+Chrome	132.0.6834.112	desktop	Macintosh	Intel 14.6	1
+Chrome	132.0.6834.112	desktop	Windows	10	1
+Chrome	132.0.6834.112	desktop	Windows	11	1
+Chrome	132.0.6834.112	mobile	Macintosh	 12.4	1
+Chrome	132.0.6834.122	mobile	Android	11.0.0	1
+Chrome	132.0.6834.122	tablet	Android	12.0.0	1
+Chrome	132.0.6834.122	tablet	Android	13.0.0	1
+Chrome	132.0.6834.123	mobile	Android	9.0.0	1
+Chrome	132.0.6834.14	mobile	Android	11.0.0	1
+Chrome	132.0.6834.14	mobile	Android	14.0.0	1
+Chrome	132.0.6834.159	desktop	Linux	4.15.0	1
+Chrome	132.0.6834.159	desktop	Linux	6.14.5	1
+Chrome	132.0.6834.159	desktop	Linux	6.2.0	1
+Chrome	132.0.6834.159	desktop	Linux	6.7.10	1
+Chrome	132.0.6834.159	desktop	Linux	6.8.9	1
+Chrome	132.0.6834.159	desktop	Linux	6.9.3	1
+Chrome	132.0.6834.159	desktop	Macintosh	Intel 14.6	1
+Chrome	132.0.6834.159	desktop	Windows	11	1
+Chrome	132.0.6834.160	desktop	Macintosh	Intel 13.0	1
+Chrome	132.0.6834.160	desktop	Macintosh	Intel 13.2	1
+Chrome	132.0.6834.160	desktop	Macintosh	Intel 13.3	1
+Chrome	132.0.6834.160	desktop	Macintosh	Intel 14.1	1
+Chrome	132.0.6834.160	desktop	Macintosh	Intel 14.2	1
+Chrome	132.0.6834.160	desktop	Macintosh	Intel 14.5	1
+Chrome	132.0.6834.162	desktop	Macintosh	Intel 12.5	1
+Chrome	132.0.6834.162	desktop	Macintosh	Intel 13.0	1
+Chrome	132.0.6834.162	desktop	Macintosh	Intel 15.3	1
+Chrome	132.0.6834.163	mobile	Android	14	1
+Chrome	132.0.6834.164	mobile	Android	12.0.0	1
+Chrome	132.0.6834.165	mobile	Android	12.0.0	1
+Chrome	132.0.6834.165	mobile	Android	13.0.0	1
+Chrome	132.0.6834.165	mobile	Android	8.1.0	1
+Chrome	132.0.6834.165	mobile	Android	9.0.0	1
+Chrome	132.0.6834.165	tablet	Android	13.0.0	1
+Chrome	132.0.6834.166	mobile	Android	14.0.0	1
+Chrome	132.0.6834.190	desktop	Chrome OS	x86_64 16093.86.0	1
+Chrome	132.0.6834.196	mobile	Windows	11	1
+Chrome	132.0.6834.2037	mobile	Android	11.0.0	1
+Chrome	132.0.6834.2037	mobile	Android	13	1
+Chrome	132.0.6834.2037	mobile	Android	13.0.0	1
+Chrome	132.0.6834.2037	mobile	Android	14	1
+Chrome	132.0.6834.210	desktop	Linux	5.15.0	1
+Chrome	132.0.6834.211	mobile	Android	11.0.0	1
+Chrome	132.0.6834.2144	mobile	Android	11	1
+Chrome	132.0.6834.2144	mobile	Android	14	1
+Chrome	132.0.6834.345	tablet	iOS	17.6.1	1
+Chrome	132.0.6834.419	mobile	Android	11.0.0	1
+Chrome	132.0.6834.419	mobile	Android	14	1
+Chrome	132.0.6834.497	mobile	iOS	16.5.1	1
+Chrome	132.0.6834.577	mobile	Android	10.0.0	1
+Chrome	132.0.6834.578	mobile	Android	14.0.0	1
+Chrome	132.0.6834.705	mobile	Android	11.0.0	1
+Chrome	132.0.6834.705	mobile	Android	15.0.0	1
+Chrome	132.0.6834.760	mobile	Android	11.0.0	1
+Chrome	132.0.6834.78	mobile	iOS	17.5.1	1
+Chrome	132.0.6834.78	mobile	iOS	18.1.1	1
+Chrome	132.0.6834.78	mobile	iOS	18.2.1	1
+Chrome	132.0.6834.79	mobile	Android	8.1.0	1
+Chrome	132.0.6834.79	mobile	Android	9.0.0	1
+Chrome	132.0.6834.791	mobile	Android	11.0.0	1
+Chrome	132.0.6834.80	mobile	Android	12.0.0	1
+Chrome	132.0.6834.80	mobile	Android	14.0.0	1
+Chrome	132.0.6834.80	mobile	Android	15.0.0	1
+Chrome	132.0.6834.83	desktop	Linux	6.11.11	1
+Chrome	132.0.6834.83	desktop	Linux	6.11.2	1
+Chrome	132.0.6834.83	desktop	Linux	6.12.25	1
+Chrome	132.0.6834.83	desktop	Linux	6.12.9	1
+Chrome	132.0.6834.83	desktop	Linux	6.5.0	1
+Chrome	132.0.6834.83	desktop	Linux	6.5.12	1
+Chrome	132.0.6834.83	desktop	Linux	6.6.65	1
+Chrome	132.0.6834.83	desktop	Linux	6.9.3	1
+Chrome	132.0.6834.83	desktop	Macintosh	Intel 13.4	1
+Chrome	132.0.6834.84	desktop	Macintosh	Intel 13.3	1
+Chrome	132.0.6834.84	desktop	Macintosh	Intel 13.6	1
+Chrome	132.0.6834.84	desktop	Macintosh	Intel 13.7	1
+Chrome	132.0.6834.84	desktop	Macintosh	Intel 15.1	1
+Chrome	132.0.6834.84	mobile	Android	12.0.0	1
+Chrome	132.0.6834.84	mobile	Macintosh	 14.6	1
+Chrome	133	desktop	Chrome OS	x86_64 14541.0.0	1
+Chrome	133	desktop	Linux	6.5.0	1
+Chrome	133	mobile	Android	13.0.0	1
+Chrome	133	tablet	Android	13.0.0	1
+Chrome	133.0.0.0	desktop	Linux	5.15.19	1
+Chrome	133.0.0.0	desktop	Linux	6.1.0	1
+Chrome	133.0.0.0	desktop	Linux	6.12.25	1
+Chrome	133.0.0.0	desktop	Linux	6.13.1	1
+Chrome	133.0.0.0	desktop	Linux	6.6.87	1
+Chrome	133.0.0.0	desktop	Linux	6.8.0	1
+Chrome	133.0.0.0	desktop	Macintosh	Intel 13.3	1
+Chrome	133.0.0.0	desktop	Macintosh	Intel 14.0	1
+Chrome	133.0.0.0	desktop	Macintosh	Intel 14.6	1
+Chrome	133.0.0.0	desktop	Macintosh	Intel 15.2	1
+Chrome	133.0.0.0	desktop	Macintosh	Intel 16.0	1
+Chrome	133.0.0.0	mobile	Android	12.0.0	1
+Chrome	133.0.0.0	mobile	Android	13.0.0	1
+Chrome	133.0.0.0	mobile	Android	15.0.0	1
+Chrome	133.0.0.0	mobile	Android	6.0	1
+Chrome	133.0.6779.70	desktop	Windows	8	1
+Chrome	133.0.6848.2	mobile	Android	11.0.0	1
+Chrome	133.0.6848.2	mobile	Android	15.0.0	1
+Chrome	133.0.6905.0	desktop	Windows	11	1
+Chrome	133.0.6922.0	desktop	Macintosh	Intel 12.2	1
+Chrome	133.0.6943.100	desktop	Macintosh	Intel 15.0	1
+Chrome	133.0.6943.100	desktop	Macintosh	Intel 15.3	1
+Chrome	133.0.6943.100	desktop	Windows	11	1
+Chrome	133.0.6943.117	tablet	Android	14.0.0	1
+Chrome	133.0.6943.120	mobile	iOS	16.7.7	1
+Chrome	133.0.6943.120	mobile	iOS	18.2.0	1
+Chrome	133.0.6943.120	mobile	iOS	18.3.0	1
+Chrome	133.0.6943.120	mobile	iOS	18.3.1	1
+Chrome	133.0.6943.120	mobile	iOS	18.6.0	1
+Chrome	133.0.6943.120	tablet	iOS	18.3.2	1
+Chrome	133.0.6943.121	mobile	Android	12	1
+Chrome	133.0.6943.121	mobile	Android	8.0.0	1
+Chrome	133.0.6943.121	mobile	Android	9	1
+Chrome	133.0.6943.122	mobile	Android	10.0.0	1
+Chrome	133.0.6943.122	mobile	Android	11.0.0	1
+Chrome	133.0.6943.122	mobile	Android	12.0.0	1
+Chrome	133.0.6943.122	mobile	Android	8.1.0	1
+Chrome	133.0.6943.126	desktop	Linux	5.14.0	1
+Chrome	133.0.6943.126	desktop	Linux	6.9.3	1
+Chrome	133.0.6943.126	desktop	Macintosh	Intel 14.6	1
+Chrome	133.0.6943.126	desktop	Macintosh	Intel 15.0	1
+Chrome	133.0.6943.127	desktop	Macintosh	Intel 10.15	1
+Chrome	133.0.6943.127	desktop	Macintosh	Intel 11.3	1
+Chrome	133.0.6943.127	desktop	Macintosh	Intel 11.7	1
+Chrome	133.0.6943.127	desktop	Macintosh	Intel 12.3	1
+Chrome	133.0.6943.127	desktop	Macintosh	Intel 13.0	1
+Chrome	133.0.6943.127	desktop	Macintosh	Intel 14.1	1
+Chrome	133.0.6943.127	desktop	Macintosh	Intel 14.5	1
+Chrome	133.0.6943.127	mobile	Android	11.0	1
+Chrome	133.0.6943.128	desktop	Macintosh	Intel 15.0	1
+Chrome	133.0.6943.128	desktop	Macintosh	Intel 15.2	1
+Chrome	133.0.6943.128	desktop	Macintosh	Intel 15.3	1
+Chrome	133.0.6943.137	mobile	Android	13	1
+Chrome	133.0.6943.137	mobile	Android	14	1
+Chrome	133.0.6943.137	mobile	Android	16	1
+Chrome	133.0.6943.138	mobile	Android	9.0.0	1
+Chrome	133.0.6943.138	tablet	Android	11.0.0	1
+Chrome	133.0.6943.141	desktop	Linux	5.10.60	1
+Chrome	133.0.6943.141	desktop	Linux	5.14.0	1
+Chrome	133.0.6943.141	desktop	Linux	5.4.0	1
+Chrome	133.0.6943.141	desktop	Linux	6.12.16	1
+Chrome	133.0.6943.141	desktop	Linux	6.15.2	1
+Chrome	133.0.6943.141	desktop	Linux	6.15.4	1
+Chrome	133.0.6943.141	desktop	Linux	6.15.6	1
+Chrome	133.0.6943.141	desktop	Linux	6.2.0	1
+Chrome	133.0.6943.141	desktop	Linux	6.5.0	1
+Chrome	133.0.6943.141	desktop	Macintosh	 10.15	1
+Chrome	133.0.6943.141	desktop	Macintosh	Intel 10.15	1
+Chrome	133.0.6943.141	desktop	Macintosh	Intel 12.7	1
+Chrome	133.0.6943.141	desktop	Macintosh	Intel 14.7	1
+Chrome	133.0.6943.141	desktop	Macintosh	Intel 15.3	1
+Chrome	133.0.6943.142	desktop	Macintosh	Intel 11.7	1
+Chrome	133.0.6943.142	desktop	Macintosh	Intel 12.5	1
+Chrome	133.0.6943.142	desktop	Macintosh	Intel 12.7	1
+Chrome	133.0.6943.142	desktop	Macintosh	Intel 13.0	1
+Chrome	133.0.6943.142	desktop	Macintosh	Intel 13.6	1
+Chrome	133.0.6943.142	desktop	Macintosh	Intel 13.7	1
+Chrome	133.0.6943.142	desktop	Macintosh	Intel 14.7	1
+Chrome	133.0.6943.142	desktop	Macintosh	Intel 15.2	1
+Chrome	133.0.6943.143	desktop	Macintosh	Intel 13.1	1
+Chrome	133.0.6943.143	desktop	Macintosh	Intel 13.5	1
+Chrome	133.0.6943.143	desktop	Macintosh	Intel 14.3	1
+Chrome	133.0.6943.143	desktop	Macintosh	Intel 14.4	1
+Chrome	133.0.6943.143	desktop	Macintosh	Intel 14.5	1
+Chrome	133.0.6943.143	desktop	Macintosh	Intel 15.0	1
+Chrome	133.0.6943.148	desktop	Windows	11	1
+Chrome	133.0.6943.150	desktop	Macintosh	Intel 15.3	1
+Chrome	133.0.6943.16	desktop	Windows	10	1
+Chrome	133.0.6943.23	desktop	Windows	10	1
+Chrome	133.0.6943.33	mobile	iOS	16.1.0	1
+Chrome	133.0.6943.33	mobile	iOS	18.1.1	1
+Chrome	133.0.6943.33	mobile	iOS	18.2.1	1
+Chrome	133.0.6943.33	mobile	iOS	18.4.1	1
+Chrome	133.0.6943.33	tablet	iOS	18.5.0	1
+Chrome	133.0.6943.39	mobile	Android	11.0.0	1
+Chrome	133.0.6943.39	mobile	Android	12.0.0	1
+Chrome	133.0.6943.39	mobile	Android	13.0.0	1
+Chrome	133.0.6943.49	mobile	Android	8.0.0	1
+Chrome	133.0.6943.49	mobile	Android	9	1
+Chrome	133.0.6943.50	mobile	Android	8.0.0	1
+Chrome	133.0.6943.51	mobile	Android	10.0.0	1
+Chrome	133.0.6943.51	mobile	Android	12.0.0	1
+Chrome	133.0.6943.51	mobile	Android	13.0.0	1
+Chrome	133.0.6943.51	mobile	Android	15.0.0	1
+Chrome	133.0.6943.53	desktop	Linux	5.19.16	1
+Chrome	133.0.6943.53	desktop	Linux	6.12.11	1
+Chrome	133.0.6943.53	desktop	Linux	6.14.6	1
+Chrome	133.0.6943.53	desktop	Linux	6.14.7	1
+Chrome	133.0.6943.53	desktop	Linux	6.9.12	1
+Chrome	133.0.6943.53	desktop	Macintosh	 10.15	1
+Chrome	133.0.6943.53	desktop	Macintosh	Intel 10.15	1
+Chrome	133.0.6943.53	desktop	Macintosh	Intel 14.5	1
+Chrome	133.0.6943.54	desktop	Macintosh	Intel 12.6	1
+Chrome	133.0.6943.54	desktop	Macintosh	Intel 13.3	1
+Chrome	133.0.6943.54	desktop	Macintosh	Intel 13.6	1
+Chrome	133.0.6943.54	desktop	Macintosh	Intel 14.2	1
+Chrome	133.0.6943.54	desktop	Macintosh	Intel 14.5	1
+Chrome	133.0.6943.54	desktop	Macintosh	Intel 14.6	1
+Chrome	133.0.6943.54	desktop	Macintosh	Intel 15.1	1
+Chrome	133.0.6943.54	desktop	Windows	11	1
+Chrome	133.0.6943.55	desktop	Macintosh	Intel 12.7	1
+Chrome	133.0.6943.55	desktop	Macintosh	Intel 15.2	1
+Chrome	133.0.6943.55	desktop	Macintosh	Intel 15.3	1
+Chrome	133.0.6943.84	mobile	iOS	17.4.1	1
+Chrome	133.0.6943.84	mobile	iOS	18.2.0	1
+Chrome	133.0.6943.84	tablet	iOS	18.5.0	1
+Chrome	133.0.6943.89	mobile	Android	10.0.0	1
+Chrome	133.0.6943.89	mobile	Android	11.0.0	1
+Chrome	133.0.6943.89	mobile	Android	8.1.0	1
+Chrome	133.0.6943.89	tablet	Android	15.0.0	1
+Chrome	133.0.6943.98	desktop	Linux	5.10.0	1
+Chrome	133.0.6943.98	desktop	Linux	5.19.0	1
+Chrome	133.0.6943.98	desktop	Linux	6.11.2	1
+Chrome	133.0.6943.98	desktop	Linux	6.12.13	1
+Chrome	133.0.6943.98	desktop	Linux	6.14.0	1
+Chrome	133.0.6943.98	desktop	Macintosh	Intel 12.7	1
+Chrome	133.0.6943.98	desktop	Macintosh	Intel 13.1	1
+Chrome	133.0.6943.98	desktop	Macintosh	Intel 13.3	1
+Chrome	133.0.6943.98	desktop	Macintosh	Intel 13.4	1
+Chrome	133.0.6943.98	desktop	Macintosh	Intel 14.3	1
+Chrome	133.0.6943.98	desktop	Macintosh	Intel 14.4	1
+Chrome	133.0.6943.98	desktop	Macintosh	Intel 14.7	1
+Chrome	133.0.6943.98	desktop	Macintosh	Intel 15.1	1
+Chrome	133.0.6943.99	desktop	Macintosh	Intel 14.4	1
+Chrome	133.0.6943.99	desktop	Macintosh	Intel 14.5	1
+Chrome	133.0.6943.99	desktop	Macintosh	Intel 15.1	1
+Chrome	133.0.6943.99	desktop	Macintosh	Intel 15.2	1
+Chrome	133.0.6943.99	desktop	Macintosh	Intel 15.4	1
+Chrome	134	desktop	Macintosh	Intel 14.2	1
+Chrome	134	desktop	Windows	10	1
+Chrome	134	mobile	iOS	(not set)	1
+Chrome	134.0.0.0	desktop	Chrome OS	x86_64 14541.0.0	1
+Chrome	134.0.0.0	desktop	Linux	6.12.13	1
+Chrome	134.0.0.0	desktop	Linux	6.12.16	1
+Chrome	134.0.0.0	desktop	Linux	6.12.19	1
+Chrome	134.0.0.0	desktop	Linux	6.6.85	1
+Chrome	134.0.0.0	desktop	Linux	6.8.0	1
+Chrome	134.0.0.0	desktop	Macintosh	Intel 14.2	1
+Chrome	134.0.0.0	desktop	Macintosh	Intel 14.4	1
+Chrome	134.0.0.0	desktop	Macintosh	Intel 14.7	1
+Chrome	134.0.0.0	desktop	Macintosh	Intel 15.3	1
+Chrome	134.0.0.0	desktop	Macintosh	Intel 15.4	1
+Chrome	134.0.0.0	desktop	Macintosh	Intel 15.5	1
+Chrome	134.0.0.0	mobile	Android	10.0.0	1
+Chrome	134.0.0.0	mobile	Macintosh	 15.5	1
+Chrome	134.0.0.0	mobile	Macintosh	 15.6	1
+Chrome	134.0.0.0	mobile	Windows	11	1
+Chrome	134.0.29548.179	desktop	Windows	10	1
+Chrome	134.0.5672.92	desktop	Windows	10	1
+Chrome	134.0.6946.0	desktop	Macintosh	Intel 14.4	1
+Chrome	134.0.6954.1	desktop	Windows	10	1
+Chrome	134.0.6958.2	desktop	Windows	10	1
+Chrome	134.0.6982.0	desktop	Windows	10	1
+Chrome	134.0.6988.0	desktop	Windows	10	1
+Chrome	134.0.6998.102	mobile	Android	10.0.0	1
+Chrome	134.0.6998.107	desktop	Chrome OS	x86_64 16181.44.0	1
+Chrome	134.0.6998.107	desktop	Chrome OS	x86_64 16181.44.3	1
+Chrome	134.0.6998.108	mobile	Android	10.0.0	1
+Chrome	134.0.6998.108	mobile	Android	8.0.0	1
+Chrome	134.0.6998.108	mobile	Android	9.0.0	1
+Chrome	134.0.6998.108	tablet	Android	12.0.0	1
+Chrome	134.0.6998.109	mobile	Android	11.0.0	1
+Chrome	134.0.6998.109	mobile	Android	8.1.0	1
+Chrome	134.0.6998.109	tablet	Android	14.0.0	1
+Chrome	134.0.6998.117	desktop	Linux	5.4.0	1
+Chrome	134.0.6998.117	desktop	Linux	6.12.13	1
+Chrome	134.0.6998.117	desktop	Linux	6.5.0	1
+Chrome	134.0.6998.117	desktop	Macintosh	 10.15	1
+Chrome	134.0.6998.117	desktop	Macintosh	Intel 13.4	1
+Chrome	134.0.6998.117	desktop	Macintosh	Intel 14.4	1
+Chrome	134.0.6998.117	desktop	Macintosh	Intel 15.5	1
+Chrome	134.0.6998.117	mobile	Android	10.0.0	1
+Chrome	134.0.6998.118	desktop	Macintosh	Intel 13.0	1
+Chrome	134.0.6998.118	desktop	Macintosh	Intel 14.0	1
+Chrome	134.0.6998.118	desktop	Macintosh	Intel 14.2	1
+Chrome	134.0.6998.118	desktop	Macintosh	Intel 14.3	1
+Chrome	134.0.6998.118	desktop	Macintosh	Intel 15.0	1
+Chrome	134.0.6998.119	desktop	Macintosh	Intel 12.0	1
+Chrome	134.0.6998.119	desktop	Macintosh	Intel 13.6	1
+Chrome	134.0.6998.119	desktop	Macintosh	Intel 14.7	1
+Chrome	134.0.6998.119	desktop	Macintosh	Intel 15.3	1
+Chrome	134.0.6998.119	desktop	Windows	11	1
+Chrome	134.0.6998.13	mobile	Android	12.0.0	1
+Chrome	134.0.6998.135	mobile	Android	11	1
+Chrome	134.0.6998.135	mobile	Android	14	1
+Chrome	134.0.6998.135	tablet	Android	10.0.0	1
+Chrome	134.0.6998.135	tablet	Android	11.0.0	1
+Chrome	134.0.6998.135	tablet	Android	15.0.0	1
+Chrome	134.0.6998.136	mobile	Android	10.0.0	1
+Chrome	134.0.6998.136	mobile	Android	8.0.0	1
+Chrome	134.0.6998.165	desktop	Linux	4.18.0	1
+Chrome	134.0.6998.165	desktop	Linux	4.19.0	1
+Chrome	134.0.6998.165	desktop	Linux	5.13.0	1
+Chrome	134.0.6998.165	desktop	Linux	6.11.4	1
+Chrome	134.0.6998.165	desktop	Linux	6.12.19	1
+Chrome	134.0.6998.165	desktop	Linux	6.12.20	1
+Chrome	134.0.6998.165	desktop	Linux	6.14.2	1
+Chrome	134.0.6998.165	desktop	Linux	6.15.2	1
+Chrome	134.0.6998.165	desktop	Linux	6.2.6	1
+Chrome	134.0.6998.165	desktop	Linux	6.4.8	1
+Chrome	134.0.6998.165	desktop	Linux	6.5.0	1
+Chrome	134.0.6998.165	desktop	Macintosh	 10.15	1
+Chrome	134.0.6998.165	desktop	Macintosh	Intel 10.15	1
+Chrome	134.0.6998.165	desktop	Macintosh	Intel 12.7	1
+Chrome	134.0.6998.165	desktop	Macintosh	Intel 14.3	1
+Chrome	134.0.6998.165	mobile	Android	11.0	1
+Chrome	134.0.6998.165	mobile	Android	6.0	1
+Chrome	134.0.6998.165	mobile	Linux	6.8.0	1
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 11.7	1
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 12.2	1
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 12.6	1
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 13.2	1
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 13.7	1
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 14.0	1
+Chrome	134.0.6998.166	desktop	Macintosh	Intel 14.3	1
+Chrome	134.0.6998.167	desktop	Macintosh	Intel 13.0	1
+Chrome	134.0.6998.167	desktop	Macintosh	Intel 14.1	1
+Chrome	134.0.6998.167	desktop	Macintosh	Intel 14.4	1
+Chrome	134.0.6998.167	desktop	Macintosh	Intel 15.4	1
+Chrome	134.0.6998.167	desktop	Macintosh	Intel 15.5	1
+Chrome	134.0.6998.179	desktop	Macintosh	Intel 15.4	1
+Chrome	134.0.6998.205	desktop	Linux	6.14.9	1
+Chrome	134.0.6998.205	desktop	Linux	6.15.3	1
+Chrome	134.0.6998.205	desktop	Linux	6.15.7	1
+Chrome	134.0.6998.205	desktop	Linux	6.8.0	1
+Chrome	134.0.6998.205	desktop	Macintosh	Intel 14.7	1
+Chrome	134.0.6998.205	desktop	Macintosh	Intel 15.2	1
+Chrome	134.0.6998.205	desktop	Macintosh	Intel 15.3	1
+Chrome	134.0.6998.207	desktop	Linux	6.12.10	1
+Chrome	134.0.6998.207	desktop	Linux	6.8.0	1
+Chrome	134.0.6998.207	desktop	Windows	11	1
+Chrome	134.0.6998.207	tablet	Android	11	1
+Chrome	134.0.6998.33	mobile	iOS	16.7.11	1
+Chrome	134.0.6998.33	mobile	iOS	17.6.1	1
+Chrome	134.0.6998.33	mobile	iOS	18.3.1	1
+Chrome	134.0.6998.33	mobile	iOS	18.4.1	1
+Chrome	134.0.6998.33	mobile	iOS	18.6.0	1
+Chrome	134.0.6998.35	desktop	Linux	6.13.5	1
+Chrome	134.0.6998.35	desktop	Linux	6.13.6	1
+Chrome	134.0.6998.35	desktop	Linux	6.14.9	1
+Chrome	134.0.6998.35	desktop	Linux	6.9.3	1
+Chrome	134.0.6998.35	desktop	Windows	11	1
+Chrome	134.0.6998.36	mobile	Android	10	1
+Chrome	134.0.6998.37	desktop	Windows	11	1
+Chrome	134.0.6998.39	mobile	Android	10	1
+Chrome	134.0.6998.39	tablet	Android	9.0.0	1
+Chrome	134.0.6998.39 	mobile	Android	10.0.0	1
+Chrome	134.0.6998.44	desktop	Macintosh	Intel 12.2	1
+Chrome	134.0.6998.44	desktop	Macintosh	Intel 13.0	1
+Chrome	134.0.6998.44	desktop	Macintosh	Intel 13.3	1
+Chrome	134.0.6998.44	desktop	Macintosh	Intel 13.7	1
+Chrome	134.0.6998.44	desktop	Macintosh	Intel 14.5	1
+Chrome	134.0.6998.45	desktop	Macintosh	Intel 13.3	1
+Chrome	134.0.6998.45	desktop	Macintosh	Intel 14.3	1
+Chrome	134.0.6998.45	desktop	Macintosh	Intel 14.4	1
+Chrome	134.0.6998.45	desktop	Macintosh	Intel 14.7	1
+Chrome	134.0.6998.45	desktop	Macintosh	Intel 15.0	1
+Chrome	134.0.6998.46	desktop	Macintosh	Intel 11.6	1
+Chrome	134.0.6998.46	desktop	Macintosh	Intel 13.7	1
+Chrome	134.0.6998.46	desktop	Macintosh	Intel 15.2	1
+Chrome	134.0.6998.478	mobile	Android	11.0.0	1
+Chrome	134.0.6998.555	mobile	Android	14.0.0	1
+Chrome	134.0.6998.758	mobile	Android	14.0.0	1
+Chrome	134.0.6998.758	mobile	Android	15.0.0	1
+Chrome	134.0.6998.799	mobile	Android	11.0.0	1
+Chrome	134.0.6998.822	mobile	Android	12.0.0	1
+Chrome	134.0.6998.822	mobile	Android	13.0.0	1
+Chrome	134.0.6998.822	mobile	Android	14.0.0	1
+Chrome	134.0.6998.836	mobile	Android	10.0.0	1
+Chrome	134.0.6998.836	mobile	Android	12.0.0	1
+Chrome	134.0.6998.877	mobile	Android	14.0.0	1
+Chrome	134.0.6998.88	desktop	Linux	4.19.0	1
+Chrome	134.0.6998.88	desktop	Linux	6.10.10	1
+Chrome	134.0.6998.88	desktop	Linux	6.12.10	1
+Chrome	134.0.6998.88	desktop	Linux	6.12.9	1
+Chrome	134.0.6998.88	desktop	Linux	6.15.3	1
+Chrome	134.0.6998.88	desktop	Linux	6.5.0	1
+Chrome	134.0.6998.88	desktop	Macintosh	Intel 11.6	1
+Chrome	134.0.6998.89	desktop	Macintosh	Intel 13.0	1
+Chrome	134.0.6998.89	desktop	Macintosh	Intel 13.1	1
+Chrome	134.0.6998.89	desktop	Macintosh	Intel 13.5	1
+Chrome	134.0.6998.89	desktop	Macintosh	Intel 13.7	1
+Chrome	134.0.6998.89	desktop	Macintosh	Intel 14.1	1
+Chrome	134.0.6998.89	desktop	Macintosh	Intel 14.2	1
+Chrome	134.0.6998.895	mobile	Android	(not set)	1
+Chrome	134.0.6998.895	mobile	Android	10.0.0	1
+Chrome	134.0.6998.895	mobile	Android	11.0.0	1
+Chrome	134.0.6998.895	mobile	Android	8.0.0	1
+Chrome	134.0.6998.903	mobile	Android	13	1
+Chrome	134.0.6998.903	mobile	Android	14.0.0	1
+Chrome	134.0.6998.95	mobile	Android	8.1.0	1
+Chrome	134.0.6998.95	mobile	Android	9	1
+Chrome	134.0.6998.95	tablet	Android	10.0.0	1
+Chrome	134.0.6998.95	tablet	Android	13.0.0	1
+Chrome	134.0.6998.96	mobile	Android	11.0.0	1
+Chrome	134.0.6998.96	mobile	Android	13.0.0	1
+Chrome	134.0.6998.99	mobile	iOS	16.1.2	1
+Chrome	134.0.6998.99	mobile	iOS	17.5.1	1
+Chrome	134.0.6998.99	mobile	iOS	18.3.1	1
+Chrome	134.0.6998.99	mobile	iOS	18.4.0	1
+Chrome	134.0.6998.99	tablet	iOS	16.1.1	1
+Chrome	134.0.6998.99	tablet	iOS	16.7.11	1
+Chrome	134.0.6998.99	tablet	iOS	18.5.0	1
+Chrome	135.0.0.0	desktop	Linux	6.1.128	1
+Chrome	135.0.0.0	desktop	Linux	6.12.10	1
+Chrome	135.0.0.0	desktop	Linux	6.12.20	1
+Chrome	135.0.0.0	desktop	Linux	6.12.25	1
+Chrome	135.0.0.0	desktop	Linux	6.12.28	1
+Chrome	135.0.0.0	desktop	Linux	6.12.32	1
+Chrome	135.0.0.0	desktop	Linux	6.2.12	1
+Chrome	135.0.0.0	desktop	Linux	6.6.31	1
+Chrome	135.0.0.0	desktop	Linux	6.8.0	1
+Chrome	135.0.0.0	desktop	Macintosh	Intel 13.4	1
+Chrome	135.0.0.0	desktop	Macintosh	Intel 13.6	1
+Chrome	135.0.0.0	desktop	Macintosh	Intel 14.1	1
+Chrome	135.0.0.0	desktop	Macintosh	Intel 14.3	1
+Chrome	135.0.0.0	desktop	Macintosh	Intel 15.2	1
+Chrome	135.0.0.0	mobile	Android	6.0	1
+Chrome	135.0.0.0	mobile	iOS	15.0.1	1
+Chrome	135.0.0.0	mobile	iOS	15.1.3	1
+Chrome	135.0.0.0	mobile	iOS	15.5.6	1
+Chrome	135.0.6999.0	mobile	Android	11.0.0	1
+Chrome	135.0.7012.4	desktop	Windows	10	1
+Chrome	135.0.7049.100	mobile	Android	11	1
+Chrome	135.0.7049.100	tablet	Android	12.0.0	1
+Chrome	135.0.7049.101	mobile	Android	11.0.0	1
+Chrome	135.0.7049.101	mobile	Android	12.0.0	1
+Chrome	135.0.7049.111	mobile	Android	10	1
+Chrome	135.0.7049.111	mobile	Android	16.0.0	1
+Chrome	135.0.7049.111	mobile	Android	8.0.0	1
+Chrome	135.0.7049.111	tablet	Android	10.0.0	1
+Chrome	135.0.7049.111	tablet	Android	12.0.0	1
+Chrome	135.0.7049.111	tablet	Android	15.0.0	1
+Chrome	135.0.7049.111	tablet	Android	8.1.0	1
+Chrome	135.0.7049.112	mobile	Android	9	1
+Chrome	135.0.7049.113	mobile	Android	9.0.0	1
+Chrome	135.0.7049.113	tablet	Android	10.0.0	1
+Chrome	135.0.7049.114	desktop	Linux	4.18.0	1
+Chrome	135.0.7049.114	desktop	Linux	5.3.18	1
+Chrome	135.0.7049.114	desktop	Linux	5.4.0	1
+Chrome	135.0.7049.114	desktop	Linux	6.12.15	1
+Chrome	135.0.7049.114	desktop	Linux	6.12.21	1
+Chrome	135.0.7049.114	desktop	Linux	6.15.2	1
+Chrome	135.0.7049.114	desktop	Linux	6.15.3	1
+Chrome	135.0.7049.114	desktop	Linux	6.2.15	1
+Chrome	135.0.7049.114	desktop	Macintosh	Intel 12.7	1
+Chrome	135.0.7049.114	desktop	Macintosh	Intel 14.2	1
+Chrome	135.0.7049.114	desktop	Macintosh	Intel 14.4	1
+Chrome	135.0.7049.114	desktop	Macintosh	Intel 14.6	1
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 11.5	1
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 12.1	1
+Chrome	135.0.7049.115	desktop	Macintosh	Intel 13.0	1
+Chrome	135.0.7049.116	desktop	Macintosh	Intel 13.0	1
+Chrome	135.0.7049.116	desktop	Macintosh	Intel 13.3	1
+Chrome	135.0.7049.116	desktop	Macintosh	Intel 15.2	1
+Chrome	135.0.7049.117	desktop	Macintosh	Intel 13.2	1
+Chrome	135.0.7049.117	desktop	Macintosh	Intel 13.4	1
+Chrome	135.0.7049.117	desktop	Macintosh	Intel 14.0	1
+Chrome	135.0.7049.117	desktop	Macintosh	Intel 14.5	1
+Chrome	135.0.7049.117	desktop	Macintosh	Intel 15.1	1
+Chrome	135.0.7049.117	desktop	Macintosh	Intel 15.3	1
+Chrome	135.0.7049.120	desktop	Chrome OS	aarch64 16209.59.0	1
+Chrome	135.0.7049.14	mobile	Android	11.0.0	1
+Chrome	135.0.7049.14	mobile	Android	12	1
+Chrome	135.0.7049.213	mobile	Android	12.0.0	1
+Chrome	135.0.7049.213	mobile	Android	13.0.0	1
+Chrome	135.0.7049.236	mobile	Android	11.0.0	1
+Chrome	135.0.7049.236	mobile	Android	14.0.0	1
+Chrome	135.0.7049.236	mobile	Android	15.0.0	1
+Chrome	135.0.7049.264	mobile	Android	10.0.0	1
+Chrome	135.0.7049.264	mobile	Android	8.1.0	1
+Chrome	135.0.7049.37	mobile	Android	15	1
+Chrome	135.0.7049.38	mobile	Android	13	1
+Chrome	135.0.7049.38	mobile	Android	14	1
+Chrome	135.0.7049.38	mobile	Android	8.0.0	1
+Chrome	135.0.7049.38	mobile	Android	9	1
+Chrome	135.0.7049.38	mobile	iOS	18.0	1
+Chrome	135.0.7049.39	mobile	Android	8.0.0	1
+Chrome	135.0.7049.41	desktop	Macintosh	Intel 13.4	1
+Chrome	135.0.7049.41	desktop	Macintosh	Intel 14.4	1
+Chrome	135.0.7049.41	desktop	Macintosh	Intel 15.1	1
+Chrome	135.0.7049.41	desktop	Macintosh	Intel 15.2	1
+Chrome	135.0.7049.41	desktop	Macintosh	Intel 15.4	1
+Chrome	135.0.7049.42	desktop	Macintosh	Intel 12.6	1
+Chrome	135.0.7049.42	desktop	Macintosh	Intel 13.0	1
+Chrome	135.0.7049.42	desktop	Macintosh	Intel 13.2	1
+Chrome	135.0.7049.42	desktop	Macintosh	Intel 13.4	1
+Chrome	135.0.7049.42	desktop	Macintosh	Intel 13.6	1
+Chrome	135.0.7049.42	desktop	Macintosh	Intel 14.2	1
+Chrome	135.0.7049.42	desktop	Macintosh	Intel 14.3	1
+Chrome	135.0.7049.42	desktop	Macintosh	Intel 15.2	1
+Chrome	135.0.7049.43	desktop	Macintosh	Intel 14.6	1
+Chrome	135.0.7049.43	desktop	Macintosh	Intel 14.7	1
+Chrome	135.0.7049.52	desktop	Linux	4.15.0	1
+Chrome	135.0.7049.52	desktop	Linux	6.1.0	1
+Chrome	135.0.7049.52	desktop	Linux	6.11.4	1
+Chrome	135.0.7049.52	desktop	Linux	6.11.9	1
+Chrome	135.0.7049.52	desktop	Linux	6.14.6	1
+Chrome	135.0.7049.52	desktop	Linux	6.2.12	1
+Chrome	135.0.7049.52	desktop	Linux	6.6.87	1
+Chrome	135.0.7049.52	desktop	Macintosh	Intel 10.15	1
+Chrome	135.0.7049.53	mobile	iOS	16.1.1	1
+Chrome	135.0.7049.53	mobile	iOS	18.0.1	1
+Chrome	135.0.7049.53	mobile	iOS	18.4.0	1
+Chrome	135.0.7049.53	mobile	iOS	19.0.0	1
+Chrome	135.0.7049.53	tablet	iOS	18.5.0	1
+Chrome	135.0.7049.75	desktop	Windows	10	1
+Chrome	135.0.7049.79	mobile	Android	8.0.0	1
+Chrome	135.0.7049.79	tablet	Android	8.1.0	1
+Chrome	135.0.7049.80	mobile	Android	10.0.0	1
+Chrome	135.0.7049.80	mobile	Android	13.0.0	1
+Chrome	135.0.7049.80	tablet	Android	14.0.0	1
+Chrome	135.0.7049.83	mobile	iOS	17.4.0	1
+Chrome	135.0.7049.83	mobile	iOS	17.6.1	1
+Chrome	135.0.7049.83	mobile	iOS	18.0.1	1
+Chrome	135.0.7049.83	mobile	iOS	18.2.0	1
+Chrome	135.0.7049.83	mobile	iOS	18.3.0	1
+Chrome	135.0.7049.83	mobile	iOS	18.3.1	1
+Chrome	135.0.7049.83	mobile	iOS	18.4.0	1
+Chrome	135.0.7049.83	mobile	iOS	18.6.0	1
+Chrome	135.0.7049.83	tablet	iOS	16.6.1	1
+Chrome	135.0.7049.83	tablet	iOS	18.2.1	1
+Chrome	135.0.7049.83	tablet	iOS	18.4.1	1
+Chrome	135.0.7049.84	desktop	Linux	5.19.0	1
+Chrome	135.0.7049.84	desktop	Linux	6.1.0	1
+Chrome	135.0.7049.84	desktop	Linux	6.13.10	1
+Chrome	135.0.7049.84	desktop	Linux	6.13.5	1
+Chrome	135.0.7049.84	desktop	Linux	6.14.1	1
+Chrome	135.0.7049.84	desktop	Linux	6.14.2	1
+Chrome	135.0.7049.84	desktop	Linux	6.15.0	1
+Chrome	135.0.7049.84	desktop	Linux	6.6.86	1
+Chrome	135.0.7049.84	desktop	Linux	6.8.5	1
+Chrome	135.0.7049.84	desktop	Macintosh	Intel 13.2	1
+Chrome	135.0.7049.84	desktop	Macintosh	Intel 14.1	1
+Chrome	135.0.7049.84	desktop	Macintosh	Intel 14.4	1
+Chrome	135.0.7049.84	desktop	Macintosh	Intel 15.1	1
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 12.6	1
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 13.0	1
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 13.1	1
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 13.6	1
+Chrome	135.0.7049.85	desktop	Macintosh	Intel 14.0	1
+Chrome	135.0.7049.86	desktop	Macintosh	Intel 12.5	1
+Chrome	135.0.7049.86	desktop	Macintosh	Intel 13.4	1
+Chrome	135.0.7049.86	desktop	Macintosh	Intel 14.2	1
+Chrome	135.0.7049.86	desktop	Macintosh	Intel 14.3	1
+Chrome	135.0.7049.86	desktop	Macintosh	Intel 14.4	1
+Chrome	135.0.7049.86	desktop	Macintosh	Intel 14.7	1
+Chrome	135.0.7049.86	desktop	Macintosh	Intel 15.2	1
+Chrome	135.0.7049.86	desktop	Macintosh	Intel 15.4	1
+Chrome	135.0.7049.95	desktop	Linux	4.18.0	1
+Chrome	135.0.7049.95	desktop	Linux	5.16.12	1
+Chrome	135.0.7049.95	desktop	Linux	5.4.0	1
+Chrome	135.0.7049.95	desktop	Linux	6.1.0	1
+Chrome	135.0.7049.95	desktop	Linux	6.10.6	1
+Chrome	135.0.7049.95	desktop	Linux	6.12.34	1
+Chrome	135.0.7049.95	desktop	Linux	6.14.7	1
+Chrome	135.0.7049.95	desktop	Linux	6.15.3	1
+Chrome	135.0.7049.95	desktop	Linux	6.2.0	1
+Chrome	135.0.7049.95	desktop	Linux	6.9.3	1
+Chrome	135.0.7049.95	desktop	Macintosh	Intel 12.4	1
+Chrome	135.0.7049.95	desktop	Macintosh	Intel 12.7	1
+Chrome	135.0.7049.95	desktop	Macintosh	Intel 13.7	1
+Chrome	135.0.7049.95	desktop	Macintosh	Intel 14.1	1
+Chrome	135.0.7049.95	desktop	Macintosh	Intel 14.2	1
+Chrome	135.0.7049.95	desktop	Macintosh	Intel 14.6	1
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 12.5	1
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 13.1	1
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 13.3	1
+Chrome	135.0.7049.96	desktop	Macintosh	Intel 13.7	1
+Chrome	135.0.7049.96	mobile	Android	11.0	1
+Chrome	135.0.7049.97	desktop	Macintosh	Intel 11.7	1
+Chrome	135.0.7049.97	desktop	Macintosh	Intel 13.3	1
+Chrome	135.0.7049.97	desktop	Macintosh	Intel 14.1	1
+Chrome	135.0.7049.97	desktop	Macintosh	Intel 15.2	1
+Chrome	135.0.7049.97	desktop	Macintosh	Intel 15.4	1
+Chrome	135.0.7409.38	mobile	Android	10	1
+Chrome	136	desktop	Windows	10	1
+Chrome	136.0.0.0	desktop	Chrome OS	x86_64 14541.0.0	1
+Chrome	136.0.0.0	desktop	Linux	5.4.0	1
+Chrome	136.0.0.0	desktop	Linux	6.12.13	1
+Chrome	136.0.0.0	desktop	Linux	6.12.29	1
+Chrome	136.0.0.0	desktop	Linux	6.12.30	1
+Chrome	136.0.0.0	desktop	Linux	6.14.3	1
+Chrome	136.0.0.0	desktop	Linux	6.6.83	1
+Chrome	136.0.0.0	desktop	Macintosh	Intel 10.13	1
+Chrome	136.0.0.0	desktop	Macintosh	Intel 13.7	1
+Chrome	136.0.0.0	desktop	Macintosh	Intel 14.1	1
+Chrome	136.0.0.0	desktop	Macintosh	Intel 14.2	1
+Chrome	136.0.0.0	desktop	Macintosh	Intel 14.4	1
+Chrome	136.0.0.0	desktop	Macintosh	Intel 14.5	1
+Chrome	136.0.0.0	desktop	Macintosh	Intel 14.6	1
+Chrome	136.0.0.0	desktop	Macintosh	Intel 15.0	1
+Chrome	136.0.0.0	mobile	Android	12.0.0	1
+Chrome	136.0.0.0	mobile	Macintosh	 14.6	1
+Chrome	136.0.0.0	mobile	Windows	11	1
+Chrome	136.0.7049.37	mobile	Android	13	1
+Chrome	136.0.7049.38	mobile	Android	10	1
+Chrome	136.0.7049.38	mobile	Android	13.0.0	1
+Chrome	136.0.7087.0	desktop	Windows	10	1
+Chrome	136.0.7103.1024	mobile	Android	12.0.0	1
+Chrome	136.0.7103.1026	mobile	Android	15.0.0	1
+Chrome	136.0.7103.113	desktop	Linux	4.15.0	1
+Chrome	136.0.7103.113	desktop	Linux	4.19.52	1
+Chrome	136.0.7103.113	desktop	Linux	5.14.0	1
+Chrome	136.0.7103.113	desktop	Linux	5.15.161	1
+Chrome	136.0.7103.113	desktop	Linux	5.15.77	1
+Chrome	136.0.7103.113	desktop	Linux	5.8.0	1
+Chrome	136.0.7103.113	desktop	Linux	6.0.12	1
+Chrome	136.0.7103.113	desktop	Linux	6.1.75	1
+Chrome	136.0.7103.113	desktop	Linux	6.11.2	1
+Chrome	136.0.7103.113	desktop	Linux	6.11.9	1
+Chrome	136.0.7103.113	desktop	Linux	6.12.21	1
+Chrome	136.0.7103.113	desktop	Linux	6.12.33	1
+Chrome	136.0.7103.113	desktop	Linux	6.13.7	1
+Chrome	136.0.7103.113	desktop	Linux	6.14.9	1
+Chrome	136.0.7103.113	desktop	Linux	6.15.0	1
+Chrome	136.0.7103.113	desktop	Linux	6.15.3	1
+Chrome	136.0.7103.113	desktop	Linux	6.9.0	1
+Chrome	136.0.7103.113	desktop	Macintosh	 10.15	1
+Chrome	136.0.7103.113	desktop	Macintosh	Intel 10.15	1
+Chrome	136.0.7103.113	desktop	Macintosh	Intel 11.6	1
+Chrome	136.0.7103.113	desktop	Macintosh	Intel 11.7	1
+Chrome	136.0.7103.113	desktop	Macintosh	Intel 13.0	1
+Chrome	136.0.7103.113	desktop	Macintosh	Intel 13.2	1
+Chrome	136.0.7103.113	desktop	Macintosh	Intel 13.4	1
+Chrome	136.0.7103.113	desktop	Macintosh	Intel 13.5	1
+Chrome	136.0.7103.113	desktop	Macintosh	Intel 14.3	1
+Chrome	136.0.7103.113	desktop	Macintosh	Intel 14.7	1
+Chrome	136.0.7103.113	desktop	Macintosh	Intel 15.4	1
+Chrome	136.0.7103.113	mobile	Android	11.0	1
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 11.1	1
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 11.4	1
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 12.2	1
+Chrome	136.0.7103.114	desktop	Macintosh	Intel 12.4	1
+Chrome	136.0.7103.114	mobile	Android	11	1
+Chrome	136.0.7103.114	mobile	Android	11.0	1
+Chrome	136.0.7103.114	mobile	Android	6.0	1
+Chrome	136.0.7103.115	desktop	Macintosh	Intel 12.2	1
+Chrome	136.0.7103.115	desktop	Macintosh	Intel 15.0	1
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 11.1	1
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 11.3	1
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 12.3	1
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 12.6	1
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 13.0	1
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 13.5	1
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 14.1	1
+Chrome	136.0.7103.116	desktop	Macintosh	Intel 14.2	1
+Chrome	136.0.7103.125	mobile	Android	12	1
+Chrome	136.0.7103.125	mobile	Android	14	1
+Chrome	136.0.7103.125	tablet	Android	10.0.0	1
+Chrome	136.0.7103.125	tablet	Android	12.0.0	1
+Chrome	136.0.7103.125	tablet	Android	13.0.0	1
+Chrome	136.0.7103.125	tablet	Android	15.0.0	1
+Chrome	136.0.7103.125	tablet	Android	8.1.0	1
+Chrome	136.0.7103.125	tablet	Android	9.0.0	1
+Chrome	136.0.7103.126	mobile	Android	13.0.0	1
+Chrome	136.0.7103.127	mobile	Android	11	1
+Chrome	136.0.7103.127	mobile	Android	14	1
+Chrome	136.0.7103.128	mobile	Android	15.0.0	1
+Chrome	136.0.7103.134	mobile	iOS	(not set)	1
+Chrome	136.0.7103.138	mobile	Android	10.0.0	1
+Chrome	136.0.7103.138	mobile	Android	12.0.0	1
+Chrome	136.0.7103.148	tablet	iOS	17.5.1	1
+Chrome	136.0.7103.151	desktop	Linux	6.11.0	1
+Chrome	136.0.7103.151	desktop	Linux	6.14.5	1
+Chrome	136.0.7103.151	desktop	Macintosh	Intel 15.5	1
+Chrome	136.0.7103.151	desktop	Windows	11	1
+Chrome	136.0.7103.154	desktop	Macintosh	Intel 11.7	1
+Chrome	136.0.7103.154	desktop	Macintosh	Intel 12.7	1
+Chrome	136.0.7103.154	desktop	Macintosh	Intel 14.5	1
+Chrome	136.0.7103.154	desktop	Macintosh	Intel 15.3	1
+Chrome	136.0.7103.156	desktop	Macintosh	Intel 15.5	1
+Chrome	136.0.7103.162	desktop	Linux	6.8.0	1
+Chrome	136.0.7103.162	desktop	Macintosh	Intel 15.5	1
+Chrome	136.0.7103.168	desktop	Macintosh	Intel 13.7	1
+Chrome	136.0.7103.168	desktop	Macintosh	Intel 14.7	1
+Chrome	136.0.7103.168	desktop	Macintosh	Intel 15.3	1
+Chrome	136.0.7103.168	desktop	Macintosh	Intel 15.5	1
+Chrome	136.0.7103.17	desktop	Macintosh	Intel 14.3	1
+Chrome	136.0.7103.170	desktop	Macintosh	Intel 14.7	1
+Chrome	136.0.7103.170	desktop	Windows	11	1
+Chrome	136.0.7103.177	desktop	Macintosh	 10.15	1
+Chrome	136.0.7103.177	desktop	Macintosh	Intel 10.15	1
+Chrome	136.0.7103.177	desktop	Macintosh	Intel 14.6	1
+Chrome	136.0.7103.177	desktop	Macintosh	Intel 15.3	1
+Chrome	136.0.7103.178	mobile	Android	11.0.0	1
+Chrome	136.0.7103.178	mobile	Android	12.0.0	1
+Chrome	136.0.7103.178	mobile	Android	13.0.0	1
+Chrome	136.0.7103.178	mobile	Android	15.0.0	1
+Chrome	136.0.7103.179	desktop	Linux	5.15.0	1
+Chrome	136.0.7103.179	desktop	Linux	6.12.10	1
+Chrome	136.0.7103.179	desktop	Linux	6.14.0	1
+Chrome	136.0.7103.179	desktop	Linux	6.15.2	1
+Chrome	136.0.7103.179	desktop	Linux	6.15.3	1
+Chrome	136.0.7103.179	desktop	Linux	6.8.0	1
+Chrome	136.0.7103.179	desktop	Macintosh	Intel 14.6	1
+Chrome	136.0.7103.179	desktop	Macintosh	Intel 15.2	1
+Chrome	136.0.7103.179	desktop	Macintosh	Intel 15.3	1
+Chrome	136.0.7103.179	mobile	Android	12.0.0	1
+Chrome	136.0.7103.179	mobile	Android	14.0.0	1
+Chrome	136.0.7103.204	mobile	Android	11.0.0	1
+Chrome	136.0.7103.204	mobile	Android	12.0.0	1
+Chrome	136.0.7103.204	mobile	Android	13.0.0	1
+Chrome	136.0.7103.204	mobile	Android	14.0.0	1
+Chrome	136.0.7103.2195	mobile	Android	11.0.0	1
+Chrome	136.0.7103.24	mobile	Android	10	1
+Chrome	136.0.7103.24	mobile	Android	15.0.0	1
+Chrome	136.0.7103.25	desktop	Linux	5.15.0	1
+Chrome	136.0.7103.305	tablet	Android	13.0.0	1
+Chrome	136.0.7103.33	desktop	Linux	6.14.3	1
+Chrome	136.0.7103.33	desktop	Macintosh	Intel 14.5	1
+Chrome	136.0.7103.385	mobile	Android	13.0.0	1
+Chrome	136.0.7103.385	mobile	Android	15.0.0	1
+Chrome	136.0.7103.392	mobile	Android	12.0.0	1
+Chrome	136.0.7103.392	mobile	Android	13.0.0	1
+Chrome	136.0.7103.392	mobile	Android	14.0.0	1
+Chrome	136.0.7103.392	mobile	Android	15.0.0	1
+Chrome	136.0.7103.392	mobile	Android	16.0.0	1
+Chrome	136.0.7103.396	mobile	Android	10.0.0	1
+Chrome	136.0.7103.398	tablet	Android	12.0.0	1
+Chrome	136.0.7103.4	mobile	Android	13.0.0	1
+Chrome	136.0.7103.42	mobile	iOS	18.1.1	1
+Chrome	136.0.7103.42	tablet	iOS	18.5.0	1
+Chrome	136.0.7103.422	mobile	Android	13.0.0	1
+Chrome	136.0.7103.422	mobile	Android	14.0.0	1
+Chrome	136.0.7103.429	mobile	iOS	18.5.0	1
+Chrome	136.0.7103.44	mobile	Android	9	1
+Chrome	136.0.7103.48	desktop	Macintosh	Intel 11.6	1
+Chrome	136.0.7103.48	desktop	Macintosh	Intel 12.6	1
+Chrome	136.0.7103.48	desktop	Macintosh	Intel 13.6	1
+Chrome	136.0.7103.48	desktop	Macintosh	Intel 15.0	1
+Chrome	136.0.7103.48	desktop	Macintosh	Intel 15.5	1
+Chrome	136.0.7103.49	desktop	Macintosh	Intel 13.6	1
+Chrome	136.0.7103.49	desktop	Macintosh	Intel 14.5	1
+Chrome	136.0.7103.49	mobile	Android	14.0.0	1
+Chrome	136.0.7103.56	mobile	iOS	16.2.0	1
+Chrome	136.0.7103.56	mobile	iOS	16.5.1	1
+Chrome	136.0.7103.56	mobile	iOS	16.7.11	1
+Chrome	136.0.7103.56	tablet	iOS	18.1.1	1
+Chrome	136.0.7103.56	tablet	iOS	18.4.1	1
+Chrome	136.0.7103.59	desktop	Chrome OS	aarch64 16238.33.0	1
+Chrome	136.0.7103.59	desktop	Linux	5.10.0	1
+Chrome	136.0.7103.59	desktop	Linux	5.13.0	1
+Chrome	136.0.7103.59	desktop	Linux	5.14.0	1
+Chrome	136.0.7103.59	desktop	Linux	5.8.18	1
+Chrome	136.0.7103.59	desktop	Linux	6.11.2	1
+Chrome	136.0.7103.59	desktop	Linux	6.12.10	1
+Chrome	136.0.7103.59	desktop	Linux	6.12.13	1
+Chrome	136.0.7103.59	desktop	Linux	6.12.20	1
+Chrome	136.0.7103.59	desktop	Linux	6.12.26	1
+Chrome	136.0.7103.59	desktop	Linux	6.13.11	1
+Chrome	136.0.7103.59	desktop	Linux	6.14.0	1
+Chrome	136.0.7103.59	desktop	Linux	6.14.9	1
+Chrome	136.0.7103.59	desktop	Linux	6.15.3	1
+Chrome	136.0.7103.59	desktop	Linux	6.4.0	1
+Chrome	136.0.7103.59	desktop	Linux	6.5.0	1
+Chrome	136.0.7103.59	desktop	Linux	6.6.58	1
+Chrome	136.0.7103.59	desktop	Linux	6.6.72	1
+Chrome	136.0.7103.59	desktop	Macintosh	 10.15	1
+Chrome	136.0.7103.59	desktop	Macintosh	Intel 10.15	1
+Chrome	136.0.7103.59	mobile	Android	11.0	1
+Chrome	136.0.7103.60	mobile	Android	16.0.0	1
+Chrome	136.0.7103.60	mobile	Android	8.0.0	1
+Chrome	136.0.7103.60	tablet	Android	11.0.0	1
+Chrome	136.0.7103.61	mobile	Android	10	1
+Chrome	136.0.7103.61	mobile	Android	14.0.0	1
+Chrome	136.0.7103.61	mobile	Android	15	1
+Chrome	136.0.7103.61	mobile	Android	15.0.0	1
+Chrome	136.0.7103.87	mobile	Android	8.0.0	1
+Chrome	136.0.7103.87	mobile	Android	9	1
+Chrome	136.0.7103.87	tablet	Android	13.0.0	1
+Chrome	136.0.7103.87	tablet	Android	15.0.0	1
+Chrome	136.0.7103.88	mobile	Android	11.0.0	1
+Chrome	136.0.7103.88	mobile	Android	12	1
+Chrome	136.0.7103.88	mobile	Android	15	1
+Chrome	136.0.7103.88	mobile	Android	8.1.0	1
+Chrome	136.0.7103.88	tablet	Android	13.0.0	1
+Chrome	136.0.7103.88	tablet	Android	14.0.0	1
+Chrome	136.0.7103.91	mobile	iOS	16.2.0	1
+Chrome	136.0.7103.91	mobile	iOS	16.6.1	1
+Chrome	136.0.7103.91	mobile	iOS	17.2.0	1
+Chrome	136.0.7103.91	mobile	iOS	18.1.0	1
+Chrome	136.0.7103.91	mobile	iOS	26.0.0	1
+Chrome	136.0.7103.91	tablet	iOS	16.1.1	1
+Chrome	136.0.7103.91	tablet	iOS	16.6.0	1
+Chrome	136.0.7103.91	tablet	iOS	17.7.8	1
+Chrome	136.0.7103.91	tablet	iOS	18.6.0	1
+Chrome	136.0.7103.92	desktop	Linux	4.18.0	1
+Chrome	136.0.7103.92	desktop	Linux	5.13.0	1
+Chrome	136.0.7103.92	desktop	Linux	6.1.135	1
+Chrome	136.0.7103.92	desktop	Linux	6.1.7	1
+Chrome	136.0.7103.92	desktop	Linux	6.12.34	1
+Chrome	136.0.7103.92	desktop	Linux	6.12.35	1
+Chrome	136.0.7103.92	desktop	Linux	6.13.6	1
+Chrome	136.0.7103.92	desktop	Linux	6.14.10	1
+Chrome	136.0.7103.92	desktop	Linux	6.14.4	1
+Chrome	136.0.7103.92	desktop	Linux	6.15.2	1
+Chrome	136.0.7103.92	desktop	Linux	6.3.0	1
+Chrome	136.0.7103.92	desktop	Linux	6.6.9	1
+Chrome	136.0.7103.92	desktop	Linux	6.8.11	1
+Chrome	136.0.7103.92	desktop	Linux	6.9.3	1
+Chrome	136.0.7103.92	desktop	Macintosh	Intel 12.4	1
+Chrome	136.0.7103.92	desktop	Macintosh	Intel 13.6	1
+Chrome	136.0.7103.92	desktop	Macintosh	Intel 13.7	1
+Chrome	136.0.7103.92	desktop	Macintosh	Intel 14.1	1
+Chrome	136.0.7103.92	desktop	Macintosh	Intel 14.6	1
+Chrome	136.0.7103.92	desktop	Macintosh	Intel 14.7	1
+Chrome	136.0.7103.92	desktop	Macintosh	Intel 15.0	1
+Chrome	136.0.7103.92	desktop	Macintosh	Intel 15.4	1
+Chrome	136.0.7103.92	desktop	Macintosh	Intel 15.5	1
+Chrome	136.0.7103.92	mobile	Android	14.0.0	1
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 11.1	1
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 11.2	1
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 12.1	1
+Chrome	136.0.7103.93	desktop	Macintosh	Intel 16.0	1
+Chrome	136.0.7103.93	mobile	Android	11.0.0	1
+Chrome	136.0.7103.93	mobile	Android	12.0.0	1
+Chrome	136.0.7103.94	desktop	Macintosh	Intel 12.6	1
+Chrome	136.0.7103.94	desktop	Macintosh	Intel 13.1	1
+Chrome	136.0.7103.94	desktop	Macintosh	Intel 13.3	1
+Chrome	136.0.7103.94	desktop	Macintosh	Intel 14.5	1
+Chrome	136.0.7103.945	mobile	Android	12.0.0	1
+Chrome	136.0.7103.945	mobile	Android	14.0.0	1
+Chrome	137	desktop	Windows	10	1
+Chrome	137.0.0.0	desktop	Linux	4.15.0	1
+Chrome	137.0.0.0	desktop	Linux	5.18.0	1
+Chrome	137.0.0.0	desktop	Linux	6.11.2	1
+Chrome	137.0.0.0	desktop	Linux	6.12.12	1
+Chrome	137.0.0.0	desktop	Linux	6.12.17	1
+Chrome	137.0.0.0	desktop	Linux	6.12.21	1
+Chrome	137.0.0.0	desktop	Linux	6.12.29	1
+Chrome	137.0.0.0	desktop	Linux	6.12.30	1
+Chrome	137.0.0.0	desktop	Linux	6.14.4	1
+Chrome	137.0.0.0	desktop	Linux	6.15.0	1
+Chrome	137.0.0.0	desktop	Linux	6.15.1	1
+Chrome	137.0.0.0	desktop	Linux	6.6.93	1
+Chrome	137.0.0.0	desktop	Macintosh	 13.0	1
+Chrome	137.0.0.0	desktop	Macintosh	Intel 13.7	1
+Chrome	137.0.0.0	desktop	Macintosh	Intel 14.0	1
+Chrome	137.0.0.0	mobile	Android	11	1
+Chrome	137.0.0.0	mobile	Android	13	1
+Chrome	137.0.0.0	mobile	Android	16.0.0	1
+Chrome	137.0.0.0	mobile	Android	7.1.1	1
+Chrome	137.0.0.0	mobile	Android	7.1.2	1
+Chrome	137.0.0.0	mobile	Android	8.0.0	1
+Chrome	137.0.0.0	smart tv	Android	(not set)	1
+Chrome	137.0.0.0	smart tv	Linux	(not set)	1
+Chrome	137.0.0.0	tablet	Android	12.0.0	1
+Chrome	137.0.0.0	tablet	Android	14.0.0	1
+Chrome	137.0.0.0	tablet	Android	8.1.0	1
+Chrome	137.0.3296.82	mobile	iOS	18.5.0	1
+Chrome	137.0.3296.82	mobile	iOS	19.0.0	1
+Chrome	137.0.7104.0	mobile	Android	14.0.0	1
+Chrome	137.0.7106.2	desktop	Windows	11	1
+Chrome	137.0.7115.0	desktop	Linux	5.15.0	1
+Chrome	137.0.7117.3	mobile	Android	10.0.0	1
+Chrome	137.0.7119.0	desktop	Windows	10	1
+Chrome	137.0.7127.2	desktop	Windows	10	1
+Chrome	137.0.7131.0	mobile	Android	10	1
+Chrome	137.0.7137.0	desktop	Chrome OS	aarch64 16261.0.0	1
+Chrome	137.0.7148.0	desktop	Macintosh	Intel 14.7	1
+Chrome	137.0.7151.100	mobile	Android	14.0.0	1
+Chrome	137.0.7151.103	desktop	Linux	4.18.0	1
+Chrome	137.0.7151.103	desktop	Linux	4.19.0	1
+Chrome	137.0.7151.103	desktop	Linux	5.10.0	1
+Chrome	137.0.7151.103	desktop	Linux	5.14.0	1
+Chrome	137.0.7151.103	desktop	Linux	5.15.185	1
+Chrome	137.0.7151.103	desktop	Linux	5.19.0	1
+Chrome	137.0.7151.103	desktop	Linux	6.12.1	1
+Chrome	137.0.7151.103	desktop	Linux	6.12.20	1
+Chrome	137.0.7151.103	desktop	Linux	6.12.28	1
+Chrome	137.0.7151.103	desktop	Linux	6.12.34	1
+Chrome	137.0.7151.103	desktop	Linux	6.12.35	1
+Chrome	137.0.7151.103	desktop	Linux	6.12.9	1
+Chrome	137.0.7151.103	desktop	Linux	6.13.5	1
+Chrome	137.0.7151.103	desktop	Linux	6.13.8	1
+Chrome	137.0.7151.103	desktop	Linux	6.14.6	1
+Chrome	137.0.7151.103	desktop	Linux	6.15.3	1
+Chrome	137.0.7151.103	desktop	Linux	6.6.87	1
+Chrome	137.0.7151.103	desktop	Linux	6.9.3	1
+Chrome	137.0.7151.103	desktop	Macintosh	Intel 11.5	1
+Chrome	137.0.7151.103	desktop	Macintosh	Intel 12.0	1
+Chrome	137.0.7151.103	desktop	Macintosh	Intel 13.2	1
+Chrome	137.0.7151.104	desktop	Macintosh	 14.6	1
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 11.0	1
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 11.2	1
+Chrome	137.0.7151.104	desktop	Macintosh	Intel 11.5	1
+Chrome	137.0.7151.104	mobile	Macintosh	 14.0	1
+Chrome	137.0.7151.104	mobile	Windows	11	1
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 11.4	1
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 11.5	1
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 11.6	1
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 12.2	1
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 12.4	1
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 12.6	1
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 14.0	1
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 14.1	1
+Chrome	137.0.7151.105	desktop	Macintosh	Intel 16.0	1
+Chrome	137.0.7151.107	mobile	iOS	16.0.2	1
+Chrome	137.0.7151.107	mobile	iOS	16.1.2	1
+Chrome	137.0.7151.107	mobile	iOS	16.5.0	1
+Chrome	137.0.7151.107	mobile	iOS	16.6.0	1
+Chrome	137.0.7151.107	mobile	iOS	16.7.0	1
+Chrome	137.0.7151.107	mobile	iOS	16.7.5	1
+Chrome	137.0.7151.107	mobile	iOS	16.7.8	1
+Chrome	137.0.7151.107	mobile	iOS	17.0.0	1
+Chrome	137.0.7151.107	mobile	iOS	17.3.0	1
+Chrome	137.0.7151.107	mobile	iOS	17.6.0	1
+Chrome	137.0.7151.107	mobile	iOS	17.7.2	1
+Chrome	137.0.7151.107	tablet	iOS	16.1.1	1
+Chrome	137.0.7151.107	tablet	iOS	17.3.1	1
+Chrome	137.0.7151.107	tablet	iOS	17.4.1	1
+Chrome	137.0.7151.107	tablet	iOS	18.3.1	1
+Chrome	137.0.7151.109	mobile	Android	14	1
+Chrome	137.0.7151.112	mobile	Android	10.0.0	1
+Chrome	137.0.7151.112	mobile	Android	11	1
+Chrome	137.0.7151.112	mobile	Android	11.0.0	1
+Chrome	137.0.7151.112	mobile	Android	9	1
+Chrome	137.0.7151.112	mobile	Android	9.0.0	1
+Chrome	137.0.7151.115	desktop	Windows	10	1
+Chrome	137.0.7151.115	mobile	Android	9999.0.0	1
+Chrome	137.0.7151.115	smart tv	Android	14.0.0	1
+Chrome	137.0.7151.115	tablet	Android	11	1
+Chrome	137.0.7151.115	tablet	Android	12	1
+Chrome	137.0.7151.115	tablet	Android	14	1
+Chrome	137.0.7151.116	desktop	Linux	(not set)	1
+Chrome	137.0.7151.116	mobile	Android	10.0	1
+Chrome	137.0.7151.116	mobile	Android	11.0.0	1
+Chrome	137.0.7151.116	mobile	Android	8.0.0	1
+Chrome	137.0.7151.116	mobile	Android	9	1
+Chrome	137.0.7151.116	tablet	Android	8.1.0	1
+Chrome	137.0.7151.117	desktop	Windows	10	1
+Chrome	137.0.7151.117	desktop	Windows	Server 2003	1
+Chrome	137.0.7151.117	mobile	Android	9	1
+Chrome	137.0.7151.117	tablet	Android	8.1.0	1
+Chrome	137.0.7151.117	tablet	Android	9.0.0	1
+Chrome	137.0.7151.118	mobile	Android	13.0.0	1
+Chrome	137.0.7151.118	mobile	Android	15.0.0	1
+Chrome	137.0.7151.118	mobile	Android	16	1
+Chrome	137.0.7151.119	desktop	Linux	5.10.229	1
+Chrome	137.0.7151.119	desktop	Linux	5.11.0	1
+Chrome	137.0.7151.119	desktop	Linux	5.13.0	1
+Chrome	137.0.7151.119	desktop	Linux	5.17.12	1
+Chrome	137.0.7151.119	desktop	Linux	5.19.0	1
+Chrome	137.0.7151.119	desktop	Linux	5.19.1	1
+Chrome	137.0.7151.119	desktop	Linux	6.11.4	1
+Chrome	137.0.7151.119	desktop	Linux	6.11.7	1
+Chrome	137.0.7151.119	desktop	Linux	6.12.12	1
+Chrome	137.0.7151.119	desktop	Linux	6.12.13	1
+Chrome	137.0.7151.119	desktop	Linux	6.12.30	1
+Chrome	137.0.7151.119	desktop	Linux	6.12.31	1
+Chrome	137.0.7151.119	desktop	Linux	6.12.6	1
+Chrome	137.0.7151.119	desktop	Linux	6.13.11	1
+Chrome	137.0.7151.119	desktop	Linux	6.14.4	1
+Chrome	137.0.7151.119	desktop	Linux	6.14.5	1
+Chrome	137.0.7151.119	desktop	Linux	6.15.1	1
+Chrome	137.0.7151.119	desktop	Linux	6.2.2	1
+Chrome	137.0.7151.119	desktop	Linux	6.4.11	1
+Chrome	137.0.7151.119	desktop	Linux	6.5.6	1
+Chrome	137.0.7151.119	desktop	Linux	6.6.76	1
+Chrome	137.0.7151.119	desktop	Linux	6.6.84	1
+Chrome	137.0.7151.119	desktop	Linux	6.8.5	1
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 11.0	1
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 11.4	1
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 11.7	1
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 12.0	1
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 12.3	1
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 12.5	1
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 12.6	1
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 13.0	1
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 15.6	1
+Chrome	137.0.7151.119	desktop	Macintosh	Intel 16.0	1
+Chrome	137.0.7151.119	mobile	Android	6.0.1	1
+Chrome	137.0.7151.119	mobile	Windows	10	1
+Chrome	137.0.7151.120	mobile	Android	10.0.0	1
+Chrome	137.0.7151.120	mobile	Android	11.0.0	1
+Chrome	137.0.7151.120	mobile	Android	14.0.0	1
+Chrome	137.0.7151.120	mobile	Android	6.0.1	1
+Chrome	137.0.7151.120	mobile	Android	8.0.0	1
+Chrome	137.0.7151.120	mobile	Macintosh	 14.5	1
+Chrome	137.0.7151.120	mobile	Macintosh	 15.0	1
+Chrome	137.0.7151.120	mobile	Macintosh	 15.2	1
+Chrome	137.0.7151.120	mobile	Macintosh	 15.3	1
+Chrome	137.0.7151.120	mobile	Macintosh	 15.4	1
+Chrome	137.0.7151.120	smart tv	Macintosh	 10.15	1
+Chrome	137.0.7151.120	smart tv	Windows	11	1
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 12.0	1
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 12.4	1
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 12.6	1
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 12.7	1
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 13.1	1
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 13.3	1
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 14.3	1
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 15.1	1
+Chrome	137.0.7151.121	desktop	Macintosh	Intel 16.0	1
+Chrome	137.0.7151.121	mobile	Android	13	1
+Chrome	137.0.7151.121	mobile	Macintosh	 15.5	1
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 11.0	1
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 11.1	1
+Chrome	137.0.7151.122	desktop	Macintosh	Intel 11.4	1
+Chrome	137.0.7151.122	mobile	Macintosh	 10.15	1
+Chrome	137.0.7151.122	mobile	Macintosh	 13.0	1
+Chrome	137.0.7151.122	mobile	Macintosh	 15.1	1
+Chrome	137.0.7151.122	smart tv	Windows	10	1
+Chrome	137.0.7151.123	tablet	Chrome OS	x86_64 16267.51.0	1
+Chrome	137.0.7151.124	mobile	Windows	10	1
+Chrome	137.0.7151.125	desktop	Windows	10	1
+Chrome	137.0.7151.125	mobile	Android	12.0.0	1
+Chrome	137.0.7151.127	mobile	Android	13.0.0	1
+Chrome	137.0.7151.127	mobile	Android	14.0.0	1
+Chrome	137.0.7151.132	mobile	Android	11.0	1
+Chrome	137.0.7151.132	mobile	Android	6.0	1
+Chrome	137.0.7151.137	mobile	Android	6.0	1
+Chrome	137.0.7151.14	mobile	Android	14.0.0	1
+Chrome	137.0.7151.14	mobile	Android	15	1
+Chrome	137.0.7151.14	mobile	Android	15.0.0	1
+Chrome	137.0.7151.15	desktop	Windows	10	1
+Chrome	137.0.7151.23	mobile	Android	10.0.0	1
+Chrome	137.0.7151.34	mobile	iOS	16.5.1	1
+Chrome	137.0.7151.34	mobile	iOS	18.6.0	1
+Chrome	137.0.7151.4	mobile	Android	15.0.0	1
+Chrome	137.0.7151.40	desktop	Macintosh	Intel 14.2	1
+Chrome	137.0.7151.41	desktop	Macintosh	Intel 13.2	1
+Chrome	137.0.7151.41	desktop	Macintosh	Intel 13.5	1
+Chrome	137.0.7151.41	desktop	Macintosh	Intel 14.1	1
+Chrome	137.0.7151.41	desktop	Macintosh	Intel 14.4	1
+Chrome	137.0.7151.41	desktop	Macintosh	Intel 15.1	1
+Chrome	137.0.7151.44	mobile	Android	13.0.0	1
+Chrome	137.0.7151.44	mobile	Android	14.0.0	1
+Chrome	137.0.7151.44	mobile	Android	15.0.0	1
+Chrome	137.0.7151.49	desktop	Chrome OS	aarch64 16267.25.0	1
+Chrome	137.0.7151.50	mobile	Android	14.0.0	1
+Chrome	137.0.7151.51	mobile	iOS	16.7.10	1
+Chrome	137.0.7151.51	mobile	iOS	17.5.1	1
+Chrome	137.0.7151.51	mobile	iOS	17.6.0	1
+Chrome	137.0.7151.51	mobile	iOS	18.0.1	1
+Chrome	137.0.7151.51	mobile	iOS	18.1.0	1
+Chrome	137.0.7151.51	mobile	iOS	18.2.0	1
+Chrome	137.0.7151.51	mobile	iOS	18.4.1	1
+Chrome	137.0.7151.51	tablet	iOS	17.6.1	1
+Chrome	137.0.7151.55	desktop	Linux	4.18.0	1
+Chrome	137.0.7151.55	desktop	Linux	5.11.0	1
+Chrome	137.0.7151.55	desktop	Linux	5.19.0	1
+Chrome	137.0.7151.55	desktop	Linux	6.12.11	1
+Chrome	137.0.7151.55	desktop	Linux	6.12.12	1
+Chrome	137.0.7151.55	desktop	Linux	6.12.20	1
+Chrome	137.0.7151.55	desktop	Linux	6.12.34	1
+Chrome	137.0.7151.55	desktop	Linux	6.12.37	1
+Chrome	137.0.7151.55	desktop	Linux	6.14.10	1
+Chrome	137.0.7151.55	desktop	Linux	6.14.11	1
+Chrome	137.0.7151.55	desktop	Linux	6.14.4	1
+Chrome	137.0.7151.55	desktop	Linux	6.14.6	1
+Chrome	137.0.7151.55	desktop	Linux	6.14.7	1
+Chrome	137.0.7151.55	desktop	Linux	6.14.8	1
+Chrome	137.0.7151.55	desktop	Linux	6.15.0	1
+Chrome	137.0.7151.55	desktop	Linux	6.6.9	1
+Chrome	137.0.7151.55	desktop	Linux	6.8.9	1
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 11.6	1
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 12.5	1
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 12.6	1
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 12.7	1
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 13.0	1
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 13.3	1
+Chrome	137.0.7151.55	desktop	Macintosh	Intel 14.0	1
+Chrome	137.0.7151.55	mobile	Android	11.0	1
+Chrome	137.0.7151.55	mobile	Linux	6.8.0	1
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 11.7	1
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 12.3	1
+Chrome	137.0.7151.56	desktop	Macintosh	Intel 12.4	1
+Chrome	137.0.7151.56	mobile	Android	11.0.0	1
+Chrome	137.0.7151.56	mobile	Android	14.0.0	1
+Chrome	137.0.7151.56	mobile	Windows	10	1
+Chrome	137.0.7151.56	tablet	Android	14.0.0	1
+Chrome	137.0.7151.57	desktop	Macintosh	Intel 12.1	1
+Chrome	137.0.7151.57	desktop	Macintosh	Intel 12.4	1
+Chrome	137.0.7151.57	desktop	Macintosh	Intel 13.0	1
+Chrome	137.0.7151.57	desktop	Macintosh	Intel 13.4	1
+Chrome	137.0.7151.57	desktop	Macintosh	Intel 13.5	1
+Chrome	137.0.7151.57	desktop	Macintosh	Intel 13.6	1
+Chrome	137.0.7151.57	desktop	Macintosh	Intel 14.2	1
+Chrome	137.0.7151.57	desktop	Macintosh	Intel 14.3	1
+Chrome	137.0.7151.6	desktop	Linux	5.14.0	1
+Chrome	137.0.7151.6	desktop	Windows	11	1
+Chrome	137.0.7151.60	desktop	Windows	11	1
+Chrome	137.0.7151.61	mobile	Android	11.0.0	1
+Chrome	137.0.7151.61	mobile	Android	12	1
+Chrome	137.0.7151.61	mobile	Android	15.0.0	1
+Chrome	137.0.7151.61	tablet	Android	12.0.0	1
+Chrome	137.0.7151.63	desktop	Windows	10	1
+Chrome	137.0.7151.65	desktop	Chrome OS	x86_64 16267.31.0	1
+Chrome	137.0.7151.68	desktop	Linux	4.15.0	1
+Chrome	137.0.7151.68	desktop	Linux	5.10.0	1
+Chrome	137.0.7151.68	desktop	Linux	5.13.0	1
+Chrome	137.0.7151.68	desktop	Linux	5.14.18	1
+Chrome	137.0.7151.68	desktop	Linux	5.18.11	1
+Chrome	137.0.7151.68	desktop	Linux	6.1.124	1
+Chrome	137.0.7151.68	desktop	Linux	6.1.134	1
+Chrome	137.0.7151.68	desktop	Linux	6.11.7	1
+Chrome	137.0.7151.68	desktop	Linux	6.12.12	1
+Chrome	137.0.7151.68	desktop	Linux	6.12.16	1
+Chrome	137.0.7151.68	desktop	Linux	6.12.28	1
+Chrome	137.0.7151.68	desktop	Linux	6.12.31	1
+Chrome	137.0.7151.68	desktop	Linux	6.13.2	1
+Chrome	137.0.7151.68	desktop	Linux	6.6.80	1
+Chrome	137.0.7151.68	desktop	Linux	6.6.90	1
+Chrome	137.0.7151.68	desktop	Linux	6.7.5	1
+Chrome	137.0.7151.68	desktop	Linux	6.9.3	1
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 11.4	1
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 12.2	1
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 12.4	1
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 12.6	1
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 13.3	1
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 13.7	1
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 14.1	1
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 14.2	1
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 14.4	1
+Chrome	137.0.7151.68	desktop	Macintosh	Intel 15.1	1
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 11.0	1
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 11.2	1
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 11.4	1
+Chrome	137.0.7151.69	desktop	Macintosh	Intel 12.0	1
+Chrome	137.0.7151.69	mobile	Android	11.0	1
+Chrome	137.0.7151.69	mobile	Android	6.0	1
+Chrome	137.0.7151.69	mobile	Macintosh	 13.5	1
+Chrome	137.0.7151.69	mobile	Macintosh	 15.1	1
+Chrome	137.0.7151.69	mobile	Macintosh	 15.5	1
+Chrome	137.0.7151.69	mobile	Windows	10	1
+Chrome	137.0.7151.69	smart tv	Windows	11	1
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 11.6	1
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 12.0	1
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 12.5	1
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 13.4	1
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 13.5	1
+Chrome	137.0.7151.70	desktop	Macintosh	Intel 13.6	1
+Chrome	137.0.7151.72	desktop	Windows	10	1
+Chrome	137.0.7151.72	mobile	Android	16.0.0	1
+Chrome	137.0.7151.72	mobile	Android	9	1
+Chrome	137.0.7151.72	tablet	Android	13.0.0	1
+Chrome	137.0.7151.72	tablet	Android	8.1.0	1
+Chrome	137.0.7151.73	mobile	Android	8.1.0	1
+Chrome	137.0.7151.73	mobile	Android	9	1
+Chrome	137.0.7151.73	tablet	Android	12.0.0	1
+Chrome	137.0.7151.79	mobile	iOS	16.7.10	1
+Chrome	137.0.7151.79	mobile	iOS	17.5.1	1
+Chrome	137.0.7151.79	mobile	iOS	17.6.1	1
+Chrome	137.0.7151.79	mobile	iOS	18.1.1	1
+Chrome	137.0.7151.79	mobile	iOS	18.3.0	1
+Chrome	137.0.7151.79	mobile	iOS	18.4.0	1
+Chrome	137.0.7151.79	tablet	iOS	17.7.6	1
+Chrome	137.0.7151.79	tablet	iOS	17.7.8	1
+Chrome	137.0.7151.80	desktop	Chrome OS	x86_64 16267.37.0	1
+Chrome	137.0.7151.80	mobile	Android	15	1
+Chrome	137.0.7151.80	mobile	Android	15.0.0	1
+Chrome	137.0.7151.84	mobile	Android	14	1
+Chrome	137.0.7151.84	mobile	Android	14.0.0	1
+Chrome	137.0.7151.86	mobile	Chrome OS	x86_64 16267.43.0	1
+Chrome	137.0.7151.87	mobile	Android	13.0.0	1
+Chrome	137.0.7151.88	mobile	Android	12	1
+Chrome	137.0.7151.88	mobile	Android	6.0	1
+Chrome	137.0.7151.88	mobile	Android	8.1.0	1
+Chrome	137.0.7151.89	mobile	Android	16.0.0	1
+Chrome	137.0.7151.89	mobile	Android	9	1
+Chrome	137.0.7151.89	tablet	Android	10.0.0	1
+Chrome	137.0.7151.90	desktop	Windows	Server 2003	1
+Chrome	137.0.7151.90	mobile	Android	10	1
+Chrome	137.0.7151.90	mobile	Android	16	1
+Chrome	137.0.7151.90	mobile	Android	8.0.0	1
+Chrome	137.0.7151.90	tablet	Android	12.0.0	1
+Chrome	137.0.7151.90	tablet	Android	15.0.0	1
+Chrome	137.0.7151.97	desktop	Windows	10	1
+Chrome	137.0.7151.97	mobile	Android	12.0.0	1
+Chrome	137.0.7151.97	mobile	Android	14.0.0	1
+Chrome	137.1.7151.123	mobile	Android	14.0.0	1
+Chrome	138.0.0.0	desktop	Linux	4.4.0	1
+Chrome	138.0.0.0	desktop	Linux	5.14.0	1
+Chrome	138.0.0.0	desktop	Linux	5.15.167	1
+Chrome	138.0.0.0	desktop	Linux	5.15.185	1
+Chrome	138.0.0.0	desktop	Linux	5.15.9	1
+Chrome	138.0.0.0	desktop	Linux	6.0.12	1
+Chrome	138.0.0.0	desktop	Linux	6.1.140	1
+Chrome	138.0.0.0	desktop	Linux	6.10.14	1
+Chrome	138.0.0.0	desktop	Linux	6.10.6	1
+Chrome	138.0.0.0	desktop	Linux	6.12.25	1
+Chrome	138.0.0.0	desktop	Linux	6.12.3	1
+Chrome	138.0.0.0	desktop	Linux	6.12.36	1
+Chrome	138.0.0.0	desktop	Linux	6.12.38	1
+Chrome	138.0.0.0	desktop	Linux	6.12.39	1
+Chrome	138.0.0.0	desktop	Linux	6.14.6	1
+Chrome	138.0.0.0	desktop	Linux	6.15.2	1
+Chrome	138.0.0.0	desktop	Linux	6.2.0	1
+Chrome	138.0.0.0	desktop	Linux	6.5.0	1
+Chrome	138.0.0.0	desktop	Linux	6.6.97	1
+Chrome	138.0.0.0	desktop	Macintosh	Intel 12.7	1
+Chrome	138.0.0.0	desktop	Macintosh	Intel 13.0	1
+Chrome	138.0.0.0	desktop	Macintosh	Intel 13.1	1
+Chrome	138.0.0.0	desktop	Macintosh	Intel 13.4	1
+Chrome	138.0.0.0	desktop	Macintosh	Intel 13.5	1
+Chrome	138.0.0.0	desktop	Macintosh	Intel 13.6	1
+Chrome	138.0.0.0	mobile	Android	6.0	1
+Chrome	138.0.0.0	mobile	Linux	6.15.3	1
+Chrome	138.0.0.0	mobile	Macintosh	 15.5	1
+Chrome	138.0.0.0	smart tv	Linux	(not set)	1
+Chrome	138.0.3351.47	mobile	iOS	18.2.0	1
+Chrome	138.0.3351.55	mobile	iOS	18.5.0	1
+Chrome	138.0.3351.70	mobile	iOS	18.5.0	1
+Chrome	138.0.3351.70	mobile	iOS	18.6.0	1
+Chrome	138.0.3351.70	mobile	iOS	26.0.0	1
+Chrome	138.0.3351.83	mobile	iOS	18.1.0	1
+Chrome	138.0.3351.83	mobile	iOS	18.5.0	1
+Chrome	138.0.7152.0	mobile	Android	10.0.0	1
+Chrome	138.0.7153.0	desktop	Linux	6.11.0	1
+Chrome	138.0.7157.1	desktop	Macintosh	Intel 15.4	1
+Chrome	138.0.7166.2	desktop	Linux	6.14.5	1
+Chrome	138.0.7166.2	desktop	Macintosh	Intel 15.5	1
+Chrome	138.0.7178.0	mobile	Android	15.0.0	1
+Chrome	138.0.7180.0	desktop	Macintosh	Intel 14.3	1
+Chrome	138.0.7180.2	desktop	Linux	6.8.0	1
+Chrome	138.0.7181.0	mobile	Android	9.0.0	1
+Chrome	138.0.7183.3	desktop	Windows	11	1
+Chrome	138.0.7191.0	desktop	Macintosh	Intel 11.6	1
+Chrome	138.0.7191.0	desktop	Macintosh	Intel 11.7	1
+Chrome	138.0.7191.0	desktop	Windows	10	1
+Chrome	138.0.7192.0	mobile	Android	11.0.0	1
+Chrome	138.0.7199.0	desktop	Linux	6.8.0	1
+Chrome	138.0.7201.0	desktop	Macintosh	Intel 13.4	1
+Chrome	138.0.7204.100	desktop	Linux	5.15.6	1
+Chrome	138.0.7204.100	desktop	Linux	5.15.90	1
+Chrome	138.0.7204.100	desktop	Linux	6.1.144	1
+Chrome	138.0.7204.100	desktop	Linux	6.10.11	1
+Chrome	138.0.7204.100	desktop	Linux	6.12.25	1
+Chrome	138.0.7204.100	desktop	Linux	6.12.28	1
+Chrome	138.0.7204.100	desktop	Linux	6.12.30	1
+Chrome	138.0.7204.100	desktop	Linux	6.12.35	1
+Chrome	138.0.7204.100	desktop	Linux	6.12.36	1
+Chrome	138.0.7204.100	desktop	Linux	6.12.38	1
+Chrome	138.0.7204.100	desktop	Linux	6.12.39	1
+Chrome	138.0.7204.100	desktop	Linux	6.13.3	1
+Chrome	138.0.7204.100	desktop	Linux	6.14.4	1
+Chrome	138.0.7204.100	desktop	Linux	6.14.6	1
+Chrome	138.0.7204.100	desktop	Linux	6.14.9	1
+Chrome	138.0.7204.100	desktop	Linux	6.15.0	1
+Chrome	138.0.7204.100	desktop	Linux	6.16.0	1
+Chrome	138.0.7204.100	desktop	Linux	6.4.0	1
+Chrome	138.0.7204.100	desktop	Linux	6.5.13	1
+Chrome	138.0.7204.100	desktop	Linux	6.6.15	1
+Chrome	138.0.7204.100	desktop	Linux	6.6.76	1
+Chrome	138.0.7204.100	desktop	Linux	6.6.87	1
+Chrome	138.0.7204.100	desktop	Linux	6.6.94	1
+Chrome	138.0.7204.100	desktop	Linux	6.7.1	1
+Chrome	138.0.7204.100	desktop	Linux	6.9.10	1
+Chrome	138.0.7204.100	desktop	Linux	6.9.3	1
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 11.6	1
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 12.3	1
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 12.5	1
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 13.0	1
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 13.3	1
+Chrome	138.0.7204.100	desktop	Macintosh	Intel 13.6	1
+Chrome	138.0.7204.100	mobile	Linux	6.11.0	1
+Chrome	138.0.7204.100	mobile	Linux	6.8.0	1
+Chrome	138.0.7204.100	mobile	Macintosh	 10.15	1
+Chrome	138.0.7204.101	desktop	Linux	5.15.0	1
+Chrome	138.0.7204.101	desktop	Macintosh	Intel 11.3	1
+Chrome	138.0.7204.101	mobile	Android	11	1
+Chrome	138.0.7204.101	mobile	Android	8.0.0	1
+Chrome	138.0.7204.101	mobile	Macintosh	 13.2	1
+Chrome	138.0.7204.101	mobile	Macintosh	 13.6	1
+Chrome	138.0.7204.101	mobile	Macintosh	 14.5	1
+Chrome	138.0.7204.101	mobile	Macintosh	 14.7	1
+Chrome	138.0.7204.101	mobile	Macintosh	 15.1	1
+Chrome	138.0.7204.101	mobile	Macintosh	 15.4	1
+Chrome	138.0.7204.102	desktop	Macintosh	 10.15	1
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 10.15	1
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 11.4	1
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 12.3	1
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 12.4	1
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 13.1	1
+Chrome	138.0.7204.102	desktop	Macintosh	Intel 13.3	1
+Chrome	138.0.7204.102	mobile	Android	8.0.0	1
+Chrome	138.0.7204.119	mobile	iOS	17.0.3	1
+Chrome	138.0.7204.119	mobile	iOS	17.2.1	1
+Chrome	138.0.7204.119	mobile	iOS	17.4.0	1
+Chrome	138.0.7204.119	tablet	iOS	17.4.1	1
+Chrome	138.0.7204.119	tablet	iOS	17.7.5	1
+Chrome	138.0.7204.119	tablet	iOS	17.7.6	1
+Chrome	138.0.7204.119	tablet	iOS	18.2.0	1
+Chrome	138.0.7204.119	tablet	iOS	18.3.0	1
+Chrome	138.0.7204.119	tablet	iOS	26.0.0	1
+Chrome	138.0.7204.139	mobile	Android	12	1
+Chrome	138.0.7204.139	mobile	Android	12.0.0	1
+Chrome	138.0.7204.14	mobile	Android	11.0.0	1
+Chrome	138.0.7204.143	desktop	Linux	6.12.37	1
+Chrome	138.0.7204.143	desktop	Linux	6.14.0	1
+Chrome	138.0.7204.143	desktop	Linux	6.14.9	1
+Chrome	138.0.7204.143	desktop	Linux	6.15.3	1
+Chrome	138.0.7204.143	desktop	Linux	6.15.6	1
+Chrome	138.0.7204.143	desktop	Macintosh	Intel 14.6	1
+Chrome	138.0.7204.143	desktop	Macintosh	Intel 14.7	1
+Chrome	138.0.7204.143	desktop	Macintosh	Intel 15.3	1
+Chrome	138.0.7204.143	mobile	Android	11.0	1
+Chrome	138.0.7204.143	mobile	Android	12	1
+Chrome	138.0.7204.143	mobile	Android	12.0.0	1
+Chrome	138.0.7204.143	mobile	Macintosh	 15.5	1
+Chrome	138.0.7204.146	mobile	Android	12	1
+Chrome	138.0.7204.146	mobile	Android	12.0.0	1
+Chrome	138.0.7204.146	mobile	Android	13	1
+Chrome	138.0.7204.146	mobile	Android	13.0.0	1
+Chrome	138.0.7204.146	mobile	Android	15.0.0	1
+Chrome	138.0.7204.146	mobile	Android	8.1.0	1
+Chrome	138.0.7204.148	desktop	Chrome OS	aarch64 16295.44.0	1
+Chrome	138.0.7204.15	desktop	Macintosh	Intel 13.2	1
+Chrome	138.0.7204.15	desktop	Windows	10	1
+Chrome	138.0.7204.15	desktop	Windows	11	1
+Chrome	138.0.7204.150	mobile	Android	15	1
+Chrome	138.0.7204.150	mobile	Android	15.0.0	1
+Chrome	138.0.7204.153	mobile	Android	15	1
+Chrome	138.0.7204.153	mobile	Android	15.0.0	1
+Chrome	138.0.7204.155	desktop	Chrome OS	aarch64 16295.51.0	1
+Chrome	138.0.7204.156	mobile	iOS	17.1.1	1
+Chrome	138.0.7204.156	mobile	iOS	17.7.1	1
+Chrome	138.0.7204.156	mobile	iOS	18.0.0	1
+Chrome	138.0.7204.156	mobile	iOS	18.0.1	1
+Chrome	138.0.7204.156	mobile	iOS	19.0.0	1
+Chrome	138.0.7204.156	tablet	iOS	17.5.1	1
+Chrome	138.0.7204.156	tablet	iOS	17.7.0	1
+Chrome	138.0.7204.156	tablet	iOS	17.7.8	1
+Chrome	138.0.7204.156	tablet	iOS	18.1.1	1
+Chrome	138.0.7204.156	tablet	iOS	18.2.0	1
+Chrome	138.0.7204.156	tablet	iOS	18.3.2	1
+Chrome	138.0.7204.156	tablet	iOS	26.0.0	1
+Chrome	138.0.7204.157	desktop	Linux	(not set)	1
+Chrome	138.0.7204.157	desktop	Linux	5.15.186	1
+Chrome	138.0.7204.157	desktop	Linux	5.19.0	1
+Chrome	138.0.7204.157	desktop	Linux	6.1.144	1
+Chrome	138.0.7204.157	desktop	Linux	6.12.0	1
+Chrome	138.0.7204.157	desktop	Linux	6.12.24	1
+Chrome	138.0.7204.157	desktop	Linux	6.12.25	1
+Chrome	138.0.7204.157	desktop	Linux	6.12.31	1
+Chrome	138.0.7204.157	desktop	Linux	6.12.37	1
+Chrome	138.0.7204.157	desktop	Linux	6.14.11	1
+Chrome	138.0.7204.157	desktop	Linux	6.14.5	1
+Chrome	138.0.7204.157	desktop	Linux	6.2.15	1
+Chrome	138.0.7204.157	desktop	Linux	6.6.87	1
+Chrome	138.0.7204.157	desktop	Linux	6.6.93	1
+Chrome	138.0.7204.157	desktop	Macintosh	 10.15	1
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 10.15	1
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 11.4	1
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 11.5	1
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 12.2	1
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 12.3	1
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 13.0	1
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 13.1	1
+Chrome	138.0.7204.157	desktop	Macintosh	Intel 16.0	1
+Chrome	138.0.7204.157	mobile	Android	16	1
+Chrome	138.0.7204.157	mobile	Linux	6.8.0	1
+Chrome	138.0.7204.157	mobile	Macintosh	 10.15	1
+Chrome	138.0.7204.157	mobile	Macintosh	 12.7	1
+Chrome	138.0.7204.157	mobile	Windows	10	1
+Chrome	138.0.7204.157	smart tv	Android	13.0.0	1
+Chrome	138.0.7204.157	tablet	Android	9.0.0	1
+Chrome	138.0.7204.158	desktop	Macintosh	 15.5	1
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 11.3	1
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 11.4	1
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 12.0	1
+Chrome	138.0.7204.158	desktop	Macintosh	Intel 12.2	1
+Chrome	138.0.7204.158	mobile	Macintosh	 15.4	1
+Chrome	138.0.7204.162	desktop	Linux	6.14.0	1
+Chrome	138.0.7204.162	desktop	Linux	6.8.0	1
+Chrome	138.0.7204.162	mobile	Android	14.0.0	1
+Chrome	138.0.7204.162	mobile	Android	15.0.0	1
+Chrome	138.0.7204.162	mobile	Android	16.0.0	1
+Chrome	138.0.7204.17	desktop	Chrome OS	aarch64 16295.12.0	1
+Chrome	138.0.7204.17	desktop	Chrome OS	x86_64 16295.12.0	1
+Chrome	138.0.7204.23	desktop	Linux	6.11.0	1
+Chrome	138.0.7204.23	desktop	Macintosh	Intel 13.2	1
+Chrome	138.0.7204.23	desktop	Macintosh	Intel 13.6	1
+Chrome	138.0.7204.25	mobile	Android	10.0.0	1
+Chrome	138.0.7204.25	mobile	Android	11.0.0	1
+Chrome	138.0.7204.25	mobile	Android	13	1
+Chrome	138.0.7204.25	mobile	Android	13.0.0	1
+Chrome	138.0.7204.25	mobile	Android	14.0.0	1
+Chrome	138.0.7204.25	mobile	Android	8.1.0	1
+Chrome	138.0.7204.25	mobile	Android	9.0.0	1
+Chrome	138.0.7204.3	mobile	Android	11.0.0	1
+Chrome	138.0.7204.3	mobile	Android	13	1
+Chrome	138.0.7204.3	mobile	Android	13.0.0	1
+Chrome	138.0.7204.31	desktop	Chrome OS	aarch64 16295.23.0	1
+Chrome	138.0.7204.33	mobile	iOS	17.6.1	1
+Chrome	138.0.7204.33	mobile	iOS	18.1.1	1
+Chrome	138.0.7204.33	mobile	iOS	18.2.0	1
+Chrome	138.0.7204.33	mobile	iOS	18.2.1	1
+Chrome	138.0.7204.33	mobile	iOS	18.4.0	1
+Chrome	138.0.7204.33	mobile	iOS	18.4.1	1
+Chrome	138.0.7204.33	tablet	iOS	18.4.1	1
+Chrome	138.0.7204.33	tablet	iOS	19.0.0	1
+Chrome	138.0.7204.35	desktop	Linux	6.11.0	1
+Chrome	138.0.7204.35	desktop	Linux	6.14.11	1
+Chrome	138.0.7204.35	desktop	Macintosh	Intel 11.2	1
+Chrome	138.0.7204.35	desktop	Macintosh	Intel 14.2	1
+Chrome	138.0.7204.35	desktop	Macintosh	Intel 14.4	1
+Chrome	138.0.7204.35	desktop	Macintosh	Intel 14.6	1
+Chrome	138.0.7204.35	desktop	Macintosh	Intel 14.7	1
+Chrome	138.0.7204.35	desktop	Macintosh	Intel 15.3	1
+Chrome	138.0.7204.35	desktop	Macintosh	Intel 16.0	1
+Chrome	138.0.7204.35	mobile	Android	10.0.0	1
+Chrome	138.0.7204.35	mobile	Android	12	1
+Chrome	138.0.7204.35	mobile	Android	12.0.0	1
+Chrome	138.0.7204.35	mobile	Android	13	1
+Chrome	138.0.7204.35	mobile	Android	14	1
+Chrome	138.0.7204.35	mobile	Android	15	1
+Chrome	138.0.7204.35	mobile	Android	6.0.1	1
+Chrome	138.0.7204.35	mobile	Android	8.0.0	1
+Chrome	138.0.7204.35	mobile	Macintosh	 15.5	1
+Chrome	138.0.7204.41	desktop	Chrome OS	aarch64 16295.27.0	1
+Chrome	138.0.7204.42	mobile	Android	13	1
+Chrome	138.0.7204.42	mobile	Android	13.0.0	1
+Chrome	138.0.7204.42	mobile	Android	16.0.0	1
+Chrome	138.0.7204.42	mobile	Android	9	1
+Chrome	138.0.7204.42	mobile	Android	9.0.0	1
+Chrome	138.0.7204.46	mobile	Android	13	1
+Chrome	138.0.7204.46	tablet	Android	8.1.0	1
+Chrome	138.0.7204.49	desktop	Linux	5.14.18	1
+Chrome	138.0.7204.49	desktop	Linux	6.0.8	1
+Chrome	138.0.7204.49	desktop	Linux	6.1.141	1
+Chrome	138.0.7204.49	desktop	Linux	6.11.1	1
+Chrome	138.0.7204.49	desktop	Linux	6.11.11	1
+Chrome	138.0.7204.49	desktop	Linux	6.12.0	1
+Chrome	138.0.7204.49	desktop	Linux	6.12.11	1
+Chrome	138.0.7204.49	desktop	Linux	6.12.17	1
+Chrome	138.0.7204.49	desktop	Linux	6.12.31	1
+Chrome	138.0.7204.49	desktop	Linux	6.14.4	1
+Chrome	138.0.7204.49	desktop	Linux	6.15.1	1
+Chrome	138.0.7204.49	desktop	Linux	6.15.6	1
+Chrome	138.0.7204.49	desktop	Linux	6.4.0	1
+Chrome	138.0.7204.49	desktop	Linux	6.6.94	1
+Chrome	138.0.7204.49	desktop	Linux	6.7.5	1
+Chrome	138.0.7204.49	desktop	Linux	6.8.1	1
+Chrome	138.0.7204.49	desktop	Linux	6.8.9	1
+Chrome	138.0.7204.49	desktop	Linux	6.9.0	1
+Chrome	138.0.7204.49	desktop	Linux	6.9.7	1
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 11.5	1
+Chrome	138.0.7204.49	desktop	Macintosh	Intel 12.0	1
+Chrome	138.0.7204.49	mobile	Android	11	1
+Chrome	138.0.7204.49	mobile	Linux	6.8.0	1
+Chrome	138.0.7204.49	mobile	Macintosh	 12.7	1
+Chrome	138.0.7204.49	mobile	Macintosh	 14.5	1
+Chrome	138.0.7204.50	desktop	Macintosh	 10.15	1
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 11.2	1
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 11.4	1
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 11.6	1
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 12.1	1
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 12.2	1
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 12.6	1
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 13.1	1
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 13.2	1
+Chrome	138.0.7204.50	desktop	Macintosh	Intel 26.0	1
+Chrome	138.0.7204.50	mobile	Android	11	1
+Chrome	138.0.7204.50	mobile	Macintosh	 15.3	1
+Chrome	138.0.7204.51	desktop	Macintosh	 10.15	1
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 11.3	1
+Chrome	138.0.7204.51	desktop	Macintosh	Intel 12.4	1
+Chrome	138.0.7204.51	mobile	Macintosh	 10.15	1
+Chrome	138.0.7204.51	mobile	Macintosh	 15.5	1
+Chrome	138.0.7204.53	mobile	iOS	17.5.1	1
+Chrome	138.0.7204.53	mobile	iOS	17.7.0	1
+Chrome	138.0.7204.53	mobile	iOS	18.1.1	1
+Chrome	138.0.7204.53	mobile	iOS	18.3.0	1
+Chrome	138.0.7204.53	mobile	iOS	18.3.1	1
+Chrome	138.0.7204.53	mobile	iOS	18.3.2	1
+Chrome	138.0.7204.53	mobile	iOS	18.4.0	1
+Chrome	138.0.7204.53	mobile	iOS	18.6.0	1
+Chrome	138.0.7204.54	desktop	Chrome OS	x86_64 16295.31.0	1
+Chrome	138.0.7204.55	desktop	Windows	10	1
+Chrome	138.0.7204.55	desktop	Windows	11	1
+Chrome	138.0.7204.55	mobile	Android	15.0.0	1
+Chrome	138.0.7204.56	mobile	iOS	17.4.1	1
+Chrome	138.0.7204.56	mobile	iOS	18.0.0	1
+Chrome	138.0.7204.56	mobile	iOS	18.3.1	1
+Chrome	138.0.7204.56	tablet	iOS	17.2.0	1
+Chrome	138.0.7204.56	tablet	iOS	17.6.1	1
+Chrome	138.0.7204.56	tablet	iOS	17.7.1	1
+Chrome	138.0.7204.56	tablet	iOS	17.7.8	1
+Chrome	138.0.7204.56	tablet	iOS	18.4.1	1
+Chrome	138.0.7204.63	smart tv	Android	14.0.0	1
+Chrome	138.0.7204.63	tablet	Android	8.0.0	1
+Chrome	138.0.7204.64	tablet	Android	11.0.0	1
+Chrome	138.0.7204.64	tablet	Android	14.0.0	1
+Chrome	138.0.7204.67	desktop	Windows	Server 2003	1
+Chrome	138.0.7204.67	mobile	Android	10.0.0	1
+Chrome	138.0.7204.67	mobile	Android	11.0.0	1
+Chrome	138.0.7204.68	mobile	Android	13.0.0	1
+Chrome	138.0.7204.87	mobile	Android	10.0.0	1
+Chrome	138.0.7204.92	desktop	Linux	5.10.214	1
+Chrome	138.0.7204.92	desktop	Linux	5.14.0	1
+Chrome	138.0.7204.92	desktop	Linux	5.15.64	1
+Chrome	138.0.7204.92	desktop	Linux	5.19.0	1
+Chrome	138.0.7204.92	desktop	Linux	5.19.16	1
+Chrome	138.0.7204.92	desktop	Linux	5.4.141	1
+Chrome	138.0.7204.92	desktop	Linux	6.10.9	1
+Chrome	138.0.7204.92	desktop	Linux	6.11.2	1
+Chrome	138.0.7204.92	desktop	Linux	6.11.3	1
+Chrome	138.0.7204.92	desktop	Linux	6.11.9	1
+Chrome	138.0.7204.92	desktop	Linux	6.12.13	1
+Chrome	138.0.7204.92	desktop	Linux	6.12.3	1
+Chrome	138.0.7204.92	desktop	Linux	6.12.9	1
+Chrome	138.0.7204.92	desktop	Linux	6.13.7	1
+Chrome	138.0.7204.92	desktop	Linux	6.13.8	1
+Chrome	138.0.7204.92	desktop	Linux	6.14.2	1
+Chrome	138.0.7204.92	desktop	Linux	6.14.5	1
+Chrome	138.0.7204.92	desktop	Linux	6.14.7	1
+Chrome	138.0.7204.92	desktop	Linux	6.15.7	1
+Chrome	138.0.7204.92	desktop	Linux	6.2.15	1
+Chrome	138.0.7204.92	desktop	Linux	6.8.1	1
+Chrome	138.0.7204.92	desktop	Linux	6.8.12	1
+Chrome	138.0.7204.92	desktop	Macintosh	 10.15	1
+Chrome	138.0.7204.92	desktop	Macintosh	 15.5	1
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 10.15	1
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 11.2	1
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 11.6	1
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 12.4	1
+Chrome	138.0.7204.92	desktop	Macintosh	Intel 13.1	1
+Chrome	138.0.7204.92	mobile	Linux	6.15.4	1
+Chrome	138.0.7204.93	desktop	Macintosh	 14.6	1
+Chrome	138.0.7204.93	mobile	Macintosh	 10.15	1
+Chrome	138.0.7204.93	mobile	Macintosh	 16.0	1
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 12.0	1
+Chrome	138.0.7204.94	desktop	Macintosh	Intel 12.5	1
+Chrome	138.0.7204.94	mobile	Android	11.0	1
+Chrome	138.0.7204.96	desktop	Macintosh	Intel 14.6	1
+Chrome	138.0.7204.96	mobile	Android	11.0	1
+Chrome	138.0.7204.96	mobile	Android	6.0	1
+Chrome	138.0.7204.96	mobile	Windows	10	1
+Chrome	138.0.7204.96	smart tv	Windows	11	1
+Chrome	138.0.7204.97	desktop	Macintosh	Intel 14.1	1
+Chrome	138.0.7204.98	desktop	Macintosh	 10.15	1
+Chrome	138.0.7204.98	desktop	Macintosh	Intel 10.15	1
+Chrome	138.0.7204.98	mobile	Windows	10	1
+Chrome	139.0.0.0	desktop	Linux	6.12.11	1
+Chrome	139.0.0.0	desktop	Linux	6.15.1	1
+Chrome	139.0.0.0	desktop	Macintosh	Intel 10.15	1
+Chrome	139.0.0.0	desktop	Macintosh	Intel 14.7	1
+Chrome	139.0.0.0	mobile	Android	10	1
+Chrome	139.0.0.0	mobile	Android	9.0.0	1
+Chrome	139.0.7207.2	desktop	Linux	5.10.0	1
+Chrome	139.0.7213.0	desktop	Windows	11	1
+Chrome	139.0.7215.0	desktop	Macintosh	Intel 15.5	1
+Chrome	139.0.7217.1	desktop	Macintosh	Intel 15.5	1
+Chrome	139.0.7219.0	mobile	Android	10.0.0	1
+Chrome	139.0.7219.0	mobile	Android	11.0.0	1
+Chrome	139.0.7219.0	mobile	Android	14.0.0	1
+Chrome	139.0.7219.0	mobile	Android	8.0.0	1
+Chrome	139.0.7219.3	desktop	Macintosh	Intel 15.5	1
+Chrome	139.0.7219.4	desktop	Windows	11	1
+Chrome	139.0.7220.0	desktop	Macintosh	Intel 14.7	1
+Chrome	139.0.7227.0	desktop	Linux	6.14.9	1
+Chrome	139.0.7230.0	desktop	Macintosh	Intel 15.5	1
+Chrome	139.0.7231.0	desktop	Macintosh	Intel 14.6	1
+Chrome	139.0.7232.0	desktop	Linux	6.14.4	1
+Chrome	139.0.7232.3	desktop	Linux	6.11.0	1
+Chrome	139.0.7232.3	desktop	Macintosh	Intel 13.0	1
+Chrome	139.0.7232.3	desktop	Macintosh	Intel 15.0	1
+Chrome	139.0.7232.3	desktop	Windows	10	1
+Chrome	139.0.7233.0	desktop	Chrome OS	aarch64 16317.0.0	1
+Chrome	139.0.7234.0	desktop	Macintosh	Intel 14.7	1
+Chrome	139.0.7234.0	desktop	Macintosh	Intel 15.5	1
+Chrome	139.0.7236.0	desktop	Macintosh	Intel 13.5	1
+Chrome	139.0.7236.0	desktop	Macintosh	Intel 15.5	1
+Chrome	139.0.7237.0	desktop	Macintosh	Intel 15.5	1
+Chrome	139.0.7246.0	desktop	Linux	6.11.0	1
+Chrome	139.0.7246.0	desktop	Linux	6.12.0	1
+Chrome	139.0.7246.0	desktop	Linux	6.15.3	1
+Chrome	139.0.7246.0	mobile	Android	10.0.0	1
+Chrome	139.0.7246.0	mobile	Android	11.0.0	1
+Chrome	139.0.7246.0	mobile	Android	14.0.0	1
+Chrome	139.0.7246.0	mobile	Android	15.0.0	1
+Chrome	139.0.7246.2	desktop	Macintosh	Intel 13.7	1
+Chrome	139.0.7246.2	desktop	Macintosh	Intel 14.4	1
+Chrome	139.0.7246.2	desktop	Macintosh	Intel 14.5	1
+Chrome	139.0.7246.2	desktop	Macintosh	Intel 16.0	1
+Chrome	139.0.7247.0	desktop	Macintosh	Intel 15.5	1
+Chrome	139.0.7251.0	desktop	Macintosh	Intel 15.5	1
+Chrome	139.0.7251.0	desktop	Windows	11	1
+Chrome	139.0.7252.0	desktop	Macintosh	Intel 15.5	1
+Chrome	139.0.7252.0	mobile	Android	15.0.0	1
+Chrome	139.0.7253.1	desktop	Macintosh	Intel 13.7	1
+Chrome	139.0.7255.0	desktop	Linux	6.14.11	1
+Chrome	139.0.7255.0	desktop	Linux	6.15.3	1
+Chrome	139.0.7255.0	desktop	Macintosh	Intel 14.1	1
+Chrome	139.0.7255.0	desktop	Macintosh	Intel 14.3	1
+Chrome	139.0.7256.0	desktop	Linux	5.15.0	1
+Chrome	139.0.7256.0	desktop	Macintosh	Intel 14.5	1
+Chrome	139.0.7256.0	desktop	Windows	11	1
+Chrome	139.0.7256.0	mobile	Android	15.0.0	1
+Chrome	139.0.7257.0	desktop	Macintosh	Intel 15.3	1
+Chrome	139.0.7257.0	desktop	Macintosh	Intel 15.5	1
+Chrome	139.0.7257.0	desktop	Macintosh	Intel 15.6	1
+Chrome	139.0.7257.1	desktop	Windows	11	1
+Chrome	139.0.7258.0	desktop	Macintosh	Intel 14.4	1
+Chrome	139.0.7258.0	desktop	Macintosh	Intel 14.6	1
+Chrome	139.0.7258.0	desktop	Macintosh	Intel 15.4	1
+Chrome	139.0.7258.0	desktop	Macintosh	Intel 15.5	1
+Chrome	139.0.7258.0	desktop	Windows	10	1
+Chrome	139.0.7258.0	mobile	Android	11.0	1
+Chrome	139.0.7258.0	mobile	Android	6.0.1	1
+Chrome	139.0.7258.0	mobile	Macintosh	 15.5	1
+Chrome	139.0.7258.1	desktop	Windows	11	1
+Chrome	139.0.7258.3	mobile	Android	11	1
+Chrome	139.0.7258.3	tablet	Android	12.0.0	1
+Chrome	139.0.7258.30	mobile	iOS	26.0.0	1
+Chrome	139.0.7258.31	desktop	Linux	6.8.0	1
+Chrome	139.0.7258.31	desktop	Macintosh	Intel 15.4	1
+Chrome	139.0.7258.31	desktop	Macintosh	Intel 26.0	1
+Chrome	139.0.7258.31	mobile	Macintosh	 15.5	1
+Chrome	139.0.7258.32	mobile	Android	10	1
+Chrome	139.0.7258.32	mobile	Android	13	1
+Chrome	139.0.7258.32	mobile	Android	16	1
+Chrome	139.0.7258.32	tablet	Android	15.0.0	1
+Chrome	139.0.7258.41	tablet	Android	15.0.0	1
+Chrome	139.0.7258.42	desktop	Macintosh	Intel 26.0	1
+Chrome	139.0.7258.43	desktop	Chrome OS	aarch64 16328.25.0	1
+Chrome	139.0.7258.5	desktop	Linux	6.12.13	1
+Chrome	139.0.7258.5	desktop	Linux	6.5.0	1
+Chrome	139.0.7258.5	desktop	Macintosh	Intel 14.1	1
+Chrome	139.0.7258.5	desktop	Macintosh	Intel 14.2	1
+Chrome	139.0.7258.5	desktop	Macintosh	Intel 14.4	1
+Chrome	139.0.7258.5	desktop	Macintosh	Intel 15.0	1
+Chrome	139.0.7258.5	desktop	Macintosh	Intel 15.3	1
+Chrome	139.0.7258.5	desktop	Macintosh	Intel 15.4	1
+Chrome	139.0.7258.6	desktop	Windows	11	1
+Chrome	140.0.0.0	desktop	Macintosh	Intel 13.7	1
+Chrome	140.0.0.0	desktop	Macintosh	Intel 14.7	1
+Chrome	140.0.0.0	desktop	Macintosh	Intel 15.0	1
+Chrome	140.0.0.0	desktop	Macintosh	Intel 15.3	1
+Chrome	140.0.0.0	desktop	Windows	10	1
+Chrome	140.0.0.0	mobile	Android	10.0.0	1
+Chrome	140.0.0.0	mobile	Android	12.0.0	1
+Chrome	140.0.0.0	mobile	Android	13.0.0	1
+Chrome	140.0.7259.0	desktop	Linux	6.12.20	1
+Chrome	140.0.7259.0	desktop	Macintosh	Intel 16.0	1
+Chrome	140.0.7259.0	mobile	Android	13	1
+Chrome	140.0.7259.0	mobile	Android	15	1
+Chrome	140.0.7259.2	desktop	Linux	6.12.33	1
+Chrome	140.0.7259.2	desktop	Linux	6.12.37	1
+Chrome	140.0.7259.2	desktop	Linux	6.14.0	1
+Chrome	140.0.7259.2	desktop	Linux	6.15.2	1
+Chrome	140.0.7259.2	desktop	Linux	6.15.4	1
+Chrome	140.0.7259.2	desktop	Linux	6.6.76	1
+Chrome	140.0.7259.2	desktop	Macintosh	Intel 14.1	1
+Chrome	140.0.7259.2	desktop	Macintosh	Intel 15.2	1
+Chrome	140.0.7260.0	desktop	Macintosh	Intel 13.3	1
+Chrome	140.0.7260.0	desktop	Macintosh	Intel 13.7	1
+Chrome	140.0.7260.0	desktop	Macintosh	Intel 14.6	1
+Chrome	140.0.7260.0	desktop	Windows	10	1
+Chrome	140.0.7260.0	desktop	Windows	11	1
+Chrome	140.0.7260.0	mobile	Android	11.0.0	1
+Chrome	140.0.7260.0	mobile	Android	13.0.0	1
+Chrome	140.0.7261.0	desktop	Windows	10	1
+Chrome	140.0.7261.0	mobile	Android	15.0.0	1
+Chrome	140.0.7261.1	desktop	Macintosh	Intel 15.5	1
+Chrome	140.0.7261.1	mobile	Android	11.0	1
+Chrome	140.0.7261.1	mobile	Macintosh	 15.5	1
+Chrome	140.0.7262.0	desktop	Macintosh	Intel 14.5	1
+Chrome	140.0.7262.0	desktop	Macintosh	Intel 14.7	1
+Chrome	140.0.7262.0	desktop	Macintosh	Intel 26.0	1
+Chrome	140.0.7263.0	desktop	Linux	6.16.0	1
+Chrome	140.0.7263.0	desktop	Macintosh	Intel 12.6	1
+Chrome	140.0.7263.0	desktop	Macintosh	Intel 14.6	1
+Chrome	140.0.7263.0	desktop	Macintosh	Intel 15.3	1
+Chrome	140.0.7263.0	desktop	Windows	11	1
+Chrome	140.0.7264.0	desktop	Windows	11	1
+Chrome	140.0.7264.0	mobile	Android	14.0.0	1
+Chrome	140.0.7264.3	desktop	Windows	11	1
+Chrome	140.0.7265.0	desktop	Macintosh	Intel 26.0	1
+Chrome	140.0.7266.0	desktop	Windows	11	1
+Chrome	140.0.7267.0	desktop	Macintosh	Intel 15.1	1
+Chrome	140.0.7267.0	desktop	Macintosh	Intel 15.4	1
+Chrome	140.0.7267.0	desktop	Macintosh	Intel 15.5	1
+Chrome	140.0.7268.0	desktop	Macintosh	Intel 15.5	1
+Chrome	140.0.7268.0	desktop	Windows	11	1
+Chrome	140.0.7268.1	desktop	Macintosh	Intel 15.4	1
+Chrome	140.0.7269.0	desktop	Macintosh	Intel 12.7	1
+Chrome	140.0.7269.0	desktop	Macintosh	Intel 14.5	1
+Chrome	140.0.7269.0	desktop	Windows	11	1
+Chrome	140.0.7269.0	mobile	Android	14.0.0	1
+Chrome	140.0.7269.1	desktop	Macintosh	Intel 15.6	1
+Chrome	140.0.7269.2	desktop	Windows	11	1
+Chrome	140.0.7270.0	desktop	Macintosh	Intel 15.5	1
+Chrome	140.0.7270.0	desktop	Macintosh	Intel 26.0	1
+Chrome	140.0.7270.0	desktop	Windows	10	1
+Chrome	140.0.7270.0	mobile	Android	16.0.0	1
+Chrome	140.0.7271.0	desktop	Linux	6.15.3	1
+Chrome	140.0.7271.0	desktop	Macintosh	Intel 13.7	1
+Chrome	140.0.7271.0	desktop	Macintosh	Intel 15.2	1
+Chrome	140.0.7271.0	desktop	Windows	11	1
+Chrome	140.0.7271.0	mobile	Android	15.0.0	1
+Chrome	140.0.7271.1	desktop	Macintosh	Intel 15.5	1
+Chrome	140.0.7271.1	desktop	Windows	11	1
+Chrome	140.0.7272.0	desktop	Macintosh	Intel 15.1	1
+Chrome	140.0.7272.0	desktop	Macintosh	Intel 15.5	1
+Chrome	140.0.7272.0	desktop	Macintosh	Intel 26.0	1
+Chrome	140.0.7272.1	desktop	Macintosh	Intel 15.5	1
+Chrome	140.0.7272.1	desktop	Windows	11	1
+Chrome	140.0.7273.0	desktop	Macintosh	Intel 14.7	1
+Chrome	140.0.7273.0	desktop	Macintosh	Intel 15.5	1
+Chrome	140.0.7273.0	mobile	Android	11.0.0	1
+Chrome	140.0.7273.1	desktop	Macintosh	Intel 15.5	1
+Chrome	140.0.7273.1	desktop	Macintosh	Intel 26.0	1
+Chrome	140.0.7274.0	desktop	Windows	10	1
+Chrome	140.0.7274.0	desktop	Windows	11	1
+Chrome	140.0.7274.1	desktop	Windows	11	1
+Chrome	140.0.7275.0	desktop	Macintosh	Intel 13.7	1
+Chrome	140.0.7275.0	desktop	Macintosh	Intel 15.5	1
+Chrome	140.0.7275.0	desktop	Macintosh	Intel 15.6	1
+Chrome	140.0.7275.0	desktop	Windows	10	1
+Chrome	140.0.7275.2	desktop	Macintosh	Intel 15.3	1
+Chrome	140.0.7276.0	desktop	Macintosh	Intel 15.5	1
+Chrome	140.0.7276.0	desktop	Windows	10	1
+Chrome	140.0.7277.0	desktop	Macintosh	Intel 15.1	1
+Chrome	140.0.7277.0	desktop	Windows	11	1
+Chrome	140.0.7277.0	mobile	Android	15.0.0	1
+Chrome	140.0.7278.0	desktop	Windows	10	1
+Chrome	140.0.7280.0	desktop	Linux	6.12.27	1
+Chrome	140.0.7280.0	desktop	Macintosh	Intel 14.3	1
+Chrome	140.0.7280.0	desktop	Macintosh	Intel 14.7	1
+Chrome	140.0.7280.0	desktop	Windows	10	1
+Chrome	140.0.7280.0	mobile	Android	15.0.0	1
+Chrome	140.0.7280.1	desktop	Windows	10	1
+Chrome	140.0.7281.0	desktop	Macintosh	Intel 14.3	1
+Chrome	140.0.7281.0	desktop	Macintosh	Intel 15.4	1
+Chrome	140.0.7281.0	desktop	Windows	11	1
+Chrome	140.0.7281.1	desktop	Macintosh	Intel 15.5	1
+Chrome	140.0.7282.0	desktop	Macintosh	Intel 15.4	1
+Chrome	140.0.7282.0	desktop	Macintosh	Intel 26.0	1
+Chrome	140.0.7282.0	desktop	Windows	10	1
+Chrome	140.0.7283.0	desktop	Macintosh	Intel 15.1	1
+Chrome	140.0.7283.0	desktop	Windows	11	1
+Chrome	140.0.7283.0	mobile	Android	15.0.0	1
+Chrome	140.0.7284.0	desktop	Macintosh	Intel 14.6	1
+Chrome	140.0.7284.2	mobile	Android	10.0.0	1
+Chrome	140.0.7285.0	desktop	Linux	6.15.4	1
+Chrome	140.0.7285.0	desktop	Windows	10	1
+Chrome	140.0.7285.0	mobile	Android	11.0.0	1
+Chrome	140.0.7285.2	desktop	Macintosh	Intel 15.5	1
+Chrome	140.0.7286.0	desktop	Macintosh	Intel 14.7	1
+Chrome	140.0.7286.0	desktop	Macintosh	Intel 15.1	1
+Chrome	140.0.7286.0	desktop	Windows	11	1
+Chrome	140.0.7286.0	mobile	Android	13.0.0	1
+Chrome	140.0.7287.0	desktop	Windows	11	1
+Chrome	140.0.7288.0	desktop	Macintosh	Intel 14.6	1
+Chrome	140.0.7288.0	desktop	Macintosh	Intel 15.2	1
+Chrome	140.0.7288.0	desktop	Macintosh	Intel 15.5	1
+Chrome	140.0.7288.0	desktop	Windows	11	1
+Chrome	140.0.7289.0	desktop	Macintosh	Intel 15.5	1
+Chrome	140.0.7289.0	desktop	Windows	10	1
+Chrome	140.0.7289.0	desktop	Windows	11	1
+Chrome	140.0.7289.0	mobile	Android	15.0.0	1
+Chrome	140.0.7290.0	desktop	Windows	11	1
+Chrome	140.0.7290.1	desktop	Macintosh	Intel 15.5	1
+Chrome	140.0.7291.0	desktop	Linux	6.15.5	1
+Chrome	140.0.7292.0	desktop	Macintosh	Intel 14.7	1
+Chrome	140.0.7292.0	desktop	Windows	11	1
+Chrome	140.0.7293.0	desktop	Macintosh	Intel 13.0	1
+Chrome	140.0.7293.0	mobile	Android	13.0.0	1
+Chrome	140.0.7293.0	mobile	Android	15.0.0	1
+Chrome	140.0.7294.0	desktop	Linux	6.15.5	1
+Chrome	140.0.7295.0	desktop	Macintosh	Intel 15.2	1
+Chrome	140.0.7295.0	desktop	Macintosh	Intel 15.5	1
+Chrome	140.0.7295.0	desktop	Macintosh	Intel 26.0	1
+Chrome	140.0.7295.0	mobile	Android	13.0.0	1
+Chrome	140.0.7296.0	desktop	Macintosh	Intel 15.4	1
+Chrome	140.0.7297.0	desktop	Macintosh	Intel 26.0	1
+Chrome	140.0.7297.0	desktop	Windows	11	1
+Chrome	140.0.7298.0	desktop	Macintosh	Intel 12.4	1
+Chrome	140.0.7298.0	desktop	Windows	11	1
+Chrome	140.0.7298.0	mobile	Android	11.0	1
+Chrome	140.0.7298.0	mobile	Macintosh	 15.5	1
+Chrome	140.0.7299.0	desktop	Macintosh	Intel 13.6	1
+Chrome	140.0.7299.0	desktop	Macintosh	Intel 13.7	1
+Chrome	140.0.7299.0	desktop	Macintosh	Intel 14.3	1
+Chrome	140.0.7299.0	desktop	Macintosh	Intel 14.6	1
+Chrome	140.0.7299.0	desktop	Macintosh	Intel 15.4	1
+Chrome	140.0.7299.0	mobile	Android	10.0.0	1
+Chrome	140.0.7299.0	mobile	Android	11.0	1
+Chrome	140.0.7299.0	mobile	Android	14.0.0	1
+Chrome	140.0.7299.0	mobile	Windows	11	1
+Chrome	140.0.7299.0	tablet	Android	14.0.0	1
+Chrome	140.0.7299.0	tablet	Android	15.0.0	1
+Chrome	140.0.7300.0	desktop	Macintosh	Intel 26.0	1
+Chrome	140.0.7301.0	desktop	Windows	11	1
+Chrome	140.0.7301.0	mobile	Android	11.0.0	1
+Chrome	140.0.7302.0	desktop	Macintosh	Intel 15.5	1
+Chrome	140.0.7303.0	desktop	Windows	11	1
+Chrome	140.0.7303.0	mobile	Android	11.0.0	1
+Chrome	140.0.7304.0	desktop	Macintosh	Intel 15.5	1
+Chrome	140.0.7304.0	mobile	Android	16.0.0	1
+Chrome	140.0.7306.0	desktop	Linux	6.15.6	1
+Chrome	140.0.7306.0	desktop	Macintosh	Intel 15.5	1
+Chrome	140.0.7306.0	desktop	Windows	11	1
+Chrome	140.0.7307.1	desktop	Windows	10	1
+Chrome	140.0.7308.0	desktop	Macintosh	Intel 14.6	1
+Chrome	18.0.1025.133	mobile	Android	10	1
+Chrome	18.0.1025.133	mobile	Android	7.1.1	1
+Chrome	39.0.1101.1504	desktop	Windows	7	1
+Chrome	39.0.1311.1482	desktop	Macintosh	Intel 10.12	1
+Chrome	39.0.1337.1183	desktop	Macintosh	Intel 10.12	1
+Chrome	39.0.1440.1269	desktop	Macintosh	Intel 10.12	1
+Chrome	39.0.1653.1905	desktop	Macintosh	Intel 10.13	1
+Chrome	39.0.2150.1704	desktop	Macintosh	Intel 10.12	1
+Chrome	39.0.2193.1901	desktop	Macintosh	Intel 10.14	1
+Chrome	39.0.2645.1155	desktop	Windows	7	1
+Chrome	39.0.2784.1739	desktop	Macintosh	Intel 10.13	1
+Chrome	39.0.3057.1265	desktop	Macintosh	Intel 10.13	1
+Chrome	39.0.3489.1203	desktop	Macintosh	Intel 10.12	1
+Chrome	39.0.3762.1500	desktop	Macintosh	Intel 10.12	1
+Chrome	39.0.6077.1863	desktop	Windows	7	1
+Chrome	39.0.6317.1625	desktop	Macintosh	Intel 10.12	1
+Chrome	39.0.7640.1315	desktop	Macintosh	Intel 10.13	1
+Chrome	39.0.8341.1642	desktop	Windows	7	1
+Chrome	39.0.8359.1518	desktop	Macintosh	Intel 10.13	1
+Chrome	39.0.8383.1308	desktop	Macintosh	Intel 10.13	1
+Chrome	39.0.8562.1828	desktop	Macintosh	Intel 10.12	1
+Chrome	39.0.8843.1552	desktop	Macintosh	Intel 10.12	1
+Chrome	39.0.8958.1157	desktop	Macintosh	Intel 10.12	1
+Chrome	39.0.9877.1310	desktop	Windows	7	1
+Chrome	40.0.1658.1879	desktop	Macintosh	Intel 10.13	1
+Chrome	40.0.2034.1633	desktop	Macintosh	Intel 10.12	1
+Chrome	40.0.3252.1727	desktop	Windows	7	1
+Chrome	40.0.3819.1165	desktop	Macintosh	Intel 10.12	1
+Chrome	40.0.4114.1589	desktop	Macintosh	Intel 10.13	1
+Chrome	40.0.6018.1399	desktop	Macintosh	Intel 10.12	1
+Chrome	40.0.6789.1569	desktop	Macintosh	Intel 10.13	1
+Chrome	40.0.7061.1721	desktop	Windows	7	1
+Chrome	40.0.7064.1360	desktop	Macintosh	Intel 10.13	1
+Chrome	40.0.7228.1796	desktop	Windows	7	1
+Chrome	40.0.7628.1498	desktop	Windows	7	1
+Chrome	40.0.7957.1348	desktop	Macintosh	Intel 10.13	1
+Chrome	40.0.9431.1222	desktop	Macintosh	Intel 10.12	1
+Chrome	40.0.9712.1623	desktop	Macintosh	Intel 10.13	1
+Chrome	41.0.1157.1338	desktop	Macintosh	Intel 10.12	1
+Chrome	41.0.1656.1596	desktop	Macintosh	Intel 10.13	1
+Chrome	41.0.1920.1018	desktop	Macintosh	Intel 10.14	1
+Chrome	41.0.2228.0	mobile	Android	12.0.0	1
+Chrome	41.0.2504.1098	desktop	Macintosh	Intel 10.12	1
+Chrome	41.0.3004.1632	desktop	Macintosh	Intel 10.14	1
+Chrome	41.0.3021.1886	desktop	Macintosh	Intel 10.14	1
+Chrome	41.0.3357.1001	desktop	Macintosh	Intel 10.12	1
+Chrome	41.0.3399.1521	desktop	Macintosh	Intel 10.12	1
+Chrome	41.0.4598.1165	desktop	Macintosh	Intel 10.14	1
+Chrome	41.0.4628.1324	desktop	Macintosh	Intel 10.13	1
+Chrome	41.0.4974.1797	desktop	Macintosh	Intel 10.14	1
+Chrome	41.0.6344.1256	desktop	Macintosh	Intel 10.12	1
+Chrome	42.0.1078.1680	desktop	Windows	7	1
+Chrome	42.0.1396.1956	desktop	Macintosh	Intel 10.12	1
+Chrome	42.0.2298.1830	desktop	Macintosh	Intel 10.13	1
+Chrome	42.0.2675.1671	desktop	Macintosh	Intel 10.14	1
+Chrome	42.0.3115.1294	desktop	Macintosh	Intel 10.12	1
+Chrome	42.0.3553.1240	desktop	Macintosh	Intel 10.13	1
+Chrome	42.0.5693.1996	desktop	Macintosh	Intel 10.12	1
+Chrome	42.0.5734.1910	desktop	Macintosh	Intel 10.12	1
+Chrome	42.0.6431.1385	desktop	Macintosh	Intel 10.14	1
+Chrome	42.0.6706.1523	desktop	Macintosh	Intel 10.14	1
+Chrome	42.0.7802.1449	desktop	Windows	7	1
+Chrome	42.0.8031.1951	desktop	Macintosh	Intel 10.12	1
+Chrome	42.0.9214.1242	desktop	Macintosh	Intel 10.14	1
+Chrome	42.0.9744.1873	desktop	Macintosh	Intel 10.12	1
+Chrome	43.0.1044.1329	desktop	Macintosh	Intel 10.14	1
+Chrome	43.0.1289.1198	desktop	Windows	7	1
+Chrome	43.0.2013.1131	desktop	Windows	7	1
+Chrome	43.0.5023.1701	desktop	Macintosh	Intel 10.13	1
+Chrome	43.0.5195.1768	desktop	Macintosh	Intel 10.12	1
+Chrome	43.0.6402.1882	desktop	Macintosh	Intel 10.13	1
+Chrome	43.0.8428.1848	desktop	Macintosh	Intel 10.12	1
+Chrome	44.0.1108.1082	desktop	Macintosh	Intel 10.12	1
+Chrome	44.0.1170.1240	desktop	Macintosh	Intel 10.12	1
+Chrome	44.0.1240.1730	desktop	Macintosh	Intel 10.12	1
+Chrome	44.0.1419.1292	desktop	Macintosh	Intel 10.12	1
+Chrome	44.0.1906.1162	desktop	Windows	7	1
+Chrome	44.0.2897.1556	desktop	Macintosh	Intel 10.12	1
+Chrome	44.0.3967.1517	desktop	Macintosh	Intel 10.12	1
+Chrome	44.0.4240.1199	desktop	Macintosh	Intel 10.12	1
+Chrome	44.0.5038.1519	desktop	Macintosh	Intel 10.14	1
+Chrome	44.0.5498.1748	desktop	Macintosh	Intel 10.14	1
+Chrome	44.0.5894.1209	desktop	Macintosh	Intel 10.12	1
+Chrome	44.0.6560.1296	desktop	Macintosh	Intel 10.13	1
+Chrome	44.0.6571.1857	desktop	Macintosh	Intel 10.13	1
+Chrome	44.0.7324.1031	desktop	Macintosh	Intel 10.13	1
+Chrome	44.0.8696.1421	desktop	Windows	7	1
+Chrome	44.0.9496.1778	desktop	Macintosh	Intel 10.12	1
+Chrome	44.0.9813.1374	desktop	Macintosh	Intel 10.12	1
+Chrome	45.0.2126.1872	desktop	Macintosh	Intel 10.12	1
+Chrome	45.0.2362.1076	desktop	Macintosh	Intel 10.13	1
+Chrome	45.0.3332.1968	desktop	Macintosh	Intel 10.12	1
+Chrome	45.0.4030.1139	desktop	Macintosh	Intel 10.14	1
+Chrome	45.0.4308.1810	desktop	Macintosh	Intel 10.14	1
+Chrome	45.0.5015.1209	desktop	Macintosh	Intel 10.12	1
+Chrome	45.0.5092.1233	desktop	Macintosh	Intel 10.13	1
+Chrome	45.0.5146.1355	desktop	Macintosh	Intel 10.13	1
+Chrome	45.0.5188.1626	desktop	Macintosh	Intel 10.13	1
+Chrome	45.0.5503.1918	desktop	Windows	7	1
+Chrome	45.0.6638.1991	desktop	Macintosh	Intel 10.13	1
+Chrome	45.0.8008.1919	desktop	Windows	7	1
+Chrome	45.0.9889.1274	desktop	Macintosh	Intel 10.14	1
+Chrome	46.0.1886.1753	desktop	Macintosh	Intel 10.13	1
+Chrome	46.0.2032.1846	desktop	Macintosh	Intel 10.12	1
+Chrome	46.0.2289.1235	desktop	Windows	7	1
+Chrome	46.0.2368.1712	desktop	Macintosh	Intel 10.14	1
+Chrome	46.0.4278.1262	desktop	Macintosh	Intel 10.14	1
+Chrome	46.0.4886.1016	desktop	Macintosh	Intel 10.13	1
+Chrome	46.0.5821.1864	desktop	Windows	7	1
+Chrome	46.0.7181.1568	desktop	Macintosh	Intel 10.12	1
+Chrome	46.0.7225.1052	desktop	Macintosh	Intel 10.13	1
+Chrome	46.0.9039.1697	desktop	Macintosh	Intel 10.12	1
+Chrome	46.0.9643.1845	desktop	Macintosh	Intel 10.13	1
+Chrome	47.0.1145.1266	desktop	Macintosh	Intel 10.14	1
+Chrome	47.0.1840.1948	desktop	Macintosh	Intel 10.14	1
+Chrome	47.0.1860.1953	desktop	Windows	7	1
+Chrome	47.0.2526.106	desktop	Windows	7	1
+Chrome	47.0.2526.111	desktop	Windows	7	1
+Chrome	47.0.2618.1974	desktop	Macintosh	Intel 10.12	1
+Chrome	47.0.3165.1764	desktop	Windows	7	1
+Chrome	47.0.3597.1676	desktop	Macintosh	Intel 10.12	1
+Chrome	47.0.3606.1107	desktop	Windows	7	1
+Chrome	47.0.3661.1754	desktop	Macintosh	Intel 10.12	1
+Chrome	47.0.5007.1052	desktop	Macintosh	Intel 10.13	1
+Chrome	47.0.5055.1547	desktop	Macintosh	Intel 10.13	1
+Chrome	47.0.6532.1945	desktop	Macintosh	Intel 10.14	1
+Chrome	47.0.6876.1962	desktop	Macintosh	Intel 10.12	1
+Chrome	47.0.7668.1152	desktop	Macintosh	Intel 10.14	1
+Chrome	47.0.8715.1515	desktop	Macintosh	Intel 10.13	1
+Chrome	47.0.8775.1263	desktop	Macintosh	Intel 10.12	1
+Chrome	47.0.9495.1277	desktop	Windows	7	1
+Chrome	47.0.9698.1183	desktop	Windows	7	1
+Chrome	48.0.1807.1483	desktop	Macintosh	Intel 10.12	1
+Chrome	48.0.1857.1531	desktop	Macintosh	Intel 10.12	1
+Chrome	48.0.1901.1744	desktop	Macintosh	Intel 10.12	1
+Chrome	48.0.2342.1343	desktop	Windows	7	1
+Chrome	48.0.2700.1421	desktop	Windows	7	1
+Chrome	48.0.3839.1236	desktop	Windows	7	1
+Chrome	48.0.4659.1939	desktop	Windows	7	1
+Chrome	48.0.5280.1380	desktop	Macintosh	Intel 10.12	1
+Chrome	48.0.5745.1393	desktop	Macintosh	Intel 10.14	1
+Chrome	48.0.6450.1981	desktop	Macintosh	Intel 10.13	1
+Chrome	48.0.7136.1307	desktop	Macintosh	Intel 10.12	1
+Chrome	48.0.7156.1068	desktop	Macintosh	Intel 10.14	1
+Chrome	48.0.7525.1404	desktop	Macintosh	Intel 10.12	1
+Chrome	48.0.7529.1500	desktop	Macintosh	Intel 10.14	1
+Chrome	48.0.7563.1630	desktop	Macintosh	Intel 10.12	1
+Chrome	48.0.8408.1860	desktop	Macintosh	Intel 10.12	1
+Chrome	48.0.8790.1322	desktop	Macintosh	Intel 10.12	1
+Chrome	49.0.1128.1043	desktop	Windows	7	1
+Chrome	49.0.2538.1754	desktop	Macintosh	Intel 10.13	1
+Chrome	49.0.2623.110	desktop	Windows	7	1
+Chrome	49.0.2623.87	desktop	Windows	7	1
+Chrome	49.0.2713.1239	desktop	Macintosh	Intel 10.12	1
+Chrome	49.0.3834.1832	desktop	Macintosh	Intel 10.12	1
+Chrome	49.0.4324.1798	desktop	Windows	7	1
+Chrome	49.0.5425.1650	desktop	Macintosh	Intel 10.13	1
+Chrome	49.0.5771.1104	desktop	Macintosh	Intel 10.12	1
+Chrome	49.0.6063.1451	desktop	Macintosh	Intel 10.12	1
+Chrome	49.0.6143.1603	desktop	Macintosh	Intel 10.12	1
+Chrome	49.0.6681.1353	desktop	Macintosh	Intel 10.12	1
+Chrome	49.0.8244.1728	desktop	Macintosh	Intel 10.14	1
+Chrome	49.0.8598.1194	desktop	Macintosh	Intel 10.12	1
+Chrome	49.0.9089.1266	desktop	Macintosh	Intel 10.14	1
+Chrome	49.0.9874.1116	desktop	Macintosh	Intel 10.12	1
+Chrome	49.0.9925.1361	desktop	Macintosh	Intel 10.13	1
+Chrome	50.0.0.0	mobile	Android	10	1
+Chrome	50.0.1810.1146	desktop	Macintosh	Intel 10.13	1
+Chrome	50.0.3586.1150	desktop	Macintosh	Intel 10.14	1
+Chrome	50.0.3981.1960	desktop	Macintosh	Intel 10.13	1
+Chrome	50.0.4797.1691	desktop	Windows	7	1
+Chrome	50.0.6232.1985	desktop	Windows	7	1
+Chrome	50.0.6527.1755	desktop	Windows	7	1
+Chrome	50.0.6668.1121	desktop	Macintosh	Intel 10.12	1
+Chrome	50.0.6910.1621	desktop	Windows	7	1
+Chrome	50.0.7510.1960	desktop	Windows	7	1
+Chrome	50.0.7784.1486	desktop	Macintosh	Intel 10.14	1
+Chrome	50.0.7888.1339	desktop	Macintosh	Intel 10.12	1
+Chrome	50.0.8867.1081	desktop	Windows	7	1
+Chrome	50.0.9353.1946	desktop	Macintosh	Intel 10.13	1
+Chrome	50.0.9479.1141	desktop	Macintosh	Intel 10.13	1
+Chrome	51.0.1025.1325	desktop	Macintosh	Intel 10.12	1
+Chrome	51.0.1558.1807	desktop	Windows	7	1
+Chrome	51.0.1647.327	mobile	Windows	10	1
+Chrome	51.0.2423.1870	desktop	Macintosh	Intel 10.12	1
+Chrome	51.0.2704.64	desktop	Chrome OS	x86_64 8172.45.0	1
+Chrome	51.0.2978.1705	desktop	Macintosh	Intel 10.12	1
+Chrome	51.0.3576.1629	desktop	Macintosh	Intel 10.13	1
+Chrome	51.0.3983.1990	desktop	Windows	7	1
+Chrome	51.0.4306.1944	desktop	Macintosh	Intel 10.12	1
+Chrome	51.0.6644.1916	desktop	Macintosh	Intel 10.14	1
+Chrome	51.0.6742.1570	desktop	Macintosh	Intel 10.13	1
+Chrome	51.0.9755.1958	desktop	Windows	7	1
+Chrome	52.0.1601.1593	desktop	Macintosh	Intel 10.12	1
+Chrome	52.0.1836.1331	desktop	Windows	7	1
+Chrome	52.0.1975.1023	desktop	Macintosh	Intel 10.12	1
+Chrome	52.0.2057.1168	desktop	Macintosh	Intel 10.14	1
+Chrome	52.0.3078.1214	desktop	Macintosh	Intel 10.13	1
+Chrome	52.0.3380.1422	desktop	Macintosh	Intel 10.14	1
+Chrome	52.0.3791.1517	mobile	Android	8.0	1
+Chrome	52.0.3896.1617	desktop	Macintosh	Intel 10.13	1
+Chrome	52.0.4767.1597	desktop	Macintosh	Intel 10.14	1
+Chrome	52.0.5512.1292	desktop	Macintosh	Intel 10.13	1
+Chrome	52.0.8443.1089	desktop	Macintosh	Intel 10.12	1
+Chrome	52.0.8647.1776	desktop	Macintosh	Intel 10.14	1
+Chrome	52.0.9624.1544	desktop	Macintosh	Intel 10.12	1
+Chrome	53.0.1385.262	mobile	Windows	10	1
+Chrome	53.0.2051.1002	desktop	Macintosh	Intel 10.13	1
+Chrome	53.0.2163.1372	desktop	Macintosh	Intel 10.12	1
+Chrome	53.0.2247.1241	desktop	Macintosh	Intel 10.14	1
+Chrome	53.0.2300.313	mobile	Windows	10	1
+Chrome	53.0.2467.1164	desktop	Macintosh	Intel 10.12	1
+Chrome	53.0.2567.1938	desktop	Macintosh	Intel 10.12	1
+Chrome	53.0.2785.34	smart tv	Linux	(not set)	1
+Chrome	53.0.3533.295	mobile	Windows	10	1
+Chrome	53.0.3551.1678	desktop	Macintosh	Intel 10.12	1
+Chrome	53.0.4488.1052	desktop	Macintosh	Intel 10.14	1
+Chrome	53.0.4730.1724	desktop	Windows	7	1
+Chrome	53.0.5379.1940	desktop	Windows	7	1
+Chrome	53.0.5561.1862	desktop	Macintosh	Intel 10.12	1
+Chrome	53.0.5630.1515	desktop	Macintosh	Intel 10.12	1
+Chrome	53.0.6123.1210	desktop	Macintosh	Intel 10.14	1
+Chrome	53.0.7197.1076	desktop	Macintosh	Intel 10.13	1
+Chrome	54.0.1597.1610	desktop	Macintosh	Intel 10.13	1
+Chrome	54.0.1612.1490	desktop	Macintosh	Intel 10.12	1
+Chrome	54.0.2300.1808	desktop	Macintosh	Intel 10.14	1
+Chrome	54.0.2991.1090	desktop	Macintosh	Intel 10.12	1
+Chrome	54.0.3531.1517	desktop	Macintosh	Intel 10.14	1
+Chrome	54.0.4575.1351	desktop	Windows	7	1
+Chrome	54.0.5208.1345	desktop	Macintosh	Intel 10.14	1
+Chrome	54.0.6583.1396	desktop	Macintosh	Intel 10.12	1
+Chrome	54.0.7198.1554	desktop	Windows	7	1
+Chrome	54.0.8020.1790	desktop	Windows	7	1
+Chrome	54.0.9097.1944	desktop	Macintosh	Intel 10.14	1
+Chrome	54.0.9199.1230	desktop	Macintosh	Intel 10.14	1
+Chrome	54.0.9644.1248	desktop	Windows	7	1
+Chrome	55.0.2145.1728	desktop	Macintosh	Intel 10.13	1
+Chrome	55.0.2883.75	desktop	Windows	10	1
+Chrome	55.0.2883.91	desktop	Windows	7	1
+Chrome	55.0.2883.91	mobile	Android	6.0	1
+Chrome	55.0.2883.91	tablet	Android	5.1.1	1
+Chrome	55.0.3105.1905	desktop	Macintosh	Intel 10.13	1
+Chrome	55.0.3859.1388	desktop	Windows	7	1
+Chrome	55.0.4885.1314	desktop	Macintosh	Intel 10.12	1
+Chrome	55.0.6051.1469	desktop	Macintosh	Intel 10.13	1
+Chrome	55.0.6970.1620	desktop	Windows	7	1
+Chrome	55.0.7159.1757	desktop	Macintosh	Intel 10.14	1
+Chrome	55.0.7363.1451	desktop	Macintosh	Intel 10.12	1
+Chrome	55.0.7558.1141	desktop	Macintosh	Intel 10.14	1
+Chrome	55.0.8017.1718	desktop	Macintosh	Intel 10.13	1
+Chrome	55.0.9286.1018	desktop	Macintosh	Intel 10.12	1
+Chrome	55.0.9515.1989	desktop	Windows	7	1
+Chrome	55.0.9747.1953	desktop	Macintosh	Intel 10.14	1
+Chrome	56.0.1364.1868	desktop	Macintosh	Intel 10.13	1
+Chrome	56.0.2093.1545	desktop	Macintosh	Intel 10.12	1
+Chrome	56.0.2766.1982	desktop	Windows	7	1
+Chrome	56.0.2776.1250	desktop	Windows	7	1
+Chrome	56.0.2924.75	mobile	iOS	10.3	1
+Chrome	56.0.2924.87	mobile	Android	5.1.1	1
+Chrome	56.0.2924.87	mobile	Android	6.0	1
+Chrome	56.0.2924.87	mobile	Android	7.0	1
+Chrome	56.0.2924.87	tablet	Android	6.0	1
+Chrome	56.0.3253.1180	desktop	Windows	7	1
+Chrome	56.0.3361.1697	desktop	Macintosh	Intel 10.13	1
+Chrome	56.0.4111.1268	desktop	Macintosh	Intel 10.14	1
+Chrome	56.0.4848.1257	desktop	Windows	7	1
+Chrome	56.0.5564.1003	desktop	Macintosh	Intel 10.14	1
+Chrome	56.0.5958.1360	desktop	Macintosh	Intel 10.12	1
+Chrome	56.0.6255.1823	desktop	Macintosh	Intel 10.12	1
+Chrome	56.0.6499.1246	desktop	Macintosh	Intel 10.12	1
+Chrome	56.0.7417.1175	desktop	Macintosh	Intel 10.14	1
+Chrome	56.0.7675.1778	desktop	Macintosh	Intel 10.14	1
+Chrome	56.0.8319.1489	desktop	Macintosh	Intel 10.12	1
+Chrome	56.0.8410.1449	desktop	Macintosh	Intel 10.13	1
+Chrome	56.0.9614.1136	desktop	Macintosh	Intel 10.12	1
+Chrome	56.77.34.5	desktop	Linux	(not set)	1
+Chrome	57.0.1602.1440	desktop	Macintosh	Intel 10.12	1
+Chrome	57.0.1864.1521	desktop	Windows	7	1
+Chrome	57.0.2305.1422	desktop	Macintosh	Intel 10.12	1
+Chrome	57.0.2346.1851	desktop	Macintosh	Intel 10.13	1
+Chrome	57.0.2987.108	desktop	Windows	Server 2003	1
+Chrome	57.0.2987.108	mobile	Android	11	1
+Chrome	57.0.2987.108	mobile	Android	6.0	1
+Chrome	57.0.4915.1319	desktop	Macintosh	Intel 10.14	1
+Chrome	57.0.5340.1768	desktop	Macintosh	Intel 10.12	1
+Chrome	57.0.5962.1552	desktop	Macintosh	Intel 10.14	1
+Chrome	57.0.6525.1137	desktop	Macintosh	Intel 10.12	1
+Chrome	57.0.7959.1137	desktop	Macintosh	Intel 10.13	1
+Chrome	57.0.8214.1367	desktop	Macintosh	Intel 10.14	1
+Chrome	57.0.9393.1761	desktop	Windows	7	1
+Chrome	57.0.9489.1173	desktop	Macintosh	Intel 10.12	1
+Chrome	57.0.9958.1650	desktop	Macintosh	Intel 10.12	1
+Chrome	58.0.2028.1388	desktop	Macintosh	Intel 10.12	1
+Chrome	58.0.3029.121	mobile	Android	14	1
+Chrome	58.0.3029.83	mobile	Android	7.0	1
+Chrome	58.0.3386.1150	desktop	Macintosh	Intel 10.12	1
+Chrome	58.0.4175.1791	desktop	Macintosh	Intel 10.12	1
+Chrome	58.0.4221.1023	desktop	Macintosh	Intel 10.14	1
+Chrome	58.0.5366.1570	desktop	Macintosh	Intel 10.12	1
+Chrome	58.0.7062.1115	desktop	Macintosh	Intel 10.13	1
+Chrome	58.0.9843.1048	desktop	Macintosh	Intel 10.12	1
+Chrome	58.0.9886.1160	desktop	Windows	7	1
+Chrome	58.0.9953.1416	desktop	Macintosh	Intel 10.12	1
+Chrome	59.0.1357.1021	desktop	Macintosh	Intel 10.12	1
+Chrome	59.0.2439.1681	desktop	Windows	7	1
+Chrome	59.0.2610.1838	desktop	Windows	7	1
+Chrome	59.0.3071.115	desktop	Windows	7	1
+Chrome	59.0.3071.125	mobile	Android	7.1.2	1
+Chrome	59.0.3071.86	desktop	Windows	7	1
+Chrome	59.0.3071.92	mobile	Android	9.1	1
+Chrome	59.0.3366.1216	desktop	Macintosh	Intel 10.14	1
+Chrome	59.0.3670.1392	desktop	Windows	7	1
+Chrome	59.0.3794.1853	desktop	Windows	7	1
+Chrome	59.0.4565.1434	desktop	Macintosh	Intel 10.14	1
+Chrome	59.0.5205.1145	desktop	Macintosh	Intel 10.12	1
+Chrome	59.0.6629.1312	desktop	Macintosh	Intel 10.14	1
+Chrome	59.0.6729.1404	desktop	Macintosh	Intel 10.14	1
+Chrome	59.0.6794.1531	desktop	Macintosh	Intel 10.12	1
+Chrome	59.0.7101.1394	desktop	Macintosh	Intel 10.13	1
+Chrome	59.0.7396.1477	desktop	Windows	7	1
+Chrome	59.0.9522.1629	desktop	Macintosh	Intel 10.14	1
+Chrome	60.0.1197.1232	desktop	Macintosh	Intel 10.12	1
+Chrome	60.0.1257.1797	desktop	Macintosh	Intel 10.12	1
+Chrome	60.0.1459.1701	desktop	Macintosh	Intel 10.13	1
+Chrome	60.0.1874.1230	desktop	Macintosh	Intel 10.13	1
+Chrome	60.0.2364.1621	desktop	Macintosh	Intel 10.12	1
+Chrome	60.0.2893.1610	desktop	Macintosh	Intel 10.12	1
+Chrome	60.0.3112.116	desktop	Linux	(not set)	1
+Chrome	60.0.3112.116	mobile	Android	7.0	1
+Chrome	60.0.3391.1711	desktop	Macintosh	Intel 10.13	1
+Chrome	60.0.5066.1116	desktop	Macintosh	Intel 10.12	1
+Chrome	60.0.5130.1478	desktop	Macintosh	Intel 10.12	1
+Chrome	60.0.5575.1491	desktop	Macintosh	Intel 10.12	1
+Chrome	60.0.6111.1751	desktop	Macintosh	Intel 10.12	1
+Chrome	60.0.6246.1989	desktop	Windows	7	1
+Chrome	60.0.8167.1931	desktop	Macintosh	Intel 10.12	1
+Chrome	60.0.8518.1109	desktop	Macintosh	Intel 10.12	1
+Chrome	60.0.9458.1293	desktop	Macintosh	Intel 10.12	1
+Chrome	60.0.9589.1683	desktop	Macintosh	Intel 10.14	1
+Chrome	60.0.9682.1152	desktop	Windows	7	1
+Chrome	61.0.3163.128	mobile	Android	6.0	1
+Chrome	61.0.3163.128	mobile	Android	6.0.1	1
+Chrome	61.0.3163.98	mobile	Android	7.1.2	1
+Chrome	61.0.3163.98	mobile	Android	8.1.0	1
+Chrome	61.0.3163.98	tablet	Android	4.4.2	1
+Chrome	62.0.3202.84	mobile	Android	7.1.2	1
+Chrome	62.0.3202.84	mobile	Android	8.0.0	1
+Chrome	63.0.3235.0	desktop	Windows	10	1
+Chrome	63.0.3239.84	desktop	Windows	10	1
+Chrome	64.0.3282.116	desktop	Windows	Vista	1
+Chrome	64.0.3282.137	mobile	Android	7.1.1	1
+Chrome	64.0.3282.137	mobile	Android	7.1.2	1
+Chrome	64.0.3282.167	desktop	Windows	10	1
+Chrome	65.0.3325.109	mobile	Android	4.1.2	1
+Chrome	65.0.3325.109	mobile	Android	4.3	1
+Chrome	66.0.3359.126	mobile	Android	7.0	1
+Chrome	66.0.3359.158	mobile	Android	8.1.0	1
+Chrome	66.0.3359.158	mobile	Android	9	1
+Chrome	66.0.3359.181	desktop	Linux	(not set)	1
+Chrome	66.0.3359.30	mobile	Android	6.0.1	1
+Chrome	67.0.3396.87	desktop	Macintosh	Intel 10.9	1
+Chrome	67.0.3396.87	tablet	Android	8.1.0	1
+Chrome	68.0.3440.91	desktop	Linux	(not set)	1
+Chrome	68.0.3440.91	mobile	Android	12.0	1
+Chrome	68.0.3440.91	tablet	Android	4.1.2	1
+Chrome	68.0.3440.91	tablet	Android	8.1.0	1
+Chrome	69.0.3497.100	mobile	Android	9	1
+Chrome	69.0.3497.100	tablet	Android	8.1.0	1
+Chrome	69.0.3497.120	desktop	Chrome OS	x86_64 10895.78.0	1
+Chrome	70.0.3538.110	mobile	Android	9	1
+Chrome	70.0.3538.110	tablet	Android	8.1.0	1
+Chrome	70.0.3538.64	desktop	Windows	10	1
+Chrome	70.0.3538.64	mobile	Android	10	1
+Chrome	70.0.3538.75	mobile	iOS	12.5	1
+Chrome	70.0.3538.77	desktop	Windows	10	1
+Chrome	70.0.3538.80	mobile	Android	9	1
+Chrome	71.0.3578.141	mobile	Android	11	1
+Chrome	71.0.3578.141	mobile	Android	7.1.2	1
+Chrome	71.0.3578.80	desktop	Windows	10	1
+Chrome	71.0.3578.98	desktop	Windows	10	1
+Chrome	71.0.3578.99	mobile	Android	4.2.2	1
+Chrome	71.0.3578.99	tablet	Android	4.1.2	1
+Chrome	72.0.3626.121	desktop	Windows	10	1
+Chrome	72.0.3626.121	desktop	Windows	7	1
+Chrome	72.0.3626.121	smart tv	Android	10	1
+Chrome	72.0.3626.122	desktop	Chrome OS	x86_64 11316.165.0	1
+Chrome	72.0.3626.81	desktop	Windows	7	1
+Chrome	73.0.3680.0	tablet	Android	4.2.2	1
+Chrome	73.0.3683.0	mobile	Android	10	1
+Chrome	73.0.3683.105	mobile	Android	8.0.0	1
+Chrome	73.0.3683.86	desktop	Linux	(not set)	1
+Chrome	73.0.3683.90	smart tv	Android	5.1.1	1
+Chrome	74.0.3729.108	desktop	Linux	(not set)	1
+Chrome	74.0.3729.108	desktop	Windows	10	1
+Chrome	74.0.3729.108	desktop	Windows	8.1	1
+Chrome	74.0.3729.125	desktop	Chrome OS	armv7l 11895.95.0	1
+Chrome	74.0.3729.131	desktop	Windows	10	1
+Chrome	74.0.3729.157	desktop	Windows	7	1
+Chrome	75.0.3770.100	desktop	Windows	10	1
+Chrome	75.0.3770.101	mobile	Android	11.0	1
+Chrome	75.0.3770.101	smart tv	Android	11.1	1
+Chrome	75.0.3770.142	desktop	Windows	10	1
+Chrome	75.0.3770.67	mobile	Android	7.1.2	1
+Chrome	75.0.3770.89	mobile	Android	10	1
+Chrome	75.0.3770.89	smart tv	Android	10	1
+Chrome	76.0.3809.111	mobile	Android	5.1	1
+Chrome	76.0.3809.132	desktop	Windows	10	1
+Chrome	76.0.3809.136	desktop	Chrome OS	x86_64 12239.92.2	1
+Chrome	76.0.3809.136	desktop	Chrome OS	x86_64 12239.92.4	1
+Chrome	77.0.3865.116	mobile	Android	12	1
+Chrome	77.0.3865.120	desktop	Linux	(not set)	1
+Chrome	77.0.3865.120	desktop	Windows	7	1
+Chrome	77.0.3865.35	desktop	Chrome OS	armv7l 12371.22.0	1
+Chrome	77.0.3865.75	desktop	Windows	10	1
+Chrome	77.0.3865.90	desktop	Macintosh	Intel 10.14	1
+Chrome	77.0.3865.92	tablet	Android	9	1
+Chrome	78.0.3904.62	mobile	Android	7.0	1
+Chrome	78.0.3904.70	desktop	Windows	7	1
+Chrome	78.0.3904.87	desktop	Windows	7	1
+Chrome	78.0.3904.90	mobile	Android	7.1.1	1
+Chrome	78.0.3904.96	mobile	Android	11	1
+Chrome	78.0.3904.96	mobile	Android	12	1
+Chrome	79.0.3945.0	desktop	Windows	10	1
+Chrome	79.0.3945.116	mobile	Android	4.4.2	1
+Chrome	79.0.3945.130	desktop	Windows	10	1
+Chrome	79.0.3945.147	mobile	Android	11	1
+Chrome	79.0.3945.86	desktop	Chrome OS	armv7l 12607.58.0	1
+Chrome	80.0.3987.132	desktop	Windows	10	1
+Chrome	80.0.3987.132	desktop	Windows	7	1
+Chrome	80.0.3987.132	desktop	Windows	XP	1
+Chrome	80.0.3987.132	mobile	Android	9	1
+Chrome	80.0.3987.149	mobile	Android	9	1
+Chrome	80.0.3987.162	desktop	Chrome OS	x86_64 12739.111.0	1
+Chrome	80.0.3987.162	desktop	Linux	(not set)	1
+Chrome	80.0.3987.162	mobile	Android	10	1
+Chrome	80.0.3987.162	mobile	Android	6.0	1
+Chrome	80.0.3987.95	mobile	iOS	13.4	1
+Chrome	80.0.3987.99	desktop	Linux	(not set)	1
+Chrome	80.0.3987.99	mobile	Android	8.0	1
+Chrome	81.0.4044.117	smart tv	Android	11	1
+Chrome	81.0.4044.138	mobile	Android	4.4.3	1
+Chrome	81.0.4044.138	mobile	Android	5.1	1
+Chrome	81.0.4044.138	mobile	Android	7.0	1
+Chrome	81.0.4044.138	mobile	Android	7.1.1	1
+Chrome	81.0.4044.138	smart tv	Android	4.4.4	1
+Chrome	81.0.4044.138	tablet	Android	10.0	1
+Chrome	81.0.4044.138	tablet	Android	5.0.2	1
+Chrome	81.0.4044.62	mobile	iOS	14.3	1
+Chrome	81.0.4044.92	desktop	Windows	7	1
+Chrome	83.0.1667.0	desktop	Windows	8	1
+Chrome	83.0.4093.2	mobile	Android	11	1
+Chrome	83.0.4103.106	mobile	iOS	6.0	1
+Chrome	83.0.4103.106	tablet	Android	10	1
+Chrome	83.0.4103.106	tablet	Android	11	1
+Chrome	83.0.4103.106	tablet	Android	8.1.0	1
+Chrome	83.0.4103.116	desktop	Linux	(not set)	1
+Chrome	83.0.4103.119	desktop	Chrome OS	x86_64 13020.87.0	1
+Chrome	83.0.4103.120	desktop	Windows	10	1
+Chrome	83.0.4103.120	mobile	Android	11	1
+Chrome	83.0.4103.122	desktop	Windows	10	1
+Chrome	83.0.4103.61	desktop	Windows	10	1
+Chrome	83.0.4103.88	tablet	iOS	13.5	1
+Chrome	84.0.4137.1	desktop	Windows	10	1
+Chrome	84.0.4147.105	desktop	Windows	8	1
+Chrome	84.0.4147.125	desktop	Windows	7	1
+Chrome	84.0.4147.127	desktop	Chrome OS	x86_64 13099.102.0	1
+Chrome	84.0.4147.38	desktop	Windows	7	1
+Chrome	84.0.4147.71	tablet	iOS	16.7	1
+Chrome	84.0.4147.89	desktop	Macintosh	Intel 10.15	1
+Chrome	84.0.4147.94	desktop	Chrome OS	x86_64 13099.72.0	1
+Chrome	85.0.4183.101	mobile	Android	8.1.0	1
+Chrome	85.0.4183.101	mobile	Android	9	1
+Chrome	85.0.4183.102	desktop	Windows	10	1
+Chrome	85.0.4183.102	desktop	Windows	8.1	1
+Chrome	85.0.4183.121	desktop	Windows	10	1
+Chrome	85.0.4183.127	mobile	Android	9	1
+Chrome	85.0.4183.127	smart tv	Android	9	1
+Chrome	85.0.4183.127	tablet	Android	11	1
+Chrome	85.0.4183.134	desktop	Chrome OS	armv7l 13310.94.2	1
+Chrome	85.0.4183.69	desktop	Macintosh	Intel 10.10	1
+Chrome	85.0.4183.83	desktop	Linux	(not set)	1
+Chrome	85.0.4183.83	desktop	Windows	7	1
+Chrome	86.0.4240.111	desktop	Macintosh	Intel 11.0	1
+Chrome	86.0.4240.183	desktop	Windows	10	1
+Chrome	86.0.4240.185	mobile	Android	10	1
+Chrome	86.0.4240.185	smart tv	Android	9	1
+Chrome	86.0.4240.198	mobile	Android	11	1
+Chrome	86.0.4240.198	mobile	Android	13	1
+Chrome	86.0.4240.198	mobile	Android	6.0.1	1
+Chrome	86.0.4240.199	desktop	Chrome OS	x86_64 13421.102.0	1
+Chrome	86.0.4240.75	desktop	Windows	7	1
+Chrome	86.0.4240.93	tablet	iOS	12.5	1
+Chrome	87.0.4280.0	desktop	Windows	10	1
+Chrome	87.0.4280.101	desktop	Linux	(not set)	1
+Chrome	87.0.4280.141	desktop	Linux	(not set)	1
+Chrome	87.0.4280.141	desktop	Macintosh	Intel 10.14	1
+Chrome	87.0.4280.141	mobile	Android	7.1.1	1
+Chrome	87.0.4280.163	mobile	iOS	17.6	1
+Chrome	87.0.4280.60	mobile	iOS	14.8	1
+Chrome	87.0.4280.66	desktop	Windows	8	1
+Chrome	87.0.4280.77	mobile	iOS	13.3	1
+Chrome	87.0.4280.77	mobile	iOS	13.6	1
+Chrome	87.0.4280.77	mobile	iOS	18.5	1
+Chrome	87.0.4280.77	tablet	iOS	12.4	1
+Chrome	87.0.4280.88	desktop	Macintosh	Intel 11.0	1
+Chrome	87.0.4280.88	desktop	Windows	7	1
+Chrome	87.0.4280.88	mobile	Android	5.0	1
+Chrome	88.0.4324.104	desktop	Windows	10	1
+Chrome	88.0.4324.181	mobile	Android	7.0	1
+Chrome	88.0.4324.192	desktop	Windows	7	1
+Chrome	88.0.4324.93	mobile	Android	8.0.0	1
+Chrome	88.0.4324.96	desktop	Windows	10	1
+Chrome	89.0.4389.105	mobile	Android	11	1
+Chrome	89.0.4389.114	desktop	Linux	(not set)	1
+Chrome	89.0.4389.114	desktop	Windows	10	1
+Chrome	89.0.4389.116	mobile	Android	7.1.2	1
+Chrome	89.0.4389.116	mobile	Android	9	1
+Chrome	89.0.4389.72	desktop	Windows	10	1
+Chrome	89.0.4389.82	desktop	Windows	10	1
+Chrome	89.0.4389.86	mobile	Android	8.0.0	1
+Chrome	89.0.4389.90	desktop	Windows	7	1
+Chrome	90.0.4427.0	tablet	Android	10	1
+Chrome	90.0.4430.210	mobile	Android	9	1
+Chrome	90.0.4430.210	tablet	Android	11	1
+Chrome	90.0.4430.212	desktop	Windows	7	1
+Chrome	90.0.4430.82	desktop	Linux	(not set)	1
+Chrome	90.0.4430.91	mobile	Android	8.0.0	1
+Chrome	90.0.4430.91	mobile	Android	9	1
+Chrome	91.0.4450.0	desktop	Macintosh	Intel 10.15	1
+Chrome	91.0.4472.10	desktop	Chrome OS	x86_64 13904.4.0	1
+Chrome	91.0.4472.101	mobile	Android	5.0	1
+Chrome	91.0.4472.114	mobile	Android	10	1
+Chrome	91.0.4472.120	mobile	Android	10	1
+Chrome	91.0.4472.120	mobile	Android	11	1
+Chrome	91.0.4472.120	mobile	Android	6.0.1	1
+Chrome	91.0.4472.120	mobile	Android	9	1
+Chrome	91.0.4472.124	desktop	Windows	11	1
+Chrome	91.0.4472.124	desktop	Windows	7	1
+Chrome	91.0.4472.124	mobile	Android	11	1
+Chrome	91.0.4472.134	tablet	Android	12	1
+Chrome	91.0.4472.164	mobile	Android	10	1
+Chrome	91.0.4472.88	mobile	Android	6.0	1
+Chrome	91.0.4472.88	mobile	Android	7.1.1	1
+Chrome	92.0.4509.0	desktop	Macintosh	Intel 10.15	1
+Chrome	92.0.4515.105	mobile	Android	9	1
+Chrome	92.0.4515.107	desktop	Macintosh	Intel 10.15	1
+Chrome	92.0.4515.131	desktop	Linux	(not set)	1
+Chrome	92.0.4515.131	desktop	Windows	10	1
+Chrome	92.0.4515.131	mobile	Android	8.1.0	1
+Chrome	92.0.4515.134	desktop	Macintosh	Intel 10.11	1
+Chrome	92.0.4515.159	desktop	Linux	(not set)	1
+Chrome	92.0.4515.159	mobile	Android	14	1
+Chrome	92.0.4515.162	desktop	Chrome OS	x86_64 13982.88.0	1
+Chrome	92.0.4515.173	desktop	Chrome OS	x86_64 13982.89.0	1
+Chrome	92.0.4515.90	mobile	iOS	18.2	1
+Chrome	92.0.4700.1	desktop	Windows	10	1
+Chrome	93.0.4577.0	desktop	Linux	(not set)	1
+Chrome	93.0.4577.107	mobile	Android	6.0.1	1
+Chrome	93.0.4577.52	mobile	Android	10	1
+Chrome	93.0.4577.78	tablet	iOS	14.4	1
+Chrome	93.0.4577.82	desktop	Windows	10	1
+Chrome	94.0.4606.61	desktop	Windows	8.1	1
+Chrome	94.0.4606.81	desktop	Linux	(not set)	1
+Chrome	94.0.4606.81	desktop	Windows	10	1
+Chrome	94.0.4606.81	mobile	Android	10	1
+Chrome	94.0.4606.85	desktop	Linux	(not set)	1
+Chrome	95.0.4617.0	desktop	Windows	10	1
+Chrome	95.0.4638.50	mobile	Android	12	1
+Chrome	95.0.4638.50	mobile	iOS	18.5	1
+Chrome	95.0.4638.54	desktop	Windows	7	1
+Chrome	95.0.4638.74	mobile	Android	6.0.1	1
+Chrome	95.0.4638.74	tablet	Android	5.0	1
+Chrome	95.0.4638.74	tablet	Android	5.0.1	1
+Chrome	95.0.4638.74	tablet	Android	5.0.2	1
+Chrome	95.0.4638.74	tablet	Android	6.0	1
+Chrome	96.0.4664.104	desktop	Linux	(not set)	1
+Chrome	96.0.4664.104	mobile	Android	9	1
+Chrome	96.0.4664.104	tablet	Android	9	1
+Chrome	96.0.4664.110	desktop	Windows	7	1
+Chrome	96.0.4664.110	mobile	Android	13	1
+Chrome	96.0.4664.45	mobile	Android	8.1.0	1
+Chrome	97.0.4692.84	mobile	iOS	16.4	1
+Chrome	97.0.4692.87	mobile	Android	8.0.0	1
+Chrome	97.0.4692.87	tablet	Android	11	1
+Chrome	97.0.4692.98	desktop	Linux	(not set)	1
+Chrome	97.0.4692.98	mobile	Android	14	1
+Chrome	97.0.4692.98	tablet	Android	11	1
+Chrome	97.0.4692.99	mobile	iOS	13.2	1
+Chrome	98.0.4758.101	mobile	Android	10	1
+Chrome	98.0.4758.101	mobile	Android	8.1.0	1
+Chrome	98.0.4758.102	desktop	Windows	7	1
+Chrome	98.0.4758.81	desktop	Windows	7	1
+Chrome	98.0.4758.87	mobile	Android	14	1
+Chrome	98.0.4758.87	mobile	Android	7.1.1	1
+Chrome	98.0.4758.87	mobile	Android	8.1.0	1
+Chrome	98.0.4758.87	mobile	Android	9	1
+Chrome	99.0.0.0	mobile	Android	10.0.1	1
+Chrome	99.0.4844.480	mobile	Android	11	1
+Chrome	99.0.4844.51	desktop	Linux	(not set)	1
+Chrome	99.0.4844.58	mobile	Android	9	1
+Chrome	99.0.4844.59	mobile	iOS	15.4	1
+Chrome	99.0.4844.73	desktop	Linux	(not set)	1
+Chrome	99.0.4844.73	mobile	Android	11	1
+Chrome	99.0.4844.83	desktop	Macintosh	Intel 10.15	1
+Chrome	99.0.4844.84	desktop	Macintosh	Intel 10.15	1
+Chrome	99.0.4844.84	desktop	Windows	7	1
+Chrome	99.0.4844.94	desktop	Chrome OS	x86_64 14469.59.0	1
+Chrome	99.0.7113.93	desktop	Windows	10	1
+Chrome	99.103.0.0	desktop	Linux	(not set)	1
+Coc Coc	80.0.180	desktop	Windows	7	1
+DuckDuckGo Browser	5	mobile	Android	12	1
+DuckDuckGo Browser	5	mobile	Android	6.0.1	1
+Edge	101.0.1210.39	desktop	Windows	10	1
+Edge	105.0.1343.27	desktop	Windows	10	1
+Edge	105.0.1343.42	desktop	Windows	10	1
+Edge	105.0.1343.53	desktop	Windows	10	1
+Edge	107.0.1418.35	mobile	Android	9.0.0	1
+Edge	107.0.1418.62	desktop	Windows	10	1
+Edge	108.0.1462.54	desktop	Windows	10	1
+Edge	109.0.1518.100	desktop	Windows	10	1
+Edge	109.0.1518.140	desktop	Windows	8	1
+Edge	109.0.1518.70	desktop	Windows	11	1
+Edge	109.0.1518.78	desktop	Windows	11	1
+Edge	110.0.1587.46	desktop	Windows	10	1
+Edge	110.0.1587.50	desktop	Windows	10	1
+Edge	111.0.1661.44	desktop	Windows	10	1
+Edge	112.0.1722.23	desktop	Windows	11	1
+Edge	112.0.1722.39	desktop	Windows	11	1
+Edge	112.0.1722.39	mobile	Android	6.0	1
+Edge	112.0.1722.48	desktop	Macintosh	Intel 14.5	1
+Edge	112.0.1722.58	desktop	Linux	6.8.0	1
+Edge	113.0.1774.42	desktop	Windows	10	1
+Edge	113.0.1774.50	desktop	Windows	10	1
+Edge	113.0.1774.57	desktop	Windows	11	1
+Edge	114.0.1823.43	desktop	Windows	10	1
+Edge	114.0.1823.43	desktop	Windows	11	1
+Edge	114.0.1823.55	desktop	Macintosh	Intel 12.7	1
+Edge	115.0.1901.183	desktop	Windows	10	1
+Edge	115.0.1901.189	mobile	Android	13.0.0	1
+Edge	115.0.1901.196	desktop	Linux	(not set)	1
+Edge	115.0.1901.196	mobile	Android	14.0.0	1
+Edge	116.0.1938.69	desktop	Windows	10	1
+Edge	117.0.2045.36	desktop	Windows	10	1
+Edge	117.0.2045.43	desktop	Windows	11	1
+Edge	117.0.2045.47	desktop	Windows	10	1
+Edge	118.0.2088.46	desktop	Windows	11	1
+Edge	118.0.2088.57	desktop	Windows	10	1
+Edge	118.0.2088.66	mobile	Android	11.0.0	1
+Edge	118.0.2088.66	mobile	Android	14.0.0	1
+Edge	119.0.2151.44	desktop	Windows	10	1
+Edge	119.0.2151.72	desktop	Windows	10	1
+Edge	119.0.2151.93	desktop	Windows	10	1
+Edge	120.0.2210.133	desktop	Windows	10	1
+Edge	120.0.2210.133	desktop	Windows	11	1
+Edge	120.0.2210.84	mobile	Android	13.0.0	1
+Edge	121.0.2277.112	desktop	Windows	10	1
+Edge	121.0.2277.128	desktop	Windows	11	1
+Edge	121.0.2277.133	mobile	Android	13.0.0	1
+Edge	122.0.2365.59	desktop	Windows	10	1
+Edge	122.0.2365.63	desktop	Windows	10	1
+Edge	122.0.2365.63	desktop	Windows	11	1
+Edge	122.0.2365.66	desktop	Windows	11	1
+Edge	122.0.2365.80	desktop	Macintosh	Intel 15.5	1
+Edge	122.0.2365.80	desktop	Windows	11	1
+Edge	122.0.2365.92	desktop	Windows	10	1
+Edge	123.0.2420.102	mobile	Android	10.0.0	1
+Edge	123.0.2420.65	desktop	Windows	10	1
+Edge	123.0.2420.97	desktop	Windows	11	1
+Edge	124.0.2478.51	desktop	Windows	11	1
+Edge	124.0.2478.67	desktop	Macintosh	Intel 15.5	1
+Edge	124.0.2478.80	desktop	Windows	10	1
+Edge	124.0.2478.80	desktop	Windows	11	1
+Edge	125.0.2535.51	desktop	Windows	10	1
+Edge	125.0.2535.67	desktop	Macintosh	Intel 15.5	1
+Edge	125.0.2535.79	desktop	Windows	10	1
+Edge	125.0.2535.85	desktop	Windows	11	1
+Edge	125.0.2535.92	desktop	Windows	11	1
+Edge	125.0.2535.96	mobile	Android	15.0.0	1
+Edge	126.0.2592.106	mobile	Android	11.0.0	1
+Edge	126.0.2592.113	desktop	Macintosh	Intel 15.5	1
+Edge	126.0.2592.113	desktop	Windows	11	1
+Edge	126.0.2592.117	mobile	Android	11.0.0	1
+Edge	126.0.2592.68	desktop	Linux	6.5.0	1
+Edge	126.0.2592.68	desktop	Windows	11	1
+Edge	126.0.2592.81	desktop	Windows	10	1
+Edge	127.0.2651.105	desktop	Macintosh	Intel 14.6	1
+Edge	127.0.2651.105	desktop	Macintosh	Intel 15.5	1
+Edge	127.0.2651.105	desktop	Windows	10	1
+Edge	127.0.2651.111	mobile	Android	15.0.0	1
+Edge	127.0.2651.74	desktop	Windows	10	1
+Edge	127.0.2651.74	desktop	Windows	11	1
+Edge	127.0.2651.86	desktop	Macintosh	Intel 13.7	1
+Edge	127.0.2651.86	desktop	Macintosh	Intel 15.5	1
+Edge	127.0.2651.98	desktop	Windows	10	1
+Edge	128.0.2739.42	desktop	Windows	10	1
+Edge	128.0.2739.54	desktop	Windows	11	1
+Edge	128.0.2739.63	desktop	Windows	11	1
+Edge	128.0.2739.67	desktop	Macintosh	Intel 10.15	1
+Edge	128.0.2739.79	desktop	Macintosh	Intel 15.5	1
+Edge	128.0.2739.79	desktop	Windows	11	1
+Edge	129.0.2792.52	desktop	Windows	10	1
+Edge	129.0.2792.52	desktop	Windows	11	1
+Edge	129.0.2792.65	desktop	Windows	11	1
+Edge	129.0.2792.79	desktop	Linux	6.8.0	1
+Edge	129.0.2792.89	desktop	Windows	11	1
+Edge	130.0.2849.27	desktop	Macintosh	Intel 14.5	1
+Edge	130.0.2849.46	desktop	Windows	10	1
+Edge	130.0.2849.56	desktop	Macintosh	Intel 13.2	1
+Edge	130.0.2849.57	mobile	Android	13.0.0	1
+Edge	130.0.2849.68	desktop	Windows	10	1
+Edge	130.0.2849.68	desktop	Windows	11	1
+Edge	130.0.2849.80	desktop	Linux	6.8.0	1
+Edge	130.0.2849.80	desktop	Macintosh	Intel 15.5	1
+Edge	130.0.2849.80	desktop	Windows	11	1
+Edge	131.0.2903.51	desktop	Linux	6.11.7	1
+Edge	131.0.2903.51	desktop	Windows	10	1
+Edge	131.0.2903.63	desktop	Macintosh	Intel 26.0	1
+Edge	131.0.2903.63	desktop	Windows	11	1
+Edge	131.0.2903.70	desktop	Linux	6.8.0	1
+Edge	131.0.2903.86	desktop	Windows	11	1
+Edge	131.0.2903.99	desktop	Linux	6.8.0	1
+Edge	131.0.6778.108	desktop	Windows	10	1
+Edge	131.0.6778.50	desktop	Windows	10	1
+Edge	132	desktop	Windows	10	1
+Edge	132.0.2957.115	desktop	Macintosh	Intel 15.5	1
+Edge	132.0.2957.115	desktop	Windows	11	1
+Edge	132.0.2957.118	mobile	Android	12.0.0	1
+Edge	132.0.2957.127	desktop	Windows	10	1
+Edge	132.0.2957.127	desktop	Windows	11	1
+Edge	132.0.2957.129	mobile	Android	14.0.0	1
+Edge	132.0.2957.129	mobile	Android	15.0.0	1
+Edge	132.0.2957.129	mobile	Android	9.0.0	1
+Edge	132.0.2957.140	desktop	Linux	6.6.84	1
+Edge	132.0.2957.140	desktop	Linux	6.9.3	1
+Edge	132.0.2957.140	desktop	Macintosh	Intel 15.3	1
+Edge	132.0.2957.55	desktop	Linux	5.15.0	1
+Edge	133	desktop	Macintosh	Intel 14.2	1
+Edge	133.0.2993.0	mobile	Android	15.0.0	1
+Edge	133.0.3000.0	desktop	Linux	6.8.0	1
+Edge	133.0.3065.67	mobile	Android	13.0.0	1
+Edge	133.0.3065.67	mobile	Android	14.0.0	1
+Edge	133.0.3065.69	desktop	Linux	5.18.0	1
+Edge	133.0.3065.69	desktop	Macintosh	Intel 14.6	1
+Edge	133.0.3065.80	mobile	Android	15.0.0	1
+Edge	133.0.3065.82	desktop	Linux	5.15.0	1
+Edge	133.0.3065.82	desktop	Linux	6.12.13	1
+Edge	133.0.3065.82	desktop	Macintosh	Intel 14.3	1
+Edge	133.0.3065.82	desktop	Macintosh	Intel 14.6	1
+Edge	133.0.3065.92	desktop	Macintosh	Intel 14.6	1
+Edge	133.0.3065.92	desktop	Macintosh	Intel 15.3	1
+Edge	133.0.3065.92	desktop	Macintosh	Intel 15.4	1
+Edge	133.0.3065.92	desktop	Macintosh	Intel 15.5	1
+Edge	134	desktop	Windows	10	1
+Edge	134.0.0.0	desktop	Windows	10	1
+Edge	134.0.3124.51	desktop	Macintosh	Intel 15.3	1
+Edge	134.0.3124.57	mobile	Android	10.0.0	1
+Edge	134.0.3124.68	desktop	Linux	6.11.0	1
+Edge	134.0.3124.68	desktop	Linux	6.8.0	1
+Edge	134.0.3124.77	mobile	Android	10.0.0	1
+Edge	134.0.3124.83	desktop	Linux	5.15.0	1
+Edge	134.0.3124.83	desktop	Linux	6.8.0	1
+Edge	134.0.3124.83	desktop	Macintosh	Intel 15.5	1
+Edge	134.0.3124.85	desktop	Linux	6.1.0	1
+Edge	134.0.3124.85	desktop	Linux	6.11.0	1
+Edge	134.0.3124.95	desktop	Linux	6.12.37	1
+Edge	134.0.3124.95	desktop	Linux	6.8.0	1
+Edge	134.0.3124.95	desktop	Macintosh	Intel 15.5	1
+Edge	134.0.6998.5	mobile	Android	14.0.0	1
+Edge	135.0.3179.54	desktop	Macintosh	Intel 12.7	1
+Edge	135.0.3179.54	desktop	Macintosh	Intel 13.0	1
+Edge	135.0.3179.54	desktop	Macintosh	Intel 14.1	1
+Edge	135.0.3179.54	desktop	Macintosh	Intel 15.5	1
+Edge	135.0.3179.54	desktop	Windows	10	1
+Edge	135.0.3179.54	mobile	Android	11.0.0	1
+Edge	135.0.3179.54	mobile	Android	15.0.0	1
+Edge	135.0.3179.72	mobile	Android	12.0.0	1
+Edge	135.0.3179.72	mobile	Android	14.0.0	1
+Edge	135.0.3179.73	desktop	Linux	6.11.0	1
+Edge	135.0.3179.73	desktop	Macintosh	Intel 15.3	1
+Edge	135.0.3179.73	desktop	Macintosh	Intel 15.5	1
+Edge	135.0.3179.85	desktop	Linux	6.11.0	1
+Edge	135.0.3179.85	mobile	Android	11.0.0	1
+Edge	135.0.3179.85	mobile	Android	14.0.0	1
+Edge	135.0.3179.98	desktop	Macintosh	Intel 14.4	1
+Edge	135.0.3179.98	desktop	Macintosh	Intel 15.0	1
+Edge	135.0.7049.81	mobile	Android	14.0.0	1
+Edge	136.0.1343.50	desktop	Windows	7	1
+Edge	136.0.3240.138	desktop	Windows	11	1
+Edge	136.0.3240.50	desktop	Linux	6.11.0	1
+Edge	136.0.3240.50	desktop	Linux	6.14.0	1
+Edge	136.0.3240.50	desktop	Linux	6.8.0	1
+Edge	136.0.3240.50	desktop	Macintosh	Intel 14.3	1
+Edge	136.0.3240.50	mobile	Android	10.0.0	1
+Edge	136.0.3240.50	mobile	Android	11.0.0	1
+Edge	136.0.3240.50	mobile	Android	12.0.0	1
+Edge	136.0.3240.50	mobile	Android	14.0.0	1
+Edge	136.0.3240.50	mobile	Windows	11	1
+Edge	136.0.3240.64	desktop	Macintosh	Intel 14.3	1
+Edge	136.0.3240.64	desktop	Macintosh	Intel 14.5	1
+Edge	136.0.3240.64	desktop	Macintosh	Intel 14.6	1
+Edge	136.0.3240.64	desktop	Macintosh	Intel 15.4	1
+Edge	136.0.3240.64	mobile	Android	12.0.0	1
+Edge	136.0.3240.64	mobile	Android	14.0.0	1
+Edge	136.0.3240.76	desktop	Linux	6.0.12	1
+Edge	136.0.3240.76	desktop	Linux	6.12.28	1
+Edge	136.0.3240.76	desktop	Linux	6.12.37	1
+Edge	136.0.3240.76	desktop	Linux	6.8.0	1
+Edge	136.0.3240.76	desktop	Macintosh	Intel 12.7	1
+Edge	136.0.3240.76	desktop	Macintosh	Intel 14.7	1
+Edge	136.0.3240.76	desktop	Macintosh	Intel 15.4	1
+Edge	136.0.3240.76	mobile	Android	15.0.0	1
+Edge	136.0.3240.91	desktop	Linux	(not set)	1
+Edge	136.0.3240.91	mobile	Android	12.0.0	1
+Edge	136.0.3240.91	mobile	Android	14.0.0	1
+Edge	136.0.3240.91	mobile	Android	15.0.0	1
+Edge	136.0.3240.92	desktop	Linux	6.11.0	1
+Edge	136.0.3240.92	desktop	Macintosh	Intel 14.5	1
+Edge	137.0.0.0	desktop	Macintosh	Intel 10.15	1
+Edge	137.0.3296.101	desktop	Windows	11	1
+Edge	137.0.3296.52	desktop	Macintosh	Intel 14.1	1
+Edge	137.0.3296.52	desktop	Macintosh	Intel 15.4	1
+Edge	137.0.3296.53	desktop	Linux	(not set)	1
+Edge	137.0.3296.53	mobile	Android	14.0.0	1
+Edge	137.0.3296.53	mobile	Android	15.0.0	1
+Edge	137.0.3296.58	desktop	Macintosh	Intel 15.4	1
+Edge	137.0.3296.58	desktop	Windows	10	1
+Edge	137.0.3296.62	desktop	Linux	6.8.0	1
+Edge	137.0.3296.62	desktop	Macintosh	Intel 14.5	1
+Edge	137.0.3296.62	desktop	Macintosh	Intel 14.6	1
+Edge	137.0.3296.62	desktop	Macintosh	Intel 15.0	1
+Edge	137.0.3296.62	desktop	Macintosh	Intel 15.4	1
+Edge	137.0.3296.62	mobile	Windows	10	1
+Edge	137.0.3296.65	mobile	Android	12.0.0	1
+Edge	137.0.3296.65	mobile	Android	15.0.0	1
+Edge	137.0.3296.68	desktop	Linux	5.11.0	1
+Edge	137.0.3296.68	desktop	Linux	6.12.10	1
+Edge	137.0.3296.68	desktop	Linux	6.12.13	1
+Edge	137.0.3296.68	desktop	Linux	6.12.33	1
+Edge	137.0.3296.68	desktop	Macintosh	Intel 12.7	1
+Edge	137.0.3296.68	desktop	Macintosh	Intel 13.0	1
+Edge	137.0.3296.68	desktop	Macintosh	Intel 13.3	1
+Edge	137.0.3296.68	desktop	Macintosh	Intel 16.0	1
+Edge	137.0.3296.82	mobile	Android	8.1.0	1
+Edge	137.0.3296.82	mobile	Android	9.0.0	1
+Edge	137.0.3296.83	desktop	Linux	5.14.0	1
+Edge	137.0.3296.83	desktop	Linux	6.14.0	1
+Edge	137.0.3296.83	desktop	Macintosh	 10.15	1
+Edge	137.0.3296.83	desktop	Macintosh	Intel 10.15	1
+Edge	137.0.3296.83	desktop	Macintosh	Intel 12.5	1
+Edge	137.0.3296.83	desktop	Macintosh	Intel 12.7	1
+Edge	137.0.3296.83	desktop	Macintosh	Intel 13.7	1
+Edge	137.0.3296.83	desktop	Macintosh	Intel 14.0	1
+Edge	137.0.3296.83	desktop	Macintosh	Intel 14.3	1
+Edge	137.0.3296.83	desktop	Macintosh	Intel 14.4	1
+Edge	137.0.3296.93	desktop	Linux	5.15.0	1
+Edge	137.0.3296.93	desktop	Linux	6.1.0	1
+Edge	137.0.3296.93	desktop	Linux	6.12.20	1
+Edge	137.0.3296.93	desktop	Linux	6.15.3	1
+Edge	137.0.3296.93	desktop	Macintosh	Intel 12.4	1
+Edge	137.0.3296.93	desktop	Macintosh	Intel 13.5	1
+Edge	137.0.3296.93	desktop	Macintosh	Intel 13.6	1
+Edge	137.0.3296.93	desktop	Macintosh	Intel 14.0	1
+Edge	137.0.3296.93	desktop	Macintosh	Intel 14.3	1
+Edge	137.0.3296.93	desktop	Macintosh	Intel 15.6	1
+Edge	137.0.3296.93	mobile	Android	11.0	1
+Edge	138.0.0.0	desktop	Macintosh	Intel 10.15	1
+Edge	138.0.3309.1	desktop	Windows	11	1
+Edge	138.0.3324.0	desktop	Macintosh	Intel 15.5	1
+Edge	138.0.3350.0	mobile	Android	12.0.0	1
+Edge	138.0.3351.101	desktop	Windows	11	1
+Edge	138.0.3351.103	desktop	Windows	11	1
+Edge	138.0.3351.11	mobile	Android	14.0.0	1
+Edge	138.0.3351.21	desktop	Windows	11	1
+Edge	138.0.3351.34	desktop	Windows	10	1
+Edge	138.0.3351.47	mobile	Android	11.0.0	1
+Edge	138.0.3351.47	mobile	Android	14.0.0	1
+Edge	138.0.3351.55	desktop	Linux	6.14.0	1
+Edge	138.0.3351.55	desktop	Linux	6.2.0	1
+Edge	138.0.3351.55	desktop	Macintosh	 10.15	1
+Edge	138.0.3351.55	desktop	Macintosh	Intel 10.15	1
+Edge	138.0.3351.55	desktop	Macintosh	Intel 13.2	1
+Edge	138.0.3351.55	desktop	Macintosh	Intel 13.7	1
+Edge	138.0.3351.55	desktop	Macintosh	Intel 14.0	1
+Edge	138.0.3351.55	desktop	Macintosh	Intel 14.2	1
+Edge	138.0.3351.55	desktop	Macintosh	Intel 15.1	1
+Edge	138.0.3351.55	desktop	Macintosh	Intel 15.2	1
+Edge	138.0.3351.55	desktop	Macintosh	Intel 15.6	1
+Edge	138.0.3351.55	mobile	Android	12.0.0	1
+Edge	138.0.3351.55	mobile	Android	13.0.0	1
+Edge	138.0.3351.55	mobile	Android	16.0.0	1
+Edge	138.0.3351.55	mobile	Windows	10	1
+Edge	138.0.3351.56	desktop	Windows	11	1
+Edge	138.0.3351.61	desktop	Windows	11	1
+Edge	138.0.3351.63	desktop	Windows	11	1
+Edge	138.0.3351.65	desktop	Linux	6.12.34	1
+Edge	138.0.3351.65	desktop	Linux	6.14.0	1
+Edge	138.0.3351.65	desktop	Linux	6.14.4	1
+Edge	138.0.3351.65	desktop	Linux	6.2.0	1
+Edge	138.0.3351.65	desktop	Macintosh	Intel 11.6	1
+Edge	138.0.3351.65	desktop	Macintosh	Intel 11.7	1
+Edge	138.0.3351.65	desktop	Macintosh	Intel 12.5	1
+Edge	138.0.3351.65	desktop	Macintosh	Intel 13.2	1
+Edge	138.0.3351.65	desktop	Macintosh	Intel 13.5	1
+Edge	138.0.3351.65	desktop	Macintosh	Intel 14.0	1
+Edge	138.0.3351.65	desktop	Macintosh	Intel 14.3	1
+Edge	138.0.3351.65	desktop	Macintosh	Intel 15.2	1
+Edge	138.0.3351.65	mobile	Android	11.0	1
+Edge	138.0.3351.65	mobile	Windows	10	1
+Edge	138.0.3351.74	desktop	Windows	11	1
+Edge	138.0.3351.75	desktop	Windows	11	1
+Edge	138.0.3351.76	desktop	Windows	11	1
+Edge	138.0.3351.77	desktop	Linux	6.1.0	1
+Edge	138.0.3351.77	desktop	Linux	6.12.10	1
+Edge	138.0.3351.77	desktop	Linux	6.13.7	1
+Edge	138.0.3351.77	desktop	Linux	6.15.6	1
+Edge	138.0.3351.77	desktop	Macintosh	Intel 11.6	1
+Edge	138.0.3351.77	desktop	Macintosh	Intel 11.7	1
+Edge	138.0.3351.77	desktop	Macintosh	Intel 12.7	1
+Edge	138.0.3351.77	desktop	Macintosh	Intel 13.4	1
+Edge	138.0.3351.77	desktop	Macintosh	Intel 13.7	1
+Edge	138.0.3351.77	desktop	Macintosh	Intel 14.1	1
+Edge	138.0.3351.77	desktop	Macintosh	Intel 14.2	1
+Edge	138.0.3351.77	desktop	Macintosh	Intel 14.4	1
+Edge	138.0.3351.77	desktop	Macintosh	Intel 15.0	1
+Edge	138.0.3351.77	desktop	Macintosh	Intel 16.0	1
+Edge	138.0.3351.77	desktop	Macintosh	Intel 26.0	1
+Edge	138.0.3351.77	mobile	Android	6.0	1
+Edge	138.0.3351.77	mobile	Windows	10	1
+Edge	138.0.3351.77	mobile	Windows	11	1
+Edge	138.0.3351.82	desktop	Windows	11	1
+Edge	138.0.3351.83	desktop	Linux	5.15.0	1
+Edge	138.0.3351.83	desktop	Linux	6.12.10	1
+Edge	138.0.3351.83	desktop	Linux	6.12.29	1
+Edge	138.0.3351.83	desktop	Linux	6.13.7	1
+Edge	138.0.3351.83	desktop	Linux	6.14.0	1
+Edge	138.0.3351.83	desktop	Linux	6.15.5	1
+Edge	138.0.3351.83	desktop	Linux	6.15.6	1
+Edge	138.0.3351.83	desktop	Macintosh	 10.15	1
+Edge	138.0.3351.83	desktop	Macintosh	Intel 10.15	1
+Edge	138.0.3351.83	desktop	Macintosh	Intel 11.6	1
+Edge	138.0.3351.83	desktop	Macintosh	Intel 11.7	1
+Edge	138.0.3351.83	desktop	Macintosh	Intel 12.4	1
+Edge	138.0.3351.83	desktop	Macintosh	Intel 13.0	1
+Edge	138.0.3351.83	desktop	Macintosh	Intel 13.2	1
+Edge	138.0.3351.83	mobile	Android	11.0	1
+Edge	138.0.3351.83	mobile	Android	11.0.0	1
+Edge	138.0.3351.83	mobile	Android	8.1.0	1
+Edge	138.0.3351.89	desktop	Windows	11	1
+Edge	138.0.3351.95	desktop	Linux	6.15.6	1
+Edge	138.0.3351.95	desktop	Macintosh	Intel 11.7	1
+Edge	138.0.3351.95	desktop	Macintosh	Intel 13.2	1
+Edge	138.0.3351.95	desktop	Macintosh	Intel 13.7	1
+Edge	138.0.3351.95	desktop	Macintosh	Intel 14.4	1
+Edge	138.0.3351.95	desktop	Macintosh	Intel 14.5	1
+Edge	138.0.3351.95	desktop	Macintosh	Intel 14.6	1
+Edge	138.0.3351.95	desktop	Macintosh	Intel 15.0	1
+Edge	138.0.3351.95	desktop	Macintosh	Intel 15.1	1
+Edge	138.0.3351.95	desktop	Macintosh	Intel 15.6	1
+Edge	138.0.3351.95	mobile	Android	6.0	1
+Edge	138.0.3351.97	desktop	Windows	11	1
+Edge	138.0.3351.99	desktop	Windows	11	1
+Edge	139.0.0.0	mobile	Android	6.0	1
+Edge	139.0.3365.2	desktop	Macintosh	Intel 15.3	1
+Edge	139.0.3365.2	desktop	Windows	11	1
+Edge	139.0.3378.0	mobile	Android	15.0.0	1
+Edge	139.0.3380.1	desktop	Macintosh	Intel 16.0	1
+Edge	139.0.3394.0	desktop	Linux	6.11.0	1
+Edge	139.0.3394.0	desktop	Macintosh	Intel 14.7	1
+Edge	139.0.3394.0	desktop	Macintosh	Intel 15.3	1
+Edge	139.0.3394.0	desktop	Windows	10	1
+Edge	139.0.3398.0	mobile	Android	12.0.0	1
+Edge	139.0.3401.0	desktop	Windows	11	1
+Edge	139.0.3404.0	mobile	Android	15.0.0	1
+Edge	139.0.3405.13	desktop	Windows	10	1
+Edge	139.0.3405.15	desktop	Windows	11	1
+Edge	139.0.3405.17	desktop	Windows	11	1
+Edge	139.0.3405.18	desktop	Windows	11	1
+Edge	139.0.3405.2	desktop	Windows	11	1
+Edge	139.0.3405.21	desktop	Macintosh	Intel 15.5	1
+Edge	139.0.3405.23	desktop	Windows	11	1
+Edge	139.0.3405.25	desktop	Windows	11	1
+Edge	139.0.3405.26	mobile	Android	11.0.0	1
+Edge	139.0.3405.26	mobile	Android	15.0.0	1
+Edge	139.0.3405.27	desktop	Windows	11	1
+Edge	139.0.3405.3	desktop	Windows	11	1
+Edge	139.0.3405.31	desktop	Windows	11	1
+Edge	139.0.3405.32	desktop	Windows	11	1
+Edge	139.0.3405.33	desktop	Windows	11	1
+Edge	139.0.3405.34	desktop	Windows	11	1
+Edge	139.0.3405.42	desktop	Windows	10	1
+Edge	139.0.3405.51	desktop	Windows	11	1
+Edge	139.0.3405.9	desktop	Windows	11	1
+Edge	140.0.3408.0	desktop	Windows	11	1
+Edge	140.0.3409.0	desktop	Windows	11	1
+Edge	140.0.3410.0	desktop	Windows	11	1
+Edge	140.0.3412.0	desktop	Windows	11	1
+Edge	140.0.3414.0	desktop	Windows	11	1
+Edge	140.0.3415.0	desktop	Windows	11	1
+Edge	140.0.3417.0	desktop	Windows	11	1
+Edge	140.0.3420.0	mobile	Android	15.0.0	1
+Edge	140.0.3420.0	mobile	Android	16.0.0	1
+Edge	140.0.3421.0	desktop	Macintosh	Intel 15.5	1
+Edge	140.0.3422.0	mobile	Android	15.0.0	1
+Edge	140.0.3424.0	desktop	Windows	11	1
+Edge	140.0.3424.0	mobile	Android	15.0.0	1
+Edge	140.0.3425.0	desktop	Windows	11	1
+Edge	140.0.3426.0	desktop	Windows	11	1
+Edge	140.0.3428.0	desktop	Windows	11	1
+Edge	140.0.3428.0	mobile	Android	15.0.0	1
+Edge	140.0.3428.0	mobile	Android	16.0.0	1
+Edge	140.0.3429.0	desktop	Macintosh	Intel 15.5	1
+Edge	140.0.3429.0	desktop	Windows	11	1
+Edge	140.0.3430.0	desktop	Windows	11	1
+Edge	140.0.3430.1	desktop	Linux	6.8.0	1
+Edge	140.0.3430.1	desktop	Windows	10	1
+Edge	140.0.3435.0	desktop	Windows	11	1
+Edge	140.0.3436.0	mobile	Android	15.0.0	1
+Edge	140.0.3437.0	desktop	Windows	11	1
+Edge	140.0.3441.0	desktop	Windows	11	1
+Edge	140.0.3444.0	desktop	Windows	11	1
+Edge	140.0.3448.0	desktop	Windows	11	1
+Edge	80.0.361.57	desktop	Windows	10	1
+Edge	84.0.522.52	desktop	Windows	10	1
+Edge	99.0.1150.39	desktop	Windows	10	1
+Firefox	100.0	mobile	Android	10	1
+Firefox	102.0	desktop	Linux	(not set)	1
+Firefox	102.0	desktop	Macintosh	Intel 10.15	1
+Firefox	102.0	desktop	Windows	10	1
+Firefox	103.0	desktop	Linux	(not set)	1
+Firefox	106.0	mobile	Android	10	1
+Firefox	107.0	mobile	Android	16	1
+Firefox	110.0	desktop	Windows	10	1
+Firefox	110.0	mobile	Android	10	1
+Firefox	111.0	desktop	Macintosh	Intel 10.15	1
+Firefox	113.0	desktop	Windows	10	1
+Firefox	115.0	desktop	Macintosh	Intel 10.15	1
+Firefox	115.0	desktop	Windows	Vista	1
+Firefox	116.0	desktop	Windows	7	1
+Firefox	117.0	desktop	Linux	(not set)	1
+Firefox	117.0	desktop	Windows	10	1
+Firefox	117.0	mobile	Android	13	1
+Firefox	118.0	desktop	Linux	(not set)	1
+Firefox	118.0	desktop	Windows	10	1
+Firefox	119.0	desktop	Linux	(not set)	1
+Firefox	119.0	desktop	Windows	10	1
+Firefox	120.0	desktop	Windows	10	1
+Firefox	121.0	desktop	Windows	10	1
+Firefox	121.0	mobile	Android	13	1
+Firefox	122.0	desktop	Windows	10	1
+Firefox	122.0	mobile	Android	11	1
+Firefox	122.0	mobile	Android	15	1
+Firefox	122.0	mobile	Android	7.1.1	1
+Firefox	123.0	desktop	Macintosh	Intel 10.15	1
+Firefox	123.0	mobile	Android	14	1
+Firefox	123.0	mobile	Firefox OS	(not set)	1
+Firefox	124.0	mobile	Android	13	1
+Firefox	125.0	desktop	Macintosh	Intel 10.15	1
+Firefox	125.0	mobile	Android	10	1
+Firefox	126.0	mobile	Android	13	1
+Firefox	127.0	desktop	Linux	(not set)	1
+Firefox	127.0	desktop	Macintosh	Intel 10.15	1
+Firefox	130.0	desktop	Macintosh	Intel 10.15	1
+Firefox	130.0	mobile	Android	15	1
+Firefox	131.0	desktop	Macintosh	Intel 10.4	1
+Firefox	131.0	mobile	Android	10	1
+Firefox	132.0	desktop	Macintosh	Intel 10.15	1
+Firefox	132.0	mobile	Android	11	1
+Firefox	132.0	mobile	Android	15	1
+Firefox	133.0	mobile	Android	10	1
+Firefox	133.0	mobile	Android	12	1
+Firefox	133.0	mobile	Android	14	1
+Firefox	134.0	mobile	Android	10	1
+Firefox	134.0	mobile	Android	13	1
+Firefox	135.0	mobile	Android	10	1
+Firefox	135.0	mobile	Android	15	1
+Firefox	136.0	mobile	Android	11	1
+Firefox	136.0	mobile	Android	13	1
+Firefox	136.0	mobile	Android	15	1
+Firefox	137.0	mobile	Android	10	1
+Firefox	137.0	mobile	Android	12	1
+Firefox	137.0	mobile	Android	13	1
+Firefox	138.0	mobile	Android	13	1
+Firefox	141.0	mobile	Android	11	1
+Firefox	142.0	mobile	Android	10	1
+Firefox	142.0	mobile	Android	11	1
+Firefox	142.0	mobile	Android	14	1
+Firefox	143.0	desktop	Windows	10	1
+Firefox	20.0	tablet	Android	(not set)	1
+Firefox	36.0	desktop	Windows	8.1	1
+Firefox	50.0	desktop	Linux	(not set)	1
+Firefox	63.0	desktop	Linux	(not set)	1
+Firefox	66.0	desktop	Linux	(not set)	1
+Firefox	66.0	mobile	Android	5.0	1
+Firefox	67.0	desktop	Linux	(not set)	1
+Firefox	68.0	desktop	Linux	(not set)	1
+Firefox	69.0	desktop	Linux	(not set)	1
+Firefox	72.0	desktop	Windows	7	1
+Firefox	73.0	desktop	Windows	8.1	1
+Firefox	76.0	mobile	Android	5.1.1	1
+Firefox	78.0	desktop	Windows	7	1
+Firefox	78.0	mobile	Firefox OS	(not set)	1
+Firefox	79.0	desktop	Linux	(not set)	1
+Firefox	80.0	desktop	Linux	(not set)	1
+Firefox	81.0	mobile	Android	14	1
+Firefox	88.0	desktop	Linux	(not set)	1
+Firefox	96.0	desktop	Windows	10	1
+Firefox	97.0	desktop	Linux	(not set)	1
+Firefox	98.0	desktop	Windows	10	1
+Firefox	99.0	desktop	Macintosh	Intel 10.15	1
+Internet Explorer	11.0	tablet	Windows	10	1
+Internet Explorer	8.0	desktop	Windows	7	1
+Meta Quest Browser	35.1.0.78.167.646680522	desktop	Linux	(not set)	1
+Meta Quest Browser	38.2.0.13.53.728503412	desktop	Linux	(not set)	1
+Meta Quest Browser	39.2.0.6.62.756685193	desktop	Linux	(not set)	1
+Mozilla	139.0	desktop	Windows	10	1
+Mozilla Compatible Agent	5.0	desktop	Windows	10	1
+Mozilla Compatible Agent	5.0	mobile	Android	14	1
+Nintendo Browser	5.1.0.35219	smart tv	(not set)	(not set)	1
+Opera	105.0.0.0	desktop	Linux	(not set)	1
+Opera	107.0.0.0	desktop	Linux	(not set)	1
+Opera	107.0.0.0	desktop	Windows	10	1
+Opera	108.0.0.0	desktop	Linux	(not set)	1
+Opera	108.0.0.0	desktop	Macintosh	Intel 10.15	1
+Opera	112.0.0.0	desktop	Linux	(not set)	1
+Opera	115.0.0.0	desktop	Windows	10	1
+Opera	116.0.0.0	desktop	Linux	(not set)	1
+Opera	116.0.5225.161	desktop	Macintosh	Intel 14.5	1
+Opera	119.0.5497.88	desktop	Linux	(not set)	1
+Opera	121.0.0.0	desktop	Macintosh	Intel 10.15	1
+Opera	44.12.2246.133431	mobile	Android	5.1	1
+Opera	44.14.2246.148970	mobile	Android	10	1
+Opera	46.0.2207.0	smart tv	Linux	(not set)	1
+Opera	48.2.2331.133274	mobile	Android	11	1
+Opera	50.8.2426.20221012	mobile	Android	4.2.2	1
+Opera	55.0.2719.50560	mobile	Android	8.1.0	1
+Opera	57.0.3098.116	desktop	Windows	10	1
+Opera	59.0.2254.59350	mobile	Android	8.1.0	1
+Opera	59.1.2926.54067	mobile	Android	5.1.1	1
+Opera	62.3.2254.60999	mobile	Android	13	1
+Opera	64.1.3282.59912	mobile	Android	11	1
+Opera	65.1.2254.63284	mobile	Android	11	1
+Opera	65.1.3381.61266	mobile	Android	9	1
+Opera	66.6.3445.73002	mobile	Android	5.1	1
+Opera	68.3.3557.64528	mobile	Android	11	1
+Opera	68.3.3557.64588	tablet	Android	10	1
+Opera	72.1.3767.68311	mobile	Android	6.0.1	1
+Opera	72.5.3767.69342	mobile	Android	7.1.2	1
+Opera	73.2.3844.71002	mobile	Android	12	1
+Opera	74.0.3922.71152	mobile	Android	10	1
+Opera	74.1.3922.71199	mobile	Android	13	1
+Opera	74.2.3922.71802	mobile	Android	15	1
+Opera	75.0.2254.68857	mobile	Android	15	1
+Opera	76.2.4027.73374	mobile	Android	11	1
+Opera	77.0.2254.69831	mobile	Android	14	1
+Opera	78.0.2254.70362	mobile	Android	10	1
+Opera	78.0.4093.153	desktop	Windows	8.1	1
+Opera	78.5.4143.75924	mobile	Android	13	1
+Opera	79.3.4195.76674	mobile	Android	12	1
+Opera	80.0.2254.71401	mobile	Android	11	1
+Opera	80.0.2254.71401	mobile	Android	7.1	1
+Opera	80.0.2254.71401	tablet	Android	8.1.0	1
+Opera	80.0.2254.71589	mobile	Android	13	1
+Opera	81.0.2254.72260	mobile	Android	12	1
+Opera	81.2.4292.78581	mobile	Android	14	1
+Opera	81.3.4292.78780	mobile	Android	15	1
+Opera	81.6.4292.79147	mobile	Android	15	1
+Opera	82.0.2254.72589	mobile	Android	10	1
+Opera	82.0.4227.32	desktop	Windows	10	1
+Opera	82.0.4227.33	desktop	Windows	10	1
+Opera	82.0.4227.43	desktop	Linux	(not set)	1
+Opera	82.0.4227.43	desktop	Windows	7	1
+Opera	82.3.4342.79590	mobile	Android	15	1
+Opera	82.5.4342.79868	mobile	Android	11	1
+Opera	83.0.4254.62	desktop	Windows	7	1
+Opera	84.0.0.0	mobile	Android	10	1
+Opera	84.0.2254.73823	tablet	Android	14	1
+Opera	84.0.2254.73866	mobile	Android	11	1
+Opera	85.0.2254.73914	mobile	Android	10	1
+Opera	85.0.2254.74399	mobile	Android	8.0.0	1
+Opera	85.0.2254.74573	mobile	Android	12	1
+Opera	86.0.2254.74831	mobile	Android	10	1
+Opera	86.0.2254.74831	mobile	Android	11	1
+Opera	87.0.4390.45	desktop	Linux	(not set)	1
+Opera	87.1.2254.75427	mobile	Android	13	1
+Opera	88.0.2254.75874	mobile	Android	11	1
+Opera	88.0.2254.75874	mobile	Android	12	1
+Opera	88.0.2254.75874	mobile	Android	14	1
+Opera	89.0.2254.76420	mobile	Android	11	1
+Opera	89.0.2254.76420	mobile	Android	9	1
+Opera	89.2.4705.83992	mobile	Android	12	1
+Opera	90.0.4480.117	desktop	Windows	10	1
+Opera	90.1.2254.77167	mobile	Android	10	1
+Opera	90.1.2254.77167	mobile	Android	11	1
+Opera	90.1.2254.77167	mobile	Android	14	1
+Opera	90.1.2254.77167	mobile	Android	5.1.1	1
+Opera	90.1.2254.77167	mobile	Android	8.1.0	1
+Opera	90.1.2254.77168	mobile	Android	11	1
+Opera	90.1.2254.77168	mobile	Android	12	1
+Opera	90.1.2254.77193	mobile	Android	10	1
+Opera	91.0.2254.77465	mobile	Android	10	1
+Opera	91.0.2254.77465	mobile	Android	14	1
+Opera	91.0.2254.77465	mobile	Android	15	1
+Opera	91.0.2254.77465	mobile	Android	9	1
+Opera	91.0.2254.77568	mobile	Android	10	1
+Opera	91.0.2254.77568	mobile	Android	11	1
+Opera	91.0.2254.77568	mobile	Android	14	1
+Opera	91.0.2254.77594	mobile	Android	12	1
+Opera	91.0.2254.77594	tablet	Android	10	1
+Opera	91.0.4516.20	desktop	Linux	(not set)	1
+Opera	92.0.0.0	desktop	Windows	10	1
+Opera	92.0.2254.77856	mobile	Android	14	1
+Opera	92.0.2254.77856	mobile	Android	8.1.0	1
+Opera	92.0.2254.77856	mobile	Android	9	1
+Opera	92.0.2254.77878	mobile	Android	8.1.0	1
+Opera	92.0.2254.77878	tablet	Android	11	1
+Opera	92.0.2254.77977	mobile	Android	10	1
+Opera	93.0.0.0	desktop	Windows	10	1
+Opera	93.0.2254.78131	mobile	Android	14	1
+Opera	93.0.2254.78339	mobile	Android	12	1
+Opera	93.0.2254.78339	mobile	Android	13	1
+Opera	93.0.2254.78340	mobile	Android	13	1
+Opera	93.0.2254.78340	mobile	Android	8.1	1
+Phoenix Browser	16.2	mobile	Android	10	1
+Phoenix Browser	16.6	mobile	Android	14	1
+Phoenix Browser	17.1	mobile	Android	14	1
+Phoenix Browser	17.4	mobile	Android	9	1
+Phoenix Browser	18.7	mobile	Android	12	1
+Phoenix Browser	18.7	mobile	Android	8.1.0	1
+Phoenix Browser	18.7	mobile	Android	9	1
+Phoenix Browser	18.8	mobile	Android	13	1
+Phoenix Browser	7.8	mobile	Android	10	1
+Playstation 4	(not set)	smart tv	Playstation 4	(not set)	1
+Puffin	132.0.3.78755FP,gzip(gfe)	desktop	(not set)	(not set)	1
+Safari	11.1.2	desktop	Macintosh	Intel 10.11	1
+Safari	12.0	mobile	iOS	12.5.6	1
+Safari	12.1	mobile	iOS	12.1.4	1
+Safari	12.1.2	desktop	Macintosh	Intel 10.14	1
+Safari	12.1.2	mobile	iOS	12.4.1	1
+Safari	12.1.2	tablet	iOS	12.4.5	1
+Safari	12.5	mobile	iOS	12.5.7	1
+Safari	12.5.7	mobile	iOS	12.5.7	1
+Safari	13.0.4	desktop	Macintosh	Intel 10.15	1
+Safari	13.1	mobile	iOS	13.4	1
+Safari	13.1.2	desktop	Macintosh	Intel 10.15	1
+Safari	14.0	desktop	Macintosh	Intel 10.15	1
+Safari	14.0	mobile	iOS	14.4	1
+Safari	14.0.1	desktop	Macintosh	Intel 10.15	1
+Safari	14.0.1	mobile	iOS	14.2	1
+Safari	14.0.2	mobile	iOS	14.3	1
+Safari	14.0.3	mobile	iOS	14.4.1	1
+Safari	14.1	mobile	iOS	14.5.1	1
+Safari	14.1.2	mobile	iOS	14.7.1	1
+Safari	14.1.3	desktop	Macintosh	Intel 10.15	1
+Safari	14.7.1	mobile	iOS	14.7.1	1
+Safari	15.0	mobile	iOS	15.0.1	1
+Safari	15.0	mobile	iOS	15.0.2	1
+Safari	15.0	mobile	iOS	15.6	1
+Safari	15.2	mobile	iOS	(not set)	1
+Safari	15.2	mobile	iOS	15.2	1
+Safari	15.2.1	mobile	iOS	15.2.1	1
+Safari	15.3	mobile	iOS	(not set)	1
+Safari	15.3	mobile	iOS	15.3	1
+Safari	15.4	mobile	iOS	15.4	1
+Safari	15.4.1	mobile	iOS	15.4.1	1
+Safari	15.5	desktop	Macintosh	Intel 10.15	1
+Safari	15.6.4	mobile	iOS	15.7.5	1
+Safari	15.6.6	mobile	iOS	15.7.7	1
+Safari	15.6.6	mobile	iOS	15.7.9	1
+Safari	15.6.6	mobile	iOS	15.8.1	1
+Safari	15.6.6	tablet	iOS	15.8.3	1
+Safari	15.7	mobile	iOS	15.7	1
+Safari	15.7	mobile	iOS	15.7.2	1
+Safari	15.7.5	mobile	iOS	15.7.5	1
+Safari	15.8.3	desktop	Macintosh	Intel 10.15	1
+Safari	15.8.4	desktop	Macintosh	Intel 10.15	1
+Safari	16.0	mobile	iOS	16.5	1
+Safari	16.0.3	mobile	iOS	16.0.3	1
+Safari	16.4	mobile	iOS	16.4	1
+Safari	16.4.1	mobile	iOS	16.4.1	1
+Safari	16.6	mobile	iOS	16.7.9	1
+Safari	16.6	tablet	iOS	16.6.1	1
+Safari	16.7.8	mobile	iOS	16.7.8	1
+Safari	17.0	desktop	Macintosh	Intel 14.5	1
+Safari	17.0	mobile	iOS	17.6.1	1
+Safari	17.0	mobile	iOS	18.0	1
+Safari	17.0	tablet	iOS	17.7.1	1
+Safari	17.0.1	desktop	Macintosh	Intel 10.15	1
+Safari	17.0.3	mobile	iOS	17.0.3	1
+Safari	17.10	desktop	Macintosh	Intel 10.15	1
+Safari	17.11	desktop	Macintosh	Intel 10.15	1
+Safari	17.11	tablet	iOS	17.7.6	1
+Safari	17.13	tablet	iOS	17.7.8	1
+Safari	17.3.14	desktop	Macintosh	Intel	1
+Safari	17.4.1	tablet	iOS	17.4.1	1
+Safari	17.5	mobile	iOS	16.0	1
+Safari	17.7	tablet	iOS	17.7	1
+Safari	17.7.8	desktop	Macintosh	Intel 10.15	1
+Safari	17.8.1	desktop	Macintosh	Intel 10.15	1
+Safari	18.0	mobile	iOS	18.1.0	1
+Safari	18.0	mobile	iOS	18.2.0	1
+Safari	18.0	mobile	iOS	18.3.2	1
+Safari	18.1	desktop	Linux	(not set)	1
+Safari	18.2	tablet	iOS	18.2	1
+Safari	18.3.1	tablet	iOS	18.3.2	1
+Safari	18.3.2	desktop	Macintosh	Intel 10.15	1
+Safari	18.4	mobile	iOS	10.3.1	1
+Safari	18.4	mobile	iOS	15.0	1
+Safari	18.5	desktop	Macintosh	(not set)	1
+Safari	19.0	tablet	iOS	19.0	1
+Safari	19.0	tablet	iOS	19.0.0	1
+Safari	5.0	mobile	Tizen	5.0	1
+Safari	537.36	mobile	Tizen	9.0	1
+Safari	6.0	mobile	iOS	17.0	1
+Safari	60.5	smart tv	Linux	(not set)	1
+Safari	604.1	mobile	iOS	15.2	1
+Safari	604.1	mobile	iOS	15.2.1	1
+Safari	604.1	mobile	iOS	15.3.1	1
+Safari	604.1	mobile	iOS	15.4.1	1
+Safari	604.1	mobile	iOS	15.7.8	1
+Safari	604.1	mobile	iOS	15.8	1
+Safari	604.1	mobile	iOS	15.8.2	1
+Safari	604.1	mobile	iOS	16.0.0	1
+Safari	604.1	mobile	iOS	16.1.1	1
+Safari	604.1	mobile	iOS	16.2	1
+Safari	604.1	mobile	iOS	16.4.1	1
+Safari	604.1	mobile	iOS	16.5.0	1
+Safari	604.1	mobile	iOS	16.7	1
+Safari	604.1	mobile	iOS	16.7.1	1
+Safari	604.1	mobile	iOS	16.7.2	1
+Safari	604.1	mobile	iOS	17.0.3	1
+Safari	604.1	mobile	iOS	17.1	1
+Safari	604.1	mobile	iOS	17.1.1	1
+Safari	604.1	mobile	iOS	17.1.2	1
+Safari	604.1	mobile	iOS	17.5	1
+Safari	604.1	mobile	iOS	17.6.0	1
+Safari	604.1	mobile	iOS	18.1	1
+Safari	604.1	mobile	iOS	18.4	1
+Safari	604.1	mobile	iOS	19.0	1
+Safari	604.1	mobile	iOS	26.0	1
+Safari	604.1	tablet	iOS	15.6.1	1
+Safari	604.1	tablet	iOS	16.1.1	1
+Safari	604.1	tablet	iOS	16.7.10	1
+Safari	604.1	tablet	iOS	17.6.1	1
+Safari	604.1	tablet	iOS	18.2.0	1
+Safari	604.1	tablet	iOS	18.4.0	1
+Safari	604.1	tablet	iOS	18.4.1	1
+Safari	605.1.15	mobile	iOS	17.5.1	1
+Safari	605.1.15	mobile	iOS	18.0.1	1
+Safari	605.1.15	mobile	iOS	18.1	1
+Safari	605.1.15	mobile	iOS	18.2	1
+Safari	605.1.15	mobile	iOS	18.3.1	1
+Safari	605.1.15	mobile	iOS	18.4	1
+Safari (in-app)	(not set)	mobile	iOS	12.5.4	1
+Safari (in-app)	(not set)	mobile	iOS	16.0	1
+Safari (in-app)	(not set)	mobile	iOS	16.0.2	1
+Safari (in-app)	(not set)	mobile	iOS	16.1.2	1
+Safari (in-app)	(not set)	mobile	iOS	16.4.1	1
+Safari (in-app)	(not set)	mobile	iOS	16.5	1
+Safari (in-app)	(not set)	mobile	iOS	16.6	1
+Safari (in-app)	(not set)	mobile	iOS	16.7.2	1
+Safari (in-app)	(not set)	mobile	iOS	16.7.5	1
+Safari (in-app)	(not set)	mobile	iOS	16.7.8	1
+Safari (in-app)	(not set)	mobile	iOS	17.0.1	1
+Safari (in-app)	(not set)	mobile	iOS	17.0.3	1
+Safari (in-app)	(not set)	mobile	iOS	17.4	1
+Safari (in-app)	(not set)	tablet	iOS	12.5.7	1
+Safari (in-app)	(not set)	tablet	iOS	14.6	1
+Safari (in-app)	(not set)	tablet	iOS	15.5	1
+Safari (in-app)	(not set)	tablet	iOS	16.7.11	1
+Safari (in-app)	(not set)	tablet	iOS	17.3.1	1
+Safari (in-app)	(not set)	tablet	iOS	17.6.1	1
+Safari (in-app)	(not set)	tablet	iOS	18.6	1
+Safari (in-app)	(not set)	tablet	iOS	26.0	1
+Safari (in-app)	1.7.0	mobile	iOS	18.5	1
+Safari (in-app)	16.0	mobile	iOS	18.2.1	1
+Safari (in-app)	16.0	mobile	iOS	18.3.2	1
+Safari (in-app)	16.2	mobile	iOS	18.5	1
+Safari (in-app)	38.7.2	mobile	iOS	15.8.4	1
+Safari (in-app)	5.67.0	mobile	iOS	15.8.4	1
+Samsung Internet	11.0	mobile	Android	12	1
+Samsung Internet	13.0	mobile	Android	10	1
+Samsung Internet	13.0	mobile	Android	12	1
+Samsung Internet	13.2	desktop	Linux	(not set)	1
+Samsung Internet	13.2	mobile	Android	11	1
+Samsung Internet	14.0	mobile	Android	8.1.0	1
+Samsung Internet	14.2	mobile	Android	11	1
+Samsung Internet	14.2	mobile	Android	12	1
+Samsung Internet	15.0	mobile	Android	11	1
+Samsung Internet	15.0	mobile	Android	8.1.0	1
+Samsung Internet	16.0	desktop	Linux	(not set)	1
+Samsung Internet	16.0	mobile	Android	10	1
+Samsung Internet	16.0	mobile	Android	6.0.1	1
+Samsung Internet	16.2	mobile	Android	13	1
+Samsung Internet	17.0	mobile	Android	12	1
+Samsung Internet	17.0	tablet	Android	7.1.1	1
+Samsung Internet	18.0	mobile	Android	11	1
+Samsung Internet	18.0	mobile	Android	12	1
+Samsung Internet	18.0	mobile	Android	8.0.0	1
+Samsung Internet	19.0	desktop	Linux	(not set)	1
+Samsung Internet	19.0	tablet	Android	7.1.1	1
+Samsung Internet	2.2	mobile	Tizen	5.0	1
+Samsung Internet	2.2	mobile	Tizen	5.5	1
+Samsung Internet	2.2	mobile	Tizen	7.0	1
+Samsung Internet	20.0	mobile	Android	10	1
+Samsung Internet	20.0	mobile	Android	11	1
+Samsung Internet	20.0	mobile	Android	14	1
+Samsung Internet	20.0	mobile	Android	8.0	1
+Samsung Internet	20.0	mobile	Android	9	1
+Samsung Internet	21.0	mobile	Android	7.1.1	1
+Samsung Internet	21.0	tablet	Android	13	1
+Samsung Internet	21.0	tablet	Android	14	1
+Samsung Internet	21.0	tablet	Android	7.0	1
+Samsung Internet	22.0	desktop	Linux	(not set)	1
+Samsung Internet	22.0	mobile	Android	8.0.0	1
+Samsung Internet	22.0	tablet	Android	14	1
+Samsung Internet	23.0	desktop	Linux	(not set)	1
+Samsung Internet	23.0	mobile	Android	10	1
+Samsung Internet	23.0	mobile	Android	8.1.0	1
+Samsung Internet	23.0	tablet	Android	14	1
+Samsung Internet	4.2	mobile	Android	10	1
+Samsung Internet	6.4	mobile	Android	6.0.1	1
+Samsung Internet	7.2	desktop	Linux	(not set)	1
+Samsung Internet	8.0	mobile	Tizen	9.0	1
+Samsung Internet	8.2	mobile	Android	6.0.1	1
+SeaMonkey	2.53.21	desktop	Linux	(not set)	1
+SeaMonkey	2.53.21	desktop	Macintosh	Intel 11.7	1
+Seznam	11.3.1	mobile	Android	11	1
+UC Browser	11.6.4.950	mobile	Android	15	1
+UC Browser	11.6.4.950	mobile	Android	5.1.1	1
+UC Browser	11.6.4.950	mobile	Android	8.1.0	1
+UC Browser	11.6.4.950	tablet	Android	9	1
+UC Browser	12.10.0.1163	mobile	Android	10	1
+UC Browser	12.10.0.1163	mobile	Android	4.1.2	1
+UC Browser	12.10.0.1163	mobile	Android	4.4.4	1
+UC Browser	12.10.0.1163	mobile	Android	5.1.1	1
+UC Browser	12.10.0.1163	mobile	Android	6.0.1	1
+UC Browser	12.10.0.1163	mobile	Android	7.0	1
+UC Browser	12.11.9.1201	tablet	Android	4.4.2	1
+UC Browser	12.12.10.1227	mobile	Android	10	1
+UC Browser	12.12.10.1227	mobile	Android	6.0.1	1
+UC Browser	12.12.10.1228	mobile	Android	9	1
+UC Browser	12.12.10.1228	tablet	Android	9	1
+UC Browser	12.12.9.1226	mobile	Android	7.0	1
+UC Browser	13.0.5.1290	mobile	Android	4.4.4	1
+UC Browser	13.3.8.1305	mobile	Android	10	1
+UC Browser	13.3.8.1305	mobile	Android	8.0.0	1
+UC Browser	13.4.0.1306	mobile	Android	11	1
+UC Browser	13.4.0.1306	mobile	Android	12	1
+UC Browser	13.4.0.1306	mobile	Android	14	1
+UC Browser	13.4.0.1306	mobile	Android	9	1
+UC Browser	13.4.5.1308	mobile	Android	10	1
+UC Browser	13.4.5.1308	mobile	Android	15	1
+UC Browser	13.6.0.1315	mobile	Android	10	1
+UC Browser	13.7.2.1320	mobile	Android	10	1
+UC Browser	13.7.8.1322	mobile	Android	11	1
+UC Browser	14.5.2.1358	mobile	Android	11	1
+UC Browser	14.5.2.1358	mobile	Android	12	1
+UC Browser	14.6.2.1361	desktop	Windows	Server 2003	1
+UC Browser	14.6.5.1362	mobile	Android	11	1
+UC Browser	14.6.5.1362	mobile	Android	12	1
+UC Browser	14.6.5.1362	mobile	Android	14	1
+UC Browser	14.6.8.1363	mobile	Android	11	1
+UC Browser	14.6.8.1363	mobile	Android	13	1
+UC Browser	14.6.8.1363	mobile	Android	14	1
+UC Browser	14.6.8.1363	mobile	Android	15	1
+UC Browser	14.6.8.1363	mobile	Android	9	1
+UC Browser	14.7.0.1364	desktop	Windows	Server 2003	1
+UC Browser	14.7.0.1364	mobile	Android	11	1
+UC Browser	14.7.0.1364	mobile	Android	12	1
+UC Browser	14.7.0.1364	mobile	Android	13	1
+UC Browser	14.7.2.1365	mobile	Android	10	1
+UC Browser	14.7.2.1365	mobile	Android	9	1
+UC Browser	14.7.5.1366	mobile	Android	12	1
+UC Browser	14.7.5.1366	mobile	Android	13	1
+Whale Browser	1.0.0.0	mobile	Android	13	1
+Whale Browser	3.9.3.2	mobile	Android	10	1
+Whale Browser	4.32.315.15	desktop	Windows	10	1
+YaBrowser	15.0	mobile	iOS	15.6	1
+YaBrowser	15.0	mobile	iOS	15.8.4	1
+YaBrowser	16.0	mobile	iOS	16.5.1	1
+YaBrowser	17.0	tablet	iOS	17.6.1	1
+YaBrowser	18.0	mobile	iOS	18.2.1	1
+YaBrowser	18.0	mobile	iOS	18.5	1
+YaBrowser	18.7.0.833.00	mobile	Android	9	1
+YaBrowser	19.12.1.121.00	mobile	Android	5.1	1
+YaBrowser	21.11.4.730	desktop	Windows	10	1
+YaBrowser	21.5.0.179.00	desktop	Linux	(not set)	1
+YaBrowser	21.5.4.610	desktop	Windows	10	1
+YaBrowser	22.5.4.904	desktop	Windows	10	1
+YaBrowser	23.1.1.1114	desktop	Linux	(not set)	1
+YaBrowser	23.1.2.1028	desktop	Linux	(not set)	1
+YaBrowser	23.11.1.105.00	mobile	Android	13	1
+YaBrowser	23.11.1.802	desktop	Linux	(not set)	1
+YaBrowser	23.11.1.843	desktop	Windows	10	1
+YaBrowser	23.3.1.930	desktop	Linux	(not set)	1
+YaBrowser	23.3.1.951	desktop	Windows	10	1
+YaBrowser	23.3.3.100.00	mobile	Android	15	1
+YaBrowser	23.3.7.27.00	mobile	Android	13	1
+YaBrowser	23.5.1.575	desktop	Linux	(not set)	1
+YaBrowser	23.5.1.725	desktop	Windows	10	1
+YaBrowser	23.7.1.1170	desktop	Windows	10	1
+YaBrowser	23.9.1.1017	desktop	Linux	(not set)	1
+YaBrowser	23.9.1.1024	desktop	Windows	10	1
+YaBrowser	23.9.2.888	desktop	Windows	10	1
+YaBrowser	23.9.4.837	desktop	Windows	10	1
+YaBrowser	23.9.5.662	desktop	Windows	10	1
+YaBrowser	23.9.6.84.00	mobile	Android	14	1
+YaBrowser	23.9.7.83.00	mobile	Android	13	1
+YaBrowser	24.1.0.0	desktop	Linux	(not set)	1
+YaBrowser	24.1.0.0	desktop	Windows	10	1
+YaBrowser	24.1.1.23	mobile	Android	11	1
+YaBrowser	24.1.1.91	mobile	Android	11	1
+YaBrowser	24.1.2.109	mobile	Android	13	1
+YaBrowser	24.1.2.109	mobile	Android	14	1
+YaBrowser	24.1.2.92	mobile	Android	12	1
+YaBrowser	24.1.3.854	desktop	Windows	10	1
+YaBrowser	24.1.5.88.00	mobile	Android	13	1
+YaBrowser	24.10.3.111.00	mobile	Android	13	1
+YaBrowser	24.10.4.648	desktop	Linux	(not set)	1
+YaBrowser	24.10.5.53.00	mobile	Android	12	1
+YaBrowser	24.10.5.53.01	mobile	Android	12	1
+YaBrowser	24.10.5.55.00	mobile	Android	14	1
+YaBrowser	24.12.0.1450	desktop	Windows	7	1
+YaBrowser	24.12.0.279.00	mobile	Android	11	1
+YaBrowser	24.12.1.704	desktop	Linux	(not set)	1
+YaBrowser	24.12.3.100.00	mobile	Android	14	1
+YaBrowser	24.12.4.1119	desktop	Windows	10	1
+YaBrowser	24.12.4.199.00	mobile	Android	14	1
+YaBrowser	24.12.5.36.00	mobile	Android	14	1
+YaBrowser	24.4.5.105.00	mobile	Android	13	1
+YaBrowser	24.6.0.0	desktop	Linux	(not set)	1
+YaBrowser	24.6.1.82.00	mobile	Android	10	1
+YaBrowser	24.6.1.82.00	mobile	Android	11	1
+YaBrowser	24.6.1.82.00	mobile	Android	13	1
+YaBrowser	24.6.5.46.00	mobile	Android	14	1
+YaBrowser	24.6.5.47.00	mobile	Android	10	1
+YaBrowser	24.6.8.2.10	mobile	iOS	18.2.1	1
+YaBrowser	24.7.2.116.00	mobile	Android	10	1
+YaBrowser	24.7.3.126.00	mobile	Android	14	1
+YaBrowser	24.7.3.1264	desktop	Linux	(not set)	1
+YaBrowser	24.7.6.1023	desktop	Windows	8.1	1
+YaBrowser	25.2.0.2118	desktop	Windows	10	1
+YaBrowser	25.2.0.241.00	mobile	Android	10	1
+YaBrowser	25.2.0.241.00	mobile	Android	12	1
+YaBrowser	25.2.0.47	mobile	Android	13	1
+YaBrowser	25.2.1.103.00	mobile	Android	13	1
+YaBrowser	25.2.1.103.00	mobile	Android	14	1
+YaBrowser	25.2.2.834	desktop	Windows	10	1
+YaBrowser	25.2.2.97.00	mobile	Android	14	1
+YaBrowser	25.2.3.90.00	mobile	Android	11	1
+YaBrowser	25.2.3.95.00	mobile	Android	14	1
+YaBrowser	25.2.3.95.00	mobile	Android	9	1
+YaBrowser	25.2.3.97.00	mobile	Android	14	1
+YaBrowser	25.2.5.105.00	mobile	Android	14	1
+YaBrowser	25.2.5.107.00	mobile	Android	12	1
+YaBrowser	25.2.6.92.00	mobile	Android	15	1
+YaBrowser	25.2.6.96.00	mobile	Android	10	1
+YaBrowser	25.2.6.96.00	mobile	Android	8.1.0	1
+YaBrowser	25.2.6.97.00	mobile	Android	11	1
+YaBrowser	25.2.6.98.00	mobile	Android	15	1
+YaBrowser	25.2.7.95.00	mobile	Android	14	1
+YaBrowser	25.2.8.97.00	mobile	Android	10	1
+YaBrowser	25.2.8.97.00	mobile	Android	11	1
+YaBrowser	25.2.8.97.00	mobile	Android	14	1
+YaBrowser	25.2.9.49.00	mobile	Android	14	1
+YaBrowser	25.2.9.55.00	mobile	Android	13	1
+YaBrowser	25.3.0.38.00	mobile	Android	9	1
+YaBrowser	25.4.1.100.00	mobile	Android	10	1
+YaBrowser	25.4.1.100.00	mobile	Android	13	1
+YaBrowser	25.4.1.103.00	mobile	Android	11	1
+YaBrowser	25.4.2.107.00	mobile	Android	13	1
+YaBrowser	25.4.2.107.00	mobile	Android	15	1
+YaBrowser	25.4.2.108.00	mobile	Android	10	1
+YaBrowser	25.4.2.108.00	mobile	Android	12	1
+YaBrowser	25.4.2.108.00	mobile	Android	15	1
+YaBrowser	25.4.2.569.10	mobile	iOS	18.5	1
+YaBrowser	25.4.3.169.00	mobile	Android	13	1
+YaBrowser	25.4.3.169.00	mobile	Android	15	1
+YaBrowser	25.4.3.180.00	mobile	Android	13	1
+YaBrowser	25.4.3.182.00	tablet	Android	10	1
+YaBrowser	25.4.3.182.01	desktop	Linux	(not set)	1
+YaBrowser	25.4.3.182.01	tablet	Android	12	1
+YaBrowser	25.4.4.105.00	mobile	Android	12	1
+YaBrowser	25.4.4.105.00	mobile	Android	14	1
+YaBrowser	25.4.4.105.00	mobile	Android	15	1
+YaBrowser	25.4.4.111.00	mobile	Android	12	1
+YaBrowser	25.4.4.111.00	mobile	Android	14	1
+YaBrowser	25.4.5.355.10	mobile	iOS	18.5	1
+YaBrowser	25.4.5.426.10	mobile	iOS	18.6	1
+YaBrowser	25.4.5.471.10	mobile	iOS	16.0	1
+YaBrowser	25.4.5.73.00	mobile	Android	15	1
+YaBrowser	25.4.5.77.00	mobile	Android	13	1
+YaBrowser	25.4.5.77.00	mobile	Android	14	1
+YaBrowser	25.4.6.49.00	mobile	Android	10	1
+YaBrowser	25.4.6.49.00	mobile	Android	11	1
+YaBrowser	25.4.6.49.00	mobile	Android	9	1
+YaBrowser	25.4.6.49.01	tablet	Android	15	1
+YaBrowser	25.4.6.54.00	mobile	Android	15	1
+YaBrowser	25.4.6.55.00	mobile	Android	10	1
+YaBrowser	25.4.6.55.00	mobile	Android	12	1
+YaBrowser	25.4.6.55.00	mobile	Android	13	1
+YaBrowser	25.4.6.55.00	mobile	Android	15	1
+YaBrowser	25.4.6.55.01	tablet	Android	12	1
+YaBrowser	25.4.6.64.00	mobile	Android	14	1
+YaBrowser	25.4.6.64.01	tablet	Android	13	1
+YaBrowser	25.6.0.271.00	mobile	Android	10	1
+YaBrowser	25.6.0.271.00	mobile	Android	11	1
+YaBrowser	25.6.0.271.00	mobile	Android	14	1
+YaBrowser	25.6.1.100.00	mobile	Android	14	1
+YaBrowser	25.6.1.101.00	mobile	Android	10	1
+YaBrowser	25.6.1.101.00	mobile	Android	11	1
+YaBrowser	25.6.1.95.00	mobile	Android	10	1
+YaBrowser	25.6.1.95.00	mobile	Android	12.0	1
+YaBrowser	25.6.1.95.00	mobile	Android	16	1
+YaBrowser	25.6.1.95.00	mobile	Android	8.1.0	1
+YaBrowser	25.6.1.95.01	tablet	Android	10	1
+YaBrowser	25.6.2.103.00	mobile	Android	12	1
+YaBrowser	25.6.2.103.00	mobile	Android	9	1
+YaBrowser	25.6.2.108.00	mobile	Android	10	1
+YaBrowser	25.6.2.108.01	desktop	Linux	(not set)	1
+YaBrowser	25.6.2.108.01	tablet	Android	14	1
+YaBrowser	25.6.2.109.00	mobile	Android	10	1
+YaBrowser	25.6.2.109.00	mobile	Android	16	1
+YaBrowser	25.6.2.109.00	mobile	Android	8.1.0	1
+YaBrowser	25.6.2.115.00	mobile	Android	12	1
+YaBrowser	25.6.2.117.00	mobile	Android	12	1
+YaBrowser	25.6.2.117.00	mobile	Android	14	1
+YaBrowser	25.6.2.120.00	mobile	Android	13	1
+YaBrowser	25.6.2.98.00	mobile	Android	14	1
+YaBrowser	25.6.3.46.00	mobile	Android	13	1
+YaBrowser	25.6.3.84.00	mobile	Android	14	1
+YaBrowser	25.6.3.95.00	mobile	Android	12	1
+YaBrowser	25.6.3.95.00	mobile	Android	9	1
+YaBrowser	25.6.3.98.00	mobile	Android	10	1
+YaBrowser	25.6.3.98.00	mobile	Android	16	1
+YaBrowser	25.6.4.107.00	mobile	Android	12	1
+YaBrowser	25.6.4.107.00	mobile	Android	14	1
+YaBrowser	25.6.4.91.00	mobile	Android	14	1
+YaBrowser	25.7.0.65.10	mobile	iOS	18.4.1	1
+YaBrowser	25.7.0.65.10	mobile	iOS	18.5	1
+YaBrowser	25.7.4.411.10	mobile	iOS	18.4.1	1
+YaBrowser	4.0	smart tv	Android	11	1
+YaBrowser	4.0	smart tv	Android	12	1


### PR DESCRIPTION
This PR adds a link to download example data, as well as click to visualize that data in the report tool. Partially address #11.

Here's a preview of what it looks like currently:

<img width="1554" height="786" alt="Screenshot 2025-07-23 at 9 54 33 AM" src="https://github.com/user-attachments/assets/a601cb97-74f0-4420-af9c-10feea557fef" />

