### PR TITLE
Nudge legacy Baseline Checker app users to use the new tool

### DIFF
--- a/tooling/google-analytics-baseline-checker/public/index.html
+++ b/tooling/google-analytics-baseline-checker/public/index.html
@@ -15,214 +15,200 @@
  limitations under the License.
  -->
 <html lang="en-us">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Google Analytics Baseline Checker</title>
-    <link rel="stylesheet" href="style.css" />
-    <link
-      rel="icon"
-      type="image/png"
-      href="https://web-platform-dx.github.io/web-features/assets/img/wide-sq-32.png"
-      sizes="32x32"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      href="https://web-platform-dx.github.io/web-features/assets/img/wide-sq-192.png"
-      sizes="192x192"
-    />
-  </head>
-  <body>
-    <header class="Header">
-      <div class="Container">
-        <svg class="Header-logo" title="Baseline Widely available logo">
-          <use href="icons.svg#baseline-widely-available"></use>
-        </svg>
-        <h1 class="Header-title">
-          <span class="Header-titlePrefix">Google Analytics</span>
-          <span class="Header-titleSuffix">Baseline Checker</span>
-        </h1>
-        <p class="Header-subTitle">
-          A tool to help Google Analytics users determine the best Baseline
-          target for their site, <strong>based on their users</strong>.
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Google Analytics Baseline Checker</title>
+  <link rel="stylesheet" href="style.css" />
+  <link rel="icon" type="image/png" href="https://web-platform-dx.github.io/web-features/assets/img/wide-sq-32.png"
+    sizes="32x32" />
+  <link rel="icon" type="image/png" href="https://web-platform-dx.github.io/web-features/assets/img/wide-sq-192.png"
+    sizes="192x192" />
+</head>
+
+<body>
+  <header class="Header">
+    <div class="Container">
+      <svg class="Header-logo" title="Baseline Widely available logo">
+        <use href="icons.svg#baseline-widely-available"></use>
+      </svg>
+      <h1 class="Header-title">
+        <span class="Header-titlePrefix">Google Analytics</span>
+        <span class="Header-titleSuffix">Baseline Checker</span>
+      </h1>
+      <p class="Header-subTitle">
+        A tool to help Google Analytics users determine the best Baseline
+        target for their site, <strong>based on their users</strong>.
+      </p>
+    </div>
+  </header>
+  <div class="Container">
+    <h2 class="SubHeading">How it works</h2>
+    <dl class="Steps">
+      <dt class="Steps-name">Step 1:</dt>
+      <dd class="Steps-desc">
+        Export your browser usage data from Google Analytics (<a href="#export-instructions">learn how</a>).
+      </dd>
+      <dt class="Steps-name">Step 2:</dt>
+      <dd class="Steps-desc">
+        Import that data using the <a href="#import-tool">tool below</a> to
+        generate a report.
+      </dd>
+      <dt class="Steps-name">Step 3:</dt>
+      <dd class="Steps-desc">
+        Use this report to help you choose the best Baseline target for you.
+      </dd>
+    </dl>
+
+    <h2 id="import-tool" class="SubHeading">
+      Import your Google Analytics data
+    </h2>
+    <p class="Note Note-subHead">
+      Or view an <a id="example-report" href="#">example report</a> based on
+      <a download href="web-dev-baseline-export.tsv">data from web.dev</a>.
+    </p>
+    <p class="Note Note-subHead Note-info">
+      Skip the TSV exports! Try <a href="https://baseline-checker.chrome.dev/">the new
+        Baseline Checker tool</a>. Support coming soon for Google Workspace accounts.
+    </p>
+    <label id="drop-zone" class="Importer">
+      Drag & Drop file here, or click to choose a file
+      <svg class="Importer-icon" aria-label="Upload icon">
+        <use href="icons.svg#upload"></use>
+      </svg>
+      <input id="input" type="file" hidden />
+    </label>
+    <aside class="Note">
+      <strong>Note:</strong>
+      All data imported into this tool is processed entirely on device. No
+      data is processed or stored remotely.
+    </aside>
+
+    <div id="report-section" class="ReportSection" hidden>
+      <h2 class="SubHeading SubHeading--flat">Baseline Report</h2>
+      <div id="report-container"></div>
+    </div>
+  </div>
+  <footer class="Footer">
+    <div class="Container">
+      <h2 id="export-instructions" class="SubHeading SubHeading--flat">
+        Google Analytics Export Instructions
+      </h2>
+      <div class="Video">
+        <iframe width="732" height="412" src="https://www.youtube.com/embed/kMZUXDDWJG4?si=zeuiFnYKuG7G4a9f"
+          title="YouTube video player" frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+        <p class="Note">
+          To learn how to export your browser usage data from Google
+          Analytics, watch this screencast or follow the instructions below:
         </p>
       </div>
