### PR TITLE
fix: babel demo is crashed at launch on Node 24

### DIFF
--- a/tooling/babel/package-lock.json
+++ b/tooling/babel/package-lock.json
@@ -8,7 +8,7 @@
         "@babel/cli": "^7.26.4",
         "@babel/core": "^7.26.9",
         "@babel/preset-env": "^7.26.9",
-        "browserslist-config-baseline": "^0.4.0"
+        "browserslist-config-baseline": "^0.5.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1539,16 +1539,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@httptoolkit/esm": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@httptoolkit/esm/-/esm-3.3.1.tgz",
-      "integrity": "sha512-XvWsT5qskZQoiHgg0kEoIonB+Zj/0T/W0rosjzyPuY++iBwO5c9fMfgvPBCffwY3cTrTD4KYpTPUEtLD0I1lmQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
@@ -1601,13 +1591,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@mdn/browser-compat-data": {
-      "version": "6.0.14",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-6.0.14.tgz",
-      "integrity": "sha512-WyNFl0UDRo/gUgp6bwvW/N0zv2DDQlmJB6G9svGBi9VSTXSww2IJj1PKwhlcXVQSD0B2fzL9bIFyCMJl4A1aLA==",
-      "dev": true,
-      "license": "CC0-1.0"
     },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
@@ -1682,14 +1665,13 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.4.1.tgz",
-      "integrity": "sha512-x2Z9jkNB6D1/sTM/IY8XU3v8OlY2NrYVT5TEZicMW5OL+MHz/Ac/D3qW27Dk01Z+Vbtlk/h/GSClc65uO5pEPA==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.4.tgz",
+      "integrity": "sha512-L+YvJwGAgwJBV1p6ffpSTa2KRc69EeeYGYjRVWKs0GKrK+LON0GC0gV+rKSNtALEDvMDqkvCFq9r1r94/Gjwxw==",
       "dev": true,
       "license": "Apache-2.0",
-      "dependencies": {
-        "@mdn/browser-compat-data": "^6.0.13",
-        "web-features": "^2.34.2"
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
       }
     },
     "node_modules/binary-extensions": {
@@ -1765,15 +1747,13 @@
       }
     },
     "node_modules/browserslist-config-baseline": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/browserslist-config-baseline/-/browserslist-config-baseline-0.4.0.tgz",
-      "integrity": "sha512-ZbdPlREt1Z77Xh2vP+wdr1jGZ8udXH4wFFEpV1WQ3GP63XD8rwdyP39yv1WDYbCVGZyUYaSN8T9HlRseVjAG1w==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/browserslist-config-baseline/-/browserslist-config-baseline-0.5.0.tgz",
+      "integrity": "sha512-TBB58g6MkqLiN7JPqkNWImFBpiybPDyMN6QeU7/Vb5J10eAyNEPQLj0HpFsTZZ+xyeFpCIz2qNdg0/xnrq929Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@httptoolkit/esm": "^3.3.1",
-        "baseline-browser-mapping": "^2.2.0",
-        "compare-versions": "^6.1.1"
+        "baseline-browser-mapping": "^2.5.6"
       }
     },
     "node_modules/caniuse-lite": {
@@ -1832,13 +1812,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/compare-versions": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
-      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2517,13 +2490,6 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
-    },
-    "node_modules/web-features": {
-      "version": "2.35.0",
-      "resolved": "https://registry.npmjs.org/web-features/-/web-features-2.35.0.tgz",
-      "integrity": "sha512-FZaOGdbjnODpn1xhecV8qEqxsLbanzshJDH88Jwex9VbhLKzbLTI8ADnR4OzJzoGf1owDQNX4BomTZJ/3EDeZw==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/tooling/babel/package.json
+++ b/tooling/babel/package.json
@@ -7,6 +7,6 @@
     "@babel/cli": "^7.26.4",
     "@babel/core": "^7.26.9",
     "@babel/preset-env": "^7.26.9",
-    "browserslist-config-baseline": "^0.4.0"
+    "browserslist-config-baseline": "^0.5.0"
   }
 }


### PR DESCRIPTION
## Environment

- MacOS 15.6.1
- NodeJS - v24.7.0
- npm - 11.6.0

## Problem description

Babel demo is crashed at launch on Node 24. Steps to reproduce:

- run `npm install` at tooling/babel
- update the `browserlistrc` contents with `extends browserslist-config-baseline`
- run `npm run build`

```
> build
> babel src -d lib && ls -lh lib


  #  node[92161]: void node::fs::InternalModuleStat(const FunctionCallbackInfo<Value> &) at ../src/node_file.cc:1061
  #  Assertion failed: (args.Length()) == (1)

----- Native stack trace -----

 1: 0x10db2c291 node::Assert(node::AssertionInfo const&) [/usr/local/Cellar/node/24.7.0/bin/node]
 2: 0x10c7cf93c node::fs::InternalModuleStat(v8::FunctionCallbackInfo<v8::Value> const&) [/usr/local/Cellar/node/24.7.0/bin/node]
 3: 0x10d30d4cd Builtins_CallApiCallbackGeneric [/usr/local/Cellar/node/24.7.0/bin/node]
 4: 0x10d30ba54 Builtins_InterpreterEntryTrampoline [/usr/local/Cellar/node/24.7.0/bin/node]
 5: 0x10d30ba54 Builtins_InterpreterEntryTrampoline [/usr/local/Cellar/node/24.7.0/bin/node]

----- JavaScript stack trace -----

1: /Users/m.i.kolesnikov/GitHub/baseline-demos-fork/tooling/babel/node_modules/@httptoolkit/esm/esm.js:1:39956
2: /Users/m.i.kolesnikov/GitHub/baseline-demos-fork/tooling/babel/node_modules/@httptoolkit/esm/esm.js:1:39597
3: /Users/m.i.kolesnikov/GitHub/baseline-demos-fork/tooling/babel/node_modules/@httptoolkit/esm/esm.js:1:39927
4: /Users/m.i.kolesnikov/GitHub/baseline-demos-fork/tooling/babel/node_modules/@httptoolkit/esm/esm.js:1:202609
5: /Users/m.i.kolesnikov/GitHub/baseline-demos-fork/tooling/babel/node_modules/@httptoolkit/esm/esm.js:1:202693
6: /Users/m.i.kolesnikov/GitHub/baseline-demos-fork/tooling/babel/node_modules/@httptoolkit/esm/esm.js:1:202794
7: /Users/m.i.kolesnikov/GitHub/baseline-demos-fork/tooling/babel/node_modules/@httptoolkit/esm/esm.js:1:287184
8: /Users/m.i.kolesnikov/GitHub/baseline-demos-fork/tooling/babel/node_modules/@httptoolkit/esm/esm.js:1:289766
9: e (/Users/m.i.kolesnikov/GitHub/baseline-demos-fork/tooling/babel/node_modules/@httptoolkit/esm/esm.js:1:290897)
10: get (/Users/m.i.kolesnikov/GitHub/baseline-demos-fork/tooling/babel/node_modules/@httptoolkit/esm/esm.js:1:290964)


sh: line 1: 92161 Abort trap: 6           babel src -d lib
````


## Suggested solution

Bump `browserslist-config-baseline` from 0.4.0 to 0.5.0