### PR TITLE
demo(eslint): use `eslint-plugin-baseline-js` for JS Baseline

### DIFF
--- a/tooling/eslint/README.md
+++ b/tooling/eslint/README.md
@@ -182,20 +182,33 @@ Output:
 ✖ 12 problems (0 errors, 12 warnings)
 ```
 
-## eslint-plugin-compat
 
-[`eslint-plugin-compat`](https://github.com/amilajack/eslint-plugin-compat) is an ESLint plugin that validates the browser support of JavaScript features.
+## eslint-plugin-baseline-js
 
-### Baseline widely available
+[`eslint-plugin-baseline-js`](https://github.com/3ru/eslint-plugin-baseline-js) is an ESLint plugin for JavaScript Baseline.
 
-This ESLint plugin relies on a browserslist config, which we can use with [browserslist-config-baseline](https://github.com/web-platform-dx/browserslist-config-baseline) to set a target of Baseline widely available.
+### Widely available
 
-1. Open [.browserslistrc](.browserslistrc)
-2. Replace the contents with
+In [eslint.config.mjs](eslint.config.mjs), import the plugin and configure the `use-baseline` rule as needed:
 
-  ```diff
-  +extends browserslist-config-baseline
-  ```
+```js
+import js from "eslint-plugin-baseline-js";
+
+export default [
+  // {...}
+  {
+    files: ["**/*.{js,ts,jsx,tsx}"],
+    plugins: { "baseline-js": js },
+    rules: {
+      "baseline-js/use-baseline": ["warn", {
+        available: "widely",
+        includeWebApis: { preset: "auto" },
+        includeJsBuiltins: { preset: "auto" }
+      }],
+    },
+  }
+];
+```
 
 Run eslint:
 
@@ -206,52 +219,41 @@ npm run lint:js
 Output:
 
 ```sh
-   71:13  warning  PaymentRequest is not supported in Firefox 104, and_ff 137                                compat/compat
-  103:1   warning  Array.toReversed() is not supported in Firefox 104, Edge 107, Chrome 107                  compat/compat
-  107:1   warning  navigator.userActivation() is not supported in Safari 16.0, iOS Safari 16.0, Firefox 104  compat/compat
-  115:5   warning  Intl.Segmenter() is not supported in Firefox 104                                          compat/compat
-  126:1   warning  scheduler is not supported in Safari 16.0, iOS Safari 16.0                                compat/compat
-  128:1   warning  IdleDetector is not supported in Safari 16.0, iOS Safari 16.0, Firefox 104, Edge 107      compat/compat
-  130:1   warning  Atomics.waitAsync() is not supported in Safari 16.0, iOS Safari 16.0, Firefox 104         compat/compat
+   71:17  warning  Feature 'payment-request' is not a widely available Baseline feature            baseline-js/use-baseline
+  107:11  warning  Feature 'user-activation' is not a widely available Baseline feature            baseline-js/use-baseline
+  109:7   warning  Feature 'array-fromasync' is not a widely available Baseline feature            baseline-js/use-baseline
+  111:8   warning  Feature 'array-group' is not a widely available Baseline feature                baseline-js/use-baseline
+  113:13  warning  Feature 'abortsignal-any' is not a widely available Baseline feature            baseline-js/use-baseline
+  115:10  warning  Feature 'intl-segmenter' is not a widely available Baseline feature             baseline-js/use-baseline
+  120:7   warning  Feature 'is-error' is not a widely available Baseline feature                   baseline-js/use-baseline
+  124:6   warning  Feature 'math-sum-precise' is not a widely available Baseline feature           baseline-js/use-baseline
+  128:14  warning  Feature 'idle-detection' is not a widely available Baseline feature             baseline-js/use-baseline
+  130:1   warning  Feature 'atomics-wait-async' is not a widely available Baseline feature         baseline-js/use-baseline
+  132:5   warning  Feature 'numeric-factory-functions' is not a widely available Baseline feature  baseline-js/use-baseline
 