-    </header>
-    <div class="Container">
-      <h2 class="SubHeading">How it works</h2>
-      <dl class="Steps">
-        <dt class="Steps-name">Step 1:</dt>
-        <dd class="Steps-desc">
-          Export your browser usage data from Google Analytics (<a
-            href="#export-instructions"
-            >learn how</a
-          >).
-        </dd>
-        <dt class="Steps-name">Step 2:</dt>
-        <dd class="Steps-desc">
-          Import that data using the <a href="#import-tool">tool below</a> to
-          generate a report.
-        </dd>
-        <dt class="Steps-name">Step 3:</dt>
-        <dd class="Steps-desc">
-          Use this report to help you choose the best Baseline target for you.
-        </dd>
-      </dl>
 
-      <h2 id="import-tool" class="SubHeading">
-        Import your Google Analytics data
-      </h2>
-      <p class="Note Note-subHead">
-        Or view an <a id="example-report" href="#">example report</a> based on
-        <a download href="web-dev-baseline-export.tsv">data from web.dev</a>.
-      </p>
-      <label id="drop-zone" class="Importer">
-        Drag & Drop file here, or click to choose a file
-        <svg class="Importer-icon" aria-label="Upload icon">
-          <use href="icons.svg#upload"></use>
-        </svg>
-        <input id="input" type="file" hidden />
-      </label>
+      <ol class="Instructions">
+        <li class="Instructions-item">
+          Log into
+          <a href="https://analytics.google.com/">Google Analytics</a>.
+        </li>
+        <li class="Instructions-item">
+          Choose the
+          <a href="https://support.google.com/analytics/answer/9679158?sjid=10172198536853481417-NC">account</a>
+          from the dropdown menu at the top that corresponds to the website
+          you want to export browser data from.
+        </li>
+        <li class="Instructions-item">
+          Select the
+          <svg class="Instructions-icon" title="Add dimension">
+            <use href="icons.svg#data_exploration"></use>
+          </svg>
+          <strong>Explore</strong> link from the left-hand sidebar.
+        </li>
+        <li class="Instructions-item">
+          If you've already created a
+          <strong>Baseline export</strong> exploration, select it from the
+          list of explorations and skip to step #12.
+        </li>
+        <li class="Instructions-item">
+          Select the <strong>Blank</strong> option to create a new
+          <a
+            href="https://support.google.com/analytics/answer/9327972?hl=en&ref_topic=9266525&sjid=10172198536853481417-NC#zippy=%2Cin-this-article">free-form
+            exploration</a>.
+        </li>
+        <li class="Instructions-item">
+          Under <strong>Exploration name</strong> enter a descriptive name
+          like <strong>Baseline export</strong>.
+        </li>
+        <li class="Instructions-item">
+          Select a date range (the default <strong>Last 28 days</strong> range
+          is recommended).
+        </li>
+        <li class="Instructions-item">
+          Click the
+          <svg class="Instructions-icon" title="Add dimension">
+            <use href="icons.svg#plus"></use>
+          </svg>
+          <strong>add dimension</strong> button next to
+          <strong>Dimensions</strong> and select the following five dimensions
+          (found under <strong>Platform / device</strong>), then click
+          <strong>Confirm</strong> to add them to your exploration:
+          <i class="Instructions-term">Browser</i>,
+          <i class="Instructions-term">Browser version</i>,
+          <i class="Instructions-term">Device category</i>,
+          <i class="Instructions-term">Operating system</i>,
+          <i class="Instructions-term">OS version</i>.
+        </li>
+        <li class="Instructions-item">
+          Click the
+          <svg class="Instructions-icon" aria-label="Add metric">
+            <use href="icons.svg#plus"></use>
+          </svg>
+          <strong>add metrics</strong> button next to
+          <strong>Metrics</strong> and select the
+          <i class="Instructions-term">Active users</i> (found under
+          <strong>Users</strong>), then click <strong>Confirm</strong> to add
+          it to your exploration:
+        </li>
+        <li class="Instructions-item">
+          Under <strong>Rows</strong> in the next column, click or drag to add
+          all five of the dimensions chosen in step #8.
+        </li>
+        <li class="Instructions-item">
+          Under <strong>Values</strong> further down in the same column, click
+          or drag to add the
+          <i class="Instructions-term">Active users</i> metric chosen in step
+          #9. This will generate the initial report table.
+        </li>
+        <li class="Instructions-item">
+          In the top right corner of the report click the
+          <svg class="Instructions-icon" aria-label="Download icon">
+            <use href="icons.svg#download"></use>
+          </svg>
+          <strong>export data</strong> button and choose
+          <strong>TSV</strong> to save the file.
+        </li>
+        <li class="Instructions-item">
+          Once the file is saved, import the file into this tool using the
+          <a href="#import-tool">widget above</a>.
+        </li>
+      </ol>
+
       <aside class="Note">
-        <strong>Note:</strong>
-        All data imported into this tool is processed entirely on device. No
-        data is processed or stored remotely.
+        (Credits: export instruction adopted from
+        <a href="https://caniuse.com/ciu/import">caniuse.com/ciu/import</a>)
       </aside>
-
-      <div id="report-section" class="ReportSection" hidden>
-        <h2 class="SubHeading SubHeading--flat">Baseline Report</h2>
-        <div id="report-container"></div>
-      </div>
     </div>
-    <footer class="Footer">
-      <div class="Container">
-        <h2 id="export-instructions" class="SubHeading SubHeading--flat">
-          Google Analytics Export Instructions
-        </h2>
-        <div class="Video">
-          <iframe
-            width="732"
-            height="412"
-            src="https://www.youtube.com/embed/kMZUXDDWJG4?si=zeuiFnYKuG7G4a9f"
-            title="YouTube video player"
-            frameborder="0"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin"
-            allowfullscreen
-          ></iframe>
-          <p class="Note">
-            To learn how to export your browser usage data from Google
-            Analytics, watch this screencast or follow the instructions below:
-          </p>
-        </div>
+  </footer>
+  <cookie-banner></cookie-banner>
+  <script type="module" src="script.js"></script>
+  <script type="module" src="https://chrome.dev/components/cookie-banner.js"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-754F24EHD8"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'G-754F24EHD8');
+  </script>
+</body>
 