-✖ 7 problems (0 errors, 7 warnings)
+✖ 11 problems (0 errors, 11 warnings)
 ```
 
-> [!NOTE]
-> Unlike the other linters, this plugin precedes Baseline and so its warnings are still in terms of specific browser versions and not Baseline targets.
+### Baseline newly available
+
+In [eslint.config.mjs](eslint.config.mjs) change the `available` option to "newly":
+
+```js
+rules: {
+  "baseline-js/use-baseline": ["warn", {
+    "available": "newly"
+  }],
+}
+```
 
 ### Baseline year
 
-1. Open [.browserslistrc](.browserslistrc)
-2. Replace the contents with
+In [eslint.config.mjs](eslint.config.mjs) change the `available` option to a year in YYYY format:
 
-  ```diff
-  -extends browserslist-config-baseline
-  +extends browserslist-config-baseline/2016
-  ```
-
-Run eslint:
-
-```sh
-npm run lint:js
-```
-
-Output:
-
-```sh
-   65:15  warning  String.padStart() is not supported in Edge 14, Chrome 53                                                        compat/compat
-   68:1   warning  fetch is not supported in Safari 10                                                                             compat/compat
-   71:13  warning  PaymentRequest is not supported in Safari 10, Firefox 49, Edge 14, Chrome 53, and_ff 137                        compat/compat
-   74:13  warning  Object.values() is not supported in Safari 10, iOS Safari 10.0-10.2, Chrome 53                                  compat/compat
-   87:1   warning  Object.fromEntries() is not supported in Safari 10, iOS Safari 10.0-10.2, Firefox 49, Edge 14, Chrome 53        compat/compat
-   90:18  warning  IntersectionObserver is not supported in Safari 10, Firefox 49, Edge 14, Chrome 53                              compat/compat
-  103:1   warning  Array.toReversed() is not supported in Safari 10, iOS Safari 10.0-10.2, Firefox 49, Edge 14, Chrome 53          compat/compat
-  107:1   warning  navigator.userActivation() is not supported in Safari 10, iOS Safari 10.0-10.2, Firefox 49, Edge 14, Chrome 53  compat/compat
-  113:1   warning  AbortSignal is not supported in Safari 10, iOS Safari 10.0-10.2, Firefox 49, Edge 14, Chrome 53                 compat/compat
-  115:5   warning  Intl.Segmenter() is not supported in Safari 10, iOS Safari 10.0-10.2, Firefox 49, Edge 14, Chrome 53            compat/compat
-  126:1   warning  scheduler is not supported in Safari 10, iOS Safari 10.0-10.2, Firefox 49, Edge 14, Chrome 53                   compat/compat
-  128:1   warning  IdleDetector is not supported in Safari 10, iOS Safari 10.0-10.2, Firefox 49, Edge 14, Chrome 53                compat/compat
-  130:1   warning  Atomics is not supported in Safari 10, iOS Safari 10.0-10.2, Firefox 49, Edge 14, Chrome 53                     compat/compat
-
-✖ 13 problems (0 errors, 13 warnings)
+```js
+rules: {
+  "baseline-js/use-baseline": ["warn", {
+    "available": 2020
+  }],
+}
 ```

--- a/tooling/eslint/eslint.config.mjs
+++ b/tooling/eslint/eslint.config.mjs
@@ -1,7 +1,7 @@
 import globals from "globals";
 import css from "@eslint/css";
 import html from "@html-eslint/eslint-plugin";
-import compat from "eslint-plugin-compat";
+import js from "eslint-plugin-baseline-js";
 
 
 /** @type {import('eslint').Linter.Config[]} */
@@ -33,12 +33,14 @@ export default [
     },
   },
   {
-    ...compat.configs["flat/recommended"],
-    settings: {
-      "lintAllEsApis": true,
-    },
+    files: ["**/*.{js,ts,jsx,tsx}"],
+    plugins: { "baseline-js": js },
     rules: {
-      "compat/compat": ["warn"],
+      "baseline-js/use-baseline": ["warn", {
+        available: "widely",
+        includeWebApis: { preset: "auto" },
+        includeJsBuiltins: { preset: "auto" }
+      }],
     },
   },
 ];

--- a/tooling/eslint/package-lock.json
+++ b/tooling/eslint/package-lock.json
@@ -8,17 +8,17 @@
         "@eslint/css": "^0.8.1",
         "@html-eslint/eslint-plugin": "^0.39.0",
         "@html-eslint/parser": "^0.39.0",
-        "browserslist-config-baseline": "^0.4.0",
         "eslint": "^9.25.1",
-        "eslint-plugin-compat": "^6.0.2",
+        "eslint-plugin-baseline-js": "^0.1.0",
         "globals": "^16.0.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
-      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
@@ -54,9 +54,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
-      "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -69,9 +69,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.1.tgz",
-      "integrity": "sha512-RI17tsD2frtDu/3dmI7QRrD4bedNKPM08ziRYaC5AhkGrzIAJelm9kJU1TznK+apx6V+cqRz8tfpEeG3oIyjxw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
+      "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -79,9 +79,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
-      "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -133,20 +133,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/css/node_modules/@eslint/plugin-kit": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
-      "integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^0.14.0",
-        "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
     "node_modules/@eslint/eslintrc": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