-        <ol class="Instructions">
-          <li class="Instructions-item">
-            Log into
-            <a href="https://analytics.google.com/">Google Analytics</a>.
-          </li>
-          <li class="Instructions-item">
-            Choose the
-            <a
-              href="https://support.google.com/analytics/answer/9679158?sjid=10172198536853481417-NC"
-              >account</a
-            >
-            from the dropdown menu at the top that corresponds to the website
-            you want to export browser data from.
-          </li>
-          <li class="Instructions-item">
-            Select the
-            <svg class="Instructions-icon" title="Add dimension">
-              <use href="icons.svg#data_exploration"></use>
-            </svg>
-            <strong>Explore</strong> link from the left-hand sidebar.
-          </li>
-          <li class="Instructions-item">
-            If you've already created a
-            <strong>Baseline export</strong> exploration, select it from the
-            list of explorations and skip to step #12.
-          </li>
-          <li class="Instructions-item">
-            Select the <strong>Blank</strong> option to create a new
-            <a
-              href="https://support.google.com/analytics/answer/9327972?hl=en&ref_topic=9266525&sjid=10172198536853481417-NC#zippy=%2Cin-this-article"
-              >free-form exploration</a
-            >.
-          </li>
-          <li class="Instructions-item">
-            Under <strong>Exploration name</strong> enter a descriptive name
-            like <strong>Baseline export</strong>.
-          </li>
-          <li class="Instructions-item">
-            Select a date range (the default <strong>Last 28 days</strong> range
-            is recommended).
-          </li>
-          <li class="Instructions-item">
-            Click the
-            <svg class="Instructions-icon" title="Add dimension">
-              <use href="icons.svg#plus"></use>
-            </svg>
-            <strong>add dimension</strong> button next to
-            <strong>Dimensions</strong> and select the following five dimensions
-            (found under <strong>Platform / device</strong>), then click
-            <strong>Confirm</strong> to add them to your exploration:
-            <i class="Instructions-term">Browser</i>,
-            <i class="Instructions-term">Browser version</i>,
-            <i class="Instructions-term">Device category</i>,
-            <i class="Instructions-term">Operating system</i>,
-            <i class="Instructions-term">OS version</i>.
-          </li>
-          <li class="Instructions-item">
-            Click the
-            <svg class="Instructions-icon" aria-label="Add metric">
-              <use href="icons.svg#plus"></use>
-            </svg>
-            <strong>add metrics</strong> button next to
-            <strong>Metrics</strong> and select the
-            <i class="Instructions-term">Active users</i> (found under
-            <strong>Users</strong>), then click <strong>Confirm</strong> to add
-            it to your exploration:
-          </li>
-          <li class="Instructions-item">
-            Under <strong>Rows</strong> in the next column, click or drag to add
-            all five of the dimensions chosen in step #8.
-          </li>
-          <li class="Instructions-item">
-            Under <strong>Values</strong> further down in the same column, click
-            or drag to add the
-            <i class="Instructions-term">Active users</i> metric chosen in step
-            #9. This will generate the initial report table.
-          </li>
-          <li class="Instructions-item">
-            In the top right corner of the report click the
-            <svg class="Instructions-icon" aria-label="Download icon">
-              <use href="icons.svg#download"></use>
-            </svg>
-            <strong>export data</strong> button and choose
-            <strong>TSV</strong> to save the file.
-          </li>
-          <li class="Instructions-item">
-            Once the file is saved, import the file into this tool using the
-            <a href="#import-tool">widget above</a>.
-          </li>
-        </ol>
-
-        <aside class="Note">
-          (Credits: export instruction adopted from
-          <a href="https://caniuse.com/ciu/import">caniuse.com/ciu/import</a>)
-        </aside>
-      </div>
-    </footer>
-    <cookie-banner></cookie-banner>
-    <script type="module" src="script.js"></script>
-    <script type="module" src="https://chrome.dev/components/cookie-banner.js"></script>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-754F24EHD8"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-754F24EHD8');
-    </script>
-  </body>
 </html>

--- a/tooling/google-analytics-baseline-checker/public/style.css
+++ b/tooling/google-analytics-baseline-checker/public/style.css
@@ -186,6 +186,23 @@
     margin: 0 auto 2rem;
   }
 
+  .Note-info {
+    background-color: #e8f0fe;
+    border: 1px solid #c2e7ff;
+    color: #0b57d0;
+    border-radius: 6px;
+    padding: 0.75rem 1.25rem;
+    font-style: normal;
+    font-size: 0.9rem;
+    max-width: 600px;
+    margin: 0 auto 2rem;
+  }
+
+  .Note-info a {
+    color: #0a52be;
+    font-weight: 600;
+  }
+
   /*
    * Importer
    * ----------------------------------------------------------------------- */


### PR DESCRIPTION
Since we're keeping both versions of the app online until we sort out the Workspace restrictions, I've added a note nudging users of the legacy app to use the new one instead.

<img width="1002" height="494" alt="image" src="https://github.com/user-attachments/assets/f040cb3f-a156-49c1-bbff-d468cc975ab5" />