@@ -185,13 +171,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.25.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.25.1.tgz",
-      "integrity": "sha512-dEIwmjntEx8u3Uvv+kr3PDeeArL8Hw07H9kyYxCjnM9pBjfEhk6uLXSchxxzgiwtRhhzVzqmUSDFBOi1TuZ7qg==",
+      "version": "9.35.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
+      "integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -205,13 +194,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
-      "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.13.0",
+        "@eslint/core": "^0.15.2",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -256,16 +245,6 @@
       "integrity": "sha512-3hE0AfpdZhJ6jBPxozvPD/5My9HM5YYf56PRrL+Tvk5p4NnRpqlm2claED75T2ne26zDiPk0pJ9oOo8huxR07Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@httptoolkit/esm": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@httptoolkit/esm/-/esm-3.3.1.tgz",
-      "integrity": "sha512-XvWsT5qskZQoiHgg0kEoIonB+Zj/0T/W0rosjzyPuY++iBwO5c9fMfgvPBCffwY3cTrTD4KYpTPUEtLD0I1lmQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -328,13 +307,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@mdn/browser-compat-data": {
-      "version": "5.7.6",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.7.6.tgz",
-      "integrity": "sha512-7xdrMX0Wk7grrTZQwAoy1GkvPMFoizStUoL+VmtUkAxegbCCec+3FKwOM6yc/uGU5+BEczQHXAlWiqvM8JeENg==",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -348,9 +320,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -409,39 +381,11 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/ast-metadata-inferer": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.8.1.tgz",
-      "integrity": "sha512-ht3Dm6Zr7SXv6t1Ra6gFo0+kLDglHGrEbYihTkcycrbHw7WCcuhBzPlJYHEsIpycaUwzsJHje+vUcxXUX4ztTA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mdn/browser-compat-data": "^5.6.19"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "node_modules/baseline-browser-mapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.3.0.tgz",
-      "integrity": "sha512-K6nnZh0g0B/ZxbHSjZfKuJK7q1wto+RBqmVk9u/G+/YSOVlVXls71j2Jbl25Dos6j4HPAtne0MYdXdNOOSJm5g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mdn/browser-compat-data": "^6.0.9",
-        "web-features": "^2.34.1"
-      }
-    },
-    "node_modules/baseline-browser-mapping/node_modules/@mdn/browser-compat-data": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-6.0.12.tgz",
-      "integrity": "sha512-lQ6p212jKeJBG+L7UYRKchTCcnQbp6yOj5swKxGLjvuW4SmbgWgd/WyA1Dxq1GGT86C7jVTEaKry36LmsBp8SQ==",
-      "dev": true,
-      "license": "CC0-1.0"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -453,51 +397,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/browserslist": {
-      "version": "4.24.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
-      "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001716",
-        "electron-to-chromium": "^1.5.149",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.3"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/browserslist-config-baseline": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/browserslist-config-baseline/-/browserslist-config-baseline-0.4.0.tgz",
-      "integrity": "sha512-ZbdPlREt1Z77Xh2vP+wdr1jGZ8udXH4wFFEpV1WQ3GP63XD8rwdyP39yv1WDYbCVGZyUYaSN8T9HlRseVjAG1w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@httptoolkit/esm": "^3.3.1",
-        "baseline-browser-mapping": "^2.2.0",
-        "compare-versions": "^6.1.1"
-      }
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -507,27 +406,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001717",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001717.tgz",
-      "integrity": "sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -562,13 +440,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/compare-versions": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
-      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -613,29 +484,12 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "node_modules/electron-to-chromium": {
-      "version": "1.5.150",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.150.tgz",
-      "integrity": "sha512-rOOkP2ZUMx1yL4fCxXQKDHQ8ZXwisb2OycOQVKHgvB3ZI4CvehOd4y2tfnnLDieJ3Zs1RL1Dlp3cMkyIn7nnXA==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/es-html-parser": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/es-html-parser/-/es-html-parser-0.1.1.tgz",
       "integrity": "sha512-SNHdEpKkN4nWZ3sFq9AxPlaUzPKJewGh59JrVS2355vELTOFygyf/lbfDDIONuGvYrhvAHoaUd+sK9UGaGrKUg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -650,20 +504,20 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.25.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.25.1.tgz",
-      "integrity": "sha512-E6Mtz9oGQWDCpV12319d59n4tx9zOTXSTmc8BLVxBx+G/0RdM5MvEEJLU9c0+aleoePYYgVTOsRblx433qmhWQ==",
+      "version": "9.35.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz",
+      "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.20.0",
-        "@eslint/config-helpers": "^0.2.1",
-        "@eslint/core": "^0.13.0",
+        "@eslint/config-array": "^0.21.0",
+        "@eslint/config-helpers": "^0.3.1",
+        "@eslint/core": "^0.15.2",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.25.1",
-        "@eslint/plugin-kit": "^0.2.8",
+        "@eslint/js": "9.35.0",
+        "@eslint/plugin-kit": "^0.3.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -674,9 +528,9 @@
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.3.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -710,46 +564,48 @@
         }
       }
     },
-    "node_modules/eslint-plugin-compat": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-6.0.2.tgz",
-      "integrity": "sha512-1ME+YfJjmOz1blH0nPZpHgjMGK4kjgEeoYqGCqoBPQ/mGu/dJzdoP0f1C8H2jcWZjzhZjAMccbM/VdXhPORIfA==",
+    "node_modules/eslint-plugin-baseline-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-baseline-js/-/eslint-plugin-baseline-js-0.1.0.tgz",
+      "integrity": "sha512-AzBkjtLV9nWZD4A5k6bWHsdoKYbIvbA2Wwu7McU7AXFciQGBBnJD2LV3dOnzREoHgsiDqcj3ggYv5b+wt1kyjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@mdn/browser-compat-data": "^5.5.35",
-        "ast-metadata-inferer": "^0.8.1",
-        "browserslist": "^4.24.2",
-        "caniuse-lite": "^1.0.30001687",
-        "find-up": "^5.0.0",
-        "globals": "^15.7.0",
-        "lodash.memoize": "^4.1.2",
-        "semver": "^7.6.2"
+        "eslint-plugin-es-x": "^9.1.0"
       },
       "engines": {
-        "node": ">=18.x"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "eslint": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
+        "eslint": ">=8.57.0 <10"
       }
     },
-    "node_modules/eslint-plugin-compat/node_modules/globals": {
-      "version": "15.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+    "node_modules/eslint-plugin-es-x": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-9.1.0.tgz",
+      "integrity": "sha512-vqKpuEsJeqFxhcJgHxyeI9sYw4o6DJ8jdT+mA4+HOszIXXbIqoW5dx4PgA5pW6/IoVBYQAk5o8ZW9EtlcXBiOQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/ota-meshi",
+        "https://opencollective.com/eslint"
+      ],
       "license": "MIT",
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.1.2",
+        "@eslint-community/regexpp": "^4.12.1",
+        "eslint-type-tracer": "^0.4.0"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.29.0"
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
-      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -763,10 +619,29 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-type-tracer": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-type-tracer/-/eslint-type-tracer-0.4.1.tgz",
+      "integrity": "sha512-7kDovYNNitAxahP/qQ9UrHssUk8d6V5Y9MQaDiHPKsJrk1g6STDqVHjJPu8ycn1+qE4D0jwQRN7waRrxrX9k+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "eslint": ">=8"
+      }
+    },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -777,15 +652,15 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.0"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1070,13 +945,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -1113,13 +981,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
-    },
-    "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -1199,13 +1060,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/picocolors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -1233,19 +1087,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/shebang-command": {
@@ -1316,37 +1157,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "escalade": "^3.2.0",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "update-browserslist-db": "cli.js"
-      },
-      "peerDependencies": {
-        "browserslist": ">= 4.21.0"
-      }
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -1356,13 +1166,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/web-features": {
-      "version": "2.34.2",
-      "resolved": "https://registry.npmjs.org/web-features/-/web-features-2.34.2.tgz",
-      "integrity": "sha512-OhPNkoNZYxfykP82LwJmpAXZHiO6eojkj9ZgDKB/u16i1rtoSZSzdgXjjTZI/gtTpZo5nuZNyDAZcNESJNylDg==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/tooling/eslint/package.json
+++ b/tooling/eslint/package.json
@@ -8,9 +8,8 @@
     "@eslint/css": "^0.8.1",
     "@html-eslint/eslint-plugin": "^0.39.0",
     "@html-eslint/parser": "^0.39.0",
-    "browserslist-config-baseline": "^0.4.0",
     "eslint": "^9.25.1",
-    "eslint-plugin-compat": "^6.0.2",
+    "eslint-plugin-baseline-js": "^0.1.0",
     "globals": "^16.0.0"
   }
 }


### PR DESCRIPTION
Apply JavaScript Baseline using `eslint-plugin-baseline-js` and replace `eslint-plugin-compat`. Provides a consistent user experience with CSS/HTML